### PR TITLE
Send script hooks in render requests

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -14,7 +14,7 @@ class RenderRequest {
    * @param {string} [platform]
    * @param {string} [browserName]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName) {
+  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
@@ -26,6 +26,7 @@ class RenderRequest {
     this._platform = platform;
     this._browserName = browserName;
     this._renderId = undefined;
+    this._scriptHooks = scriptHooks;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -81,6 +82,20 @@ class RenderRequest {
   setRenderId(value) {
     this._renderId = value;
   }
+  
+  // noinspection JSUnusedGlobalSymbols
+  /** @return {string} */
+  getScriptHooks() {
+    return this._scriptHooks;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setScriptHooks(value) {
+    this._scriptHooks = value;
+  }
+
+
 
   /** @override */
   toJSON() {
@@ -112,6 +127,10 @@ class RenderRequest {
 
     if (this._renderInfo) {
       object.renderInfo = this._renderInfo.toJSON();
+    }
+
+    if (this._scriptHooks) {
+      object.scriptHooks = this._scriptHooks;
     }
 
     return object;

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const assert = require('assert');
+
+const { RenderRequest } = require('../../index');
+
+describe.only('RenderRequest', () => {
+  describe('constructor', () => {
+    it("doesn't allow empty webhook", () => {
+      assert.throws(() => new RenderRequest(), /IllegalArgument: webhook is null or empty/);
+      assert.throws(() => new RenderRequest(''), /IllegalArgument: webhook is null or empty/);
+    });
+    
+    it("doesn't allow empty url", () => {
+      assert.throws(() => new RenderRequest('webhook'), /IllegalArgument: url is null or undefined/);
+    });
+
+    it("doesn't allow empty dom", () => {
+      assert.throws(() => new RenderRequest('webhook', 'url'), /IllegalArgument: dom is null or undefined/);
+    });
+
+    it("fills values", () => {
+      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks');
+      assert.equal(renderRequest.getWebhook(), 'webhook');
+      assert.equal(renderRequest.getUrl(), 'url');
+      assert.equal(renderRequest.getDom(), 'dom');
+      assert.equal(renderRequest.getRenderInfo(), 'renderInfo');
+      assert.equal(renderRequest.getPlatform(), 'platform');
+      assert.equal(renderRequest.getBrowserName(), 'browserName');
+      assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
+    });
+  });
+
+  describe('getResources', () => {
+    it('returns resources from dom', () => {
+      const renderRequest = new RenderRequest('webhook', 'url', { getResources: () => 'resources' });
+      assert.equal(renderRequest.getResources(), 'resources');
+    });
+  });
+
+  describe('toJSON', () => {
+    it('returns the correct object', () => {
+      const resource1 = {
+        getUrl() { return 'url1'; },
+        getHashAsObject() { return 'hashAsObject1'; }
+      };
+      const resource2 = {
+        getUrl() { return 'url2'; },
+        getHashAsObject() { return 'hashAsObject2' }
+      };
+      const dom = {
+        getResources() { return [resource1, resource2]; },
+        getHashAsObject() { return 'dom_hashAsObject'; }
+      };
+
+      const renderInfo = {
+        toJSON() { return 'renderInfoToJSON'; }
+      }
+
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
+      const expected = {
+        webhook: 'webhook',
+        url: 'url',
+        dom: 'dom_hashAsObject',
+        resources: {
+          url1: 'hashAsObject1',
+          url2: 'hashAsObject2',
+        },
+        renderInfo: 'renderInfoToJSON',
+        browser: { 
+          name: 'browserName',
+          platform: 'platform',
+        },
+        scriptHooks: 'scriptHooks'
+      }
+      assert.deepEqual(renderRequest.toJSON(), expected);
+    });
+
+    it('doesn\'t include platform if there is no browserName', () => {
+      const dom = {
+        getResources() { return []; },
+        getHashAsObject() { return 'dom_hashAsObject'; }
+      };
+
+      const renderRequest = new RenderRequest('webhook', 'url', dom, null, 'platform');
+      const expected = {
+        webhook: 'webhook',
+        url: 'url',
+        dom: 'dom_hashAsObject',
+        resources: {}
+      }
+      assert.deepEqual(renderRequest.toJSON(), expected);
+    });
+  });
+
+  describe('toString', () => {
+    it('returns the correct string', () => {
+      const resource1 = {
+        getUrl() { return 'url1'; },
+        getHashAsObject() { return 'hashAsObject1'; }
+      };
+      const resource2 = {
+        getUrl() { return 'url2'; },
+        getHashAsObject() { return 'hashAsObject2' }
+      };
+      const dom = {
+        getResources() { return [resource1, resource2]; },
+        getHashAsObject() { return 'dom_hashAsObject'; }
+      };
+
+      const renderInfo = {
+        toJSON() { return 'renderInfoToJSON'; }
+      }
+
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
+      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks"} }');
+    });
+  })
+});


### PR DESCRIPTION
Rendering grid now accepts a `scriptHooks` argument to /render that runs a script in the browser.
Currently it supports running the script before taking the screenshot, like this:
```
scriptHooks: {
  beforeCaptureScreenshot: "document.body.style.backgroundColor = 'gold'"
}
```

This PR adds the `scriptHooks` field to `RenderRequest` and adds unit tests for the whole class