### PR TITLE
Improve GeneralUtils.stringify

### DIFF
--- a/eyes.sdk.core/lib/utils/GeneralUtils.js
+++ b/eyes.sdk.core/lib/utils/GeneralUtils.js
@@ -308,12 +308,19 @@ class GeneralUtils {
   static stringify(...args) {
     return args
       .map(arg => {
-        if (typeof arg === 'object') {
-          if (typeof arg.toString === 'function') {
-            return arg.toString();
-          }
-
+        if (GeneralUtils.isPlainObject(arg)) {
           return JSON.stringify(arg);
+        }
+
+        if (arg instanceof Error) {
+          return arg.stack;
+        }
+
+        if (
+          typeof arg === 'function' ||
+          (typeof arg === 'object' && typeof arg.toString === 'function')
+        ) {
+          return arg.toString();
         }
 
         return arg;

--- a/eyes.sdk.core/test/unit/utils/GeneralUtils.spec.js
+++ b/eyes.sdk.core/test/unit/utils/GeneralUtils.spec.js
@@ -89,4 +89,35 @@ describe('GeneralUtils', () => {
       assert.equal(GeneralUtils.elapsedString(156458), '2m 36s 458ms');
     });
   });
+
+  describe.only('stringify', () => {
+    it('should return the same args for non-objects', () => {
+      assert.equal(GeneralUtils.stringify(4), 4);
+      assert.equal(GeneralUtils.stringify('str'), 'str');
+    });
+    
+    it('should call JSON.stringify for plain objects', () => {
+      assert.equal(GeneralUtils.stringify({prop: 'value'}), JSON.stringify({prop: 'value'}));
+    });
+
+    it('should return the stack for errors', () => {
+      assert.notEqual(GeneralUtils.stringify(new Error('bla')).match(/^Error: [^\n]+(\n\s+at [^\n]+)+$/), null);
+    });
+
+    it('should call toString on non-plain objects', () => {
+      const {RenderInfo} = require('../../../lib/renderer/RenderInfo');
+      assert.equal(
+        GeneralUtils.stringify(RenderInfo.fromObject({width: 3, height:4, sizeMode:'bla'})),
+        'RenderInfo { {"width":3,"height":4,"sizeMode":"bla"} }'
+      );
+    });
+
+    it('should return stringified function', () => {
+      assert.equal(GeneralUtils.stringify(() => { return 'bla'; }), '() => { return \'bla\'; }');
+    });
+
+    it('should concat multiple arguments', () => {
+      assert.equal(GeneralUtils.stringify(4, 'str', {prop: 'bla'}, ), '4 str {"prop":"bla"}');
+    });
+  })
 });


### PR DESCRIPTION
Added support for:
- plain objects (currently show as [object Object])
- errors (to show stack trace)
- functions (to show full body)