### PR TITLE
Support selector and region in RenderInfo

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderInfo.js
+++ b/eyes.sdk.core/lib/renderer/RenderInfo.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const { GeneralUtils } = require('../utils/GeneralUtils');
+const { Region } = require('../geometry/Region');
 
 class RenderInfo {
   constructor() {
     this._width = undefined;
     this._height = undefined;
     this._sizeMode = undefined;
+    this._selector = undefined;
+    this._region = undefined;
   }
 
   /**
@@ -14,7 +17,10 @@ class RenderInfo {
    * @return {RenderInfo}
    */
   static fromObject(object) {
-    return GeneralUtils.assignTo(new RenderInfo(), object);
+    const mapping = {};
+    if (object.region) mapping.region = Region.fromObject;
+    
+    return GeneralUtils.assignTo(new RenderInfo(), object, mapping);
   }
 
   /**
@@ -60,9 +66,38 @@ class RenderInfo {
     this._sizeMode = value;
   }
 
+  /** @return {string} */
+  getSelector() {
+    return this._selector;
+  }
+
+  /** @param {string} value */
+  setSelector(value) {
+    this._selector = value;
+  }
+
+  /** @return {Region} */
+  getRegion() {
+    return this._region;
+  }
+
+  /** @param {Region} value */
+  setRegion(value) {
+    this._region = value;
+  }
+
   /** @override */
   toJSON() {
-    return GeneralUtils.toPlain(this);
+    const obj = GeneralUtils.toPlain(this);
+    
+    // TODO remove this when rendering-grid changes x/y to left/top
+    if (obj.region) {
+      obj.region.x = obj.region.left;
+      obj.region.y = obj.region.top;
+      delete obj.region.left;
+      delete obj.region.top;
+    }
+    return obj;
   }
 
   /** @override */

--- a/eyes.sdk.core/lib/utils/GeneralUtils.js
+++ b/eyes.sdk.core/lib/utils/GeneralUtils.js
@@ -12,6 +12,8 @@ const BASE64_CHARS_PATTERN = /[^A-Z0-9+/=]/i;
 const MS_IN_S = 1000;
 const MS_IN_M = 60000;
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
 /**
  * @private
  * @param {object} to
@@ -99,7 +101,7 @@ class GeneralUtils {
     const plainObject = {};
     Object.keys(object).forEach(objectKey => {
       const publicKey = objectKey.replace('_', '');
-      if (Object.prototype.hasOwnProperty.call(object, objectKey) && !exclude.includes(objectKey)) {
+      if (hasOwnProperty.call(object, objectKey) && !exclude.includes(objectKey)) {
         if (object[objectKey] instanceof Object && typeof object[objectKey].toJSON === 'function') {
           plainObject[publicKey] = object[objectKey].toJSON();
         } else {
@@ -131,10 +133,10 @@ class GeneralUtils {
     Object.keys(object).forEach(objectKey => {
       const privateKey = `_${objectKey}`;
       if (
-        Object.prototype.hasOwnProperty.call(object, objectKey) &&
-        Object.prototype.hasOwnProperty.call(inst, privateKey)
+        hasOwnProperty.call(object, objectKey) &&
+        hasOwnProperty.call(inst, privateKey)
       ) {
-        if (Object.prototype.hasOwnProperty.call(mapping, objectKey)) {
+        if (hasOwnProperty.call(mapping, objectKey)) {
           inst[privateKey] = mapping[objectKey].call(null, object[objectKey]);
         } else {
           inst[privateKey] = object[objectKey];

--- a/eyes.sdk.core/test/unit/RenderInfo.spec.js
+++ b/eyes.sdk.core/test/unit/RenderInfo.spec.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+
+const { RenderInfo, Region, RectangleSize } = require('../../index');
+
+describe.only('RenderInfo', () => {
+  it('constructor', () => {
+    const renderInfo = new RenderInfo();
+    assert.equal(renderInfo.hasOwnProperty('_width'), true);
+    assert.equal(renderInfo.hasOwnProperty('_height'), true);
+    assert.equal(renderInfo.hasOwnProperty('_sizeMode'), true);
+    assert.equal(renderInfo.hasOwnProperty('_selector'), true);
+    assert.equal(renderInfo.hasOwnProperty('_region'), true);
+  });
+
+  it('fromObject', () => {
+    const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    
+    const renderInfo = RenderInfo.fromObject({
+      width: 1,
+      height: 2,
+      sizeMode: 'some size mode',
+      selector: 'some selector',
+      region: regionObj
+    });
+
+    const region = Region.fromObject(regionObj);
+
+    assert.equal(renderInfo.getWidth(), 1);
+    assert.equal(renderInfo.getHeight(), 2);
+    assert.equal(renderInfo.getSizeMode(), 'some size mode');
+    assert.equal(renderInfo.getSelector(), 'some selector');
+    assert.deepEqual(renderInfo.getRegion(), region);
+  });
+
+  it('fromObject handles undefined region', () => {
+    const renderInfo = RenderInfo.fromObject({});
+    assert.equal(renderInfo.getRegion(), undefined);
+  })
+
+  it('fromRectangleSize', () => {
+    const rectangleSize = RectangleSize.fromObject({ width: 1, height: 2});
+    const renderInfo = RenderInfo.fromRectangleSize(rectangleSize, 'some size mode');
+
+    assert.equal(renderInfo.getWidth(), 1);
+    assert.equal(renderInfo.getHeight(), 2);
+    assert.equal(renderInfo.getSizeMode(), 'some size mode');
+    assert.equal(renderInfo.getSelector(), undefined);
+    assert.equal(renderInfo.getRegion(), undefined);
+  });
+
+  it('fromRectangleSize has a default sizeMode', () => {
+    const rectangleSize = RectangleSize.fromObject({ width: 1, height: 2});
+    const renderInfo = RenderInfo.fromRectangleSize(rectangleSize);
+
+    assert.equal(renderInfo.getWidth(), 1);
+    assert.equal(renderInfo.getHeight(), 2);
+    assert.equal(renderInfo.getSizeMode(), 'full-page');
+    assert.equal(renderInfo.getSelector(), undefined);
+    assert.equal(renderInfo.getRegion(), undefined);
+  });
+
+  it('toJSON', () => {
+    const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    const renderInfoObj = {
+      width: 1,
+      height: 2,
+      sizeMode: 'some size mode',
+      selector: 'some selector',
+      region: regionObj
+    };
+    
+    const renderInfo = RenderInfo.fromObject(renderInfoObj);
+    const renderInfoWithAdjustedLeftTop = Object.assign(renderInfoObj, {
+      region: { x: 3, y: 4, width: 5, height: 6 }
+    });
+
+    assert.deepEqual(renderInfo.toJSON(), renderInfoWithAdjustedLeftTop);
+  });
+
+  it('toString', () => {
+    const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    const renderInfoObj = {
+      width: 1,
+      height: 2,
+      sizeMode: 'some size mode',
+      selector: 'some selector',
+      region: regionObj
+    };
+    
+    const renderInfo = RenderInfo.fromObject(renderInfoObj);
+    assert.deepEqual(renderInfo.toString(), 'RenderInfo { {"width":1,"height":2,"sizeMode":"some size mode","selector":"some selector","region":{"width":5,"height":6,"x":3,"y":4}} }');
+  });
+});

--- a/eyes.sdk.core/test/unit/utils/GeneralUtils.spec.js
+++ b/eyes.sdk.core/test/unit/utils/GeneralUtils.spec.js
@@ -90,7 +90,7 @@ describe('GeneralUtils', () => {
     });
   });
 
-  describe.only('stringify', () => {
+  describe('stringify', () => {
     it('should return the same args for non-objects', () => {
       assert.equal(GeneralUtils.stringify(4), 4);
       assert.equal(GeneralUtils.stringify('str'), 'str');


### PR DESCRIPTION
Rendering grid now supports 2 additional `sizeMode`'s:
1) 'selector' - with an additional `selector` property inside `RenderInfo`.
2) 'region' - with an additional `region` property that conforms to the `Region` class.

This PR adds these 2 properties to `RenderInfo` so they can be sent to the rendering grid.

I also suggest (not in this PR) to deprecate RenderInfo.fromRectangleSize because it's not scalable when additional arguments add up (like selector and region).