### PR TITLE
Allow Edge testing with webdriverio

### DIFF
--- a/eyes.sdk.core.javascript/src/UserAgent.js
+++ b/eyes.sdk.core.javascript/src/UserAgent.js
@@ -147,7 +147,7 @@ class UserAgent {
 
         if (result._OS === OSNames.Windows) {
             if (EDGE_REGEX.test(userAgent)) {
-                const edgeMatch = browserRegexes[i].exec(userAgent);
+                const edgeMatch = EDGE_REGEX.exec(userAgent);
                 result._browser = BrowserNames.Edge;
                 result._browserMajorVersion = edgeMatch[2];
                 result._browserMinorVersion = edgeMatch[3];


### PR DESCRIPTION
This is clearly a typo - not only is `i` not defined in the scope of this line, but it needs to use the edge regex directly, not look it up in list of all browser regexes.

Without this, you can't test MS Edge with webdriverio!