### PR TITLE
Add log for renderId in renderStatus response

### DIFF
--- a/eyes.sdk.core/lib/server/ServerConnector.js
+++ b/eyes.sdk.core/lib/server/ServerConnector.js
@@ -734,7 +734,7 @@ class ServerConnector {
           renderStatus = renderStatus[0]; // eslint-disable-line prefer-destructuring
         }
 
-        that._logger.verbose('ServerConnector.renderStatus - get succeeded', renderStatus);
+        that._logger.verbose(`ServerConnector.renderStatus - get succeeded for ${renderId} -`, renderStatus);
         return renderStatus;
       }
 


### PR DESCRIPTION
small addition to log - when renderStatus returns it's helpful to see what renderId it belongs to.