### PR TITLE
Add OS and userAgent to RenderStatusResults

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderStatusResults.js
+++ b/eyes.sdk.core/lib/renderer/RenderStatusResults.js
@@ -10,6 +10,8 @@ class RenderStatusResults {
     this._status = undefined;
     this._imageLocation = undefined;
     this._error = undefined;
+    this._os = undefined;
+    this._userAgent = undefined;
   }
 
   /**
@@ -22,7 +24,13 @@ class RenderStatusResults {
 
   /** @return {boolean} */
   isEmpty() {
-    return (this._status === undefined && this._imageLocation === undefined && this._error === undefined);
+    return (
+      this._status === undefined &&
+      this._imageLocation === undefined &&
+      this._error === undefined &&
+      this._os === undefined &&
+      this._userAgent === undefined
+    );
   }
 
   /** @return {RenderStatus} */
@@ -58,6 +66,28 @@ class RenderStatusResults {
     this._error = value;
   }
 
+  /** @return {string} */
+  getOS() {
+    return this._os;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setOS(value) {
+    this._os = value;
+  }
+
+  /** @return {string} */
+  getUserAgent() {
+    return this._userAgent;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setUserAgent(value) {
+    this._userAgent = value;
+  }
+  
   /** @override */
   toJSON() {
     return GeneralUtils.toPlain(this);

--- a/eyes.sdk.core/lib/server/ServerConnector.js
+++ b/eyes.sdk.core/lib/server/ServerConnector.js
@@ -704,7 +704,7 @@ class ServerConnector {
    * @return {Promise<RenderStatusResults[]|RenderStatusResults>} The render's status
    */
   renderStatusById(renderId, delayBeforeRequest = false) {
-    ArgumentGuard.notNull(renderId, 'runningRender');
+    ArgumentGuard.notNull(renderId, 'renderId');
     this._logger.verbose(`ServerConnector.renderStatus called for render: ${renderId}`);
 
     const that = this;

--- a/eyes.sdk.core/package-lock.json
+++ b/eyes.sdk.core/package-lock.json
@@ -22,7 +22,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -32,13 +32,13 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "concat-map": {
@@ -50,12 +50,12 @@
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha1-puN0maTZqc+F71hyBE1ikByYia4="
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -68,7 +68,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "es6-promise-pool": {
@@ -85,7 +85,7 @@
     "follow-redirects": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
-      "integrity": "sha1-2BIPRRgZD1Wqxlu2/HuF/NZm1qo=",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
       "requires": {
         "debug": "^3.1.0"
       }
@@ -99,7 +99,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -113,7 +113,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "has-flag": {
@@ -147,12 +147,12 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -176,7 +176,7 @@
     "mocha": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
-      "integrity": "sha1-4ijjOGuTh6RxAAemQfEnsAvkS1I=",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
@@ -224,7 +224,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
         "has-flag": "^2.0.0"

--- a/eyes.sdk.core/package-lock.json
+++ b/eyes.sdk.core/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.4.1",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "balanced-match": {
@@ -25,7 +25,7 @@
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -87,7 +87,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
       "integrity": "sha1-2BIPRRgZD1Wqxlu2/HuF/NZm1qo=",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "fs.realpath": {
@@ -102,12 +102,12 @@
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -134,8 +134,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -155,7 +155,7 @@
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -202,7 +202,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -227,7 +227,7 @@
       "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "wrappy": {

--- a/eyes.sdk.core/package.json
+++ b/eyes.sdk.core/package.json
@@ -41,7 +41,7 @@
     "mocha": "^5.0.5"
   },
   "scripts": {
-    "test": "mocha ./test/**/*.spec.js"
+    "test": "mocha 'test/**/*.spec.js'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
+++ b/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('assert');
+
+const { RenderStatusResults } = require('../../index');
+
+describe.only('RenderStatusResults', () => {
+  it('constructor', () => {
+    const results = new RenderStatusResults();
+    assert.equal(results.hasOwnProperty('_status'), true);
+    assert.equal(results.hasOwnProperty('_imageLocation'), true);
+    assert.equal(results.hasOwnProperty('_error'), true);
+    assert.equal(results.hasOwnProperty('_os'), true);
+    assert.equal(results.hasOwnProperty('_userAgent'), true);
+  });
+
+  it('fromObject', () => {
+    const status = 'some status';
+    const error = 'some error';
+    const imageLocation = 'some image location';
+    const os = 'some os';
+    const userAgent = 'some user agent';
+    const results = RenderStatusResults.fromObject({
+      status,
+      error,
+      imageLocation,
+      os,
+      userAgent
+    });
+
+    assert.equal(results.getStatus(), status);
+    assert.equal(results.getError(), error);
+    assert.equal(results.getImageLocation(), imageLocation);
+    assert.equal(results.getOS(), os);
+    assert.equal(results.getUserAgent(), userAgent);
+  });
+
+  it('toJSON', () => {
+    const status = 'some status';
+    const error = 'some error';
+    const imageLocation = 'some image location';
+    const os = 'some os';
+    const userAgent = 'some user agent';
+    const results = RenderStatusResults.fromObject({
+      status,
+      error,
+      imageLocation,
+      os,
+      userAgent
+    });
+
+    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent"}');
+  });
+
+  it('toString', () => {
+    const status = 'some status';
+    const error = 'some error';
+    const imageLocation = 'some image location';
+    const os = 'some os';
+    const userAgent = 'some user agent';
+    const results = RenderStatusResults.fromObject({
+      status,
+      error,
+      imageLocation,
+      os,
+      userAgent
+    });
+
+    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent"} }');
+  })
+})

--- a/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
+++ b/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const { RenderStatusResults } = require('../../index');
 
-describe.only('RenderStatusResults', () => {
+describe('RenderStatusResults', () => {
   it('constructor', () => {
     const results = new RenderStatusResults();
     assert.equal(results.hasOwnProperty('_status'), true);

--- a/eyes.sdk.core/test/unit/TestResults.spec.js
+++ b/eyes.sdk.core/test/unit/TestResults.spec.js
@@ -7,12 +7,12 @@ const { TestResults } = require('../../index');
 describe('TestResults', () => {
   it('constructor', () => {
     const testResults = new TestResults();
-    assert.equal(testResults.toString(), 'TestResults (Existing test) { {"name":null,"status":null,"appName":null,' +
+    assert.equal(testResults.toString(), 'TestResults of existing test {"name":null,"status":null,"appName":null,' +
       '"batchName":null,"batchId":null,"branchName":null,"hostOS":null,"hostApp":null,"hostDisplaySize":null,' +
       '"startedAt":null,"duration":null,"isNew":null,"isSaved":null,"isDifferent":null,"isAborted":null,' +
       '"appUrls":null,"apiUrls":null,"stepsInfo":null,"steps":null,"matches":null,"mismatches":null,"missing":null,' +
       '"exactMatches":null,"strictMatches":null,"contentMatches":null,"layoutMatches":null,"noneMatches":null,' +
-      '"url":null} }');
+      '"url":null}');
   });
 
   it('fromObject', () => {


### PR DESCRIPTION
Rendering grid now sends `OS` and `userAgent` as part of `/render-status` response.
This PR populates the result with these values