### PR TITLE
Support sending domUrl in matchWindow

### DIFF
--- a/eyes.sdk.core/lib/EyesBase.js
+++ b/eyes.sdk.core/lib/EyesBase.js
@@ -1897,7 +1897,7 @@ class EyesBase {
     const that = this;
     that._logger.verbose('getting screenshot...');
     // Getting the screenshot (abstract function implemented by each SDK).
-    let title, screenshot, screenshotBuffer, screenshotUrl;
+    let title, screenshot, screenshotBuffer, screenshotUrl, domUrl;
     return that.getScreenshot()
       .then(newScreenshot => {
         that._logger.verbose('Done getting screenshot!');
@@ -1947,6 +1947,13 @@ class EyesBase {
           });
       })
       .then(() => {
+        that._logger.verbose('Getting domUrl...');
+        return that.getDomUrl().then(newDomUrl => {
+          domUrl = newDomUrl;
+          that._logger.verbose('Done!');
+        });
+      })
+      .then(() => {
         that._logger.verbose('Getting title...');
         return that.getTitle().then(newTitle => {
           title = newTitle;
@@ -1954,7 +1961,7 @@ class EyesBase {
         });
       })
       .then(() => {
-        const result = new AppOutputWithScreenshot(new AppOutput(title, screenshotBuffer, screenshotUrl), screenshot);
+        const result = new AppOutputWithScreenshot(new AppOutput(title, screenshotBuffer, screenshotUrl, domUrl), screenshot);
         that._logger.verbose('Done!');
         return result;
       });
@@ -2096,6 +2103,18 @@ class EyesBase {
    */
   getTitle() {
     throw new TypeError('getTitle method is not implemented!');
+  }
+
+  // noinspection JSMethodCanBeStatic
+  /**
+   * A url pointing to a DOM capture of the AUT at the time of screenshot
+   *
+   * @protected
+   * @abstract
+   * @return {Promise<string>}
+   */
+  getDomUrl() {
+    throw new TypeError('getDomUrl method is not implemented!');
   }
 
   /**

--- a/eyes.sdk.core/lib/EyesBase.js
+++ b/eyes.sdk.core/lib/EyesBase.js
@@ -2114,7 +2114,7 @@ class EyesBase {
    * @return {Promise<string>}
    */
   getDomUrl() {
-    throw new TypeError('getDomUrl method is not implemented!');
+    return this.getPromiseFactory().resolve();
   }
 
   /**

--- a/eyes.sdk.core/lib/match/AppOutput.js
+++ b/eyes.sdk.core/lib/match/AppOutput.js
@@ -9,11 +9,13 @@ class AppOutput {
    * @param {Buffer} [screenshot64] Base64 encoding of the screenshot's bytes (the byte can be in either in compressed
    *   or uncompressed form)
    * @param {string} [screenshotUrl] The URL that points to the screenshot
+   * @param {string} [domUrl] URL that points to a dom capture of the provided screenshot
    */
-  constructor(title, screenshot64, screenshotUrl) {
+  constructor(title, screenshot64, screenshotUrl, domUrl) {
     this._title = title;
     this._screenshot64 = screenshot64;
     this._screenshotUrl = screenshotUrl;
+    this._domUrl = domUrl;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -49,6 +51,18 @@ class AppOutput {
   setScreenshotUrl(value) {
     this._screenshotUrl = value;
   }
+  
+  // noinspection JSUnusedGlobalSymbols
+  /** @return {string} */
+  getDomUrl() {
+    return this._domUrl;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setDomUrl(value) {
+    this._domUrl = value;
+  }
 
   /** @override */
   toJSON() {
@@ -62,6 +76,10 @@ class AppOutput {
 
     if (this._screenshotUrl) {
       object.screenshotUrl = this._screenshotUrl;
+    }
+
+    if (this._domUrl) {
+      object.domUrl = this._domUrl;
     }
 
     return object;


### PR DESCRIPTION
We're doing a PoC in showing relevant DOM information in the Eyes app.
To this end, we upload the information to the Eyes server, then sending it as a parameter called `domUrl` inside `MatchWindowData`.

The current implementation puts `domUrl` inside the `AppOutput` object. I figured that was the most proper place to put it.
I thing I have doubts about is in `_getAppOutputWithScreenshot` in `EyesBase.js`. This method is a bit hard to read, and so I didn't find an easy way to add this functionality there. I tried to be consistent with the other params like `screenshotUrl`. Also, there aren't tests for this method and I didn't want to dive into starting a new test for `EyesBase`. Any suggestion on how to do this better is welcome.

The SDK that currently sends this information is the Cypress SDK.