### PR TITLE
Add emulation info to render request

### DIFF
--- a/eyes.sdk.core/index.js
+++ b/eyes.sdk.core/index.js
@@ -71,6 +71,9 @@ exports.RenderStatusResults = require('./lib/renderer/RenderStatusResults').Rend
 exports.RGridDom = require('./lib/renderer/RGridDom').RGridDom;
 exports.RGridResource = require('./lib/renderer/RGridResource').RGridResource;
 exports.RunningRender = require('./lib/renderer/RunningRender').RunningRender;
+exports.EmulationInfo = require('./lib/renderer/EmulationInfo').EmulationInfo;
+exports.EmulationDevice = require('./lib/renderer/EmulationDevice').EmulationDevice;
+exports.ScreenOrientation = require('./lib/renderer/ScreenOrientation').ScreenOrientation;
 
 exports.ContextBasedScaleProvider = require('./lib/scaling/ContextBasedScaleProvider').ContextBasedScaleProvider;
 exports.ContextBasedScaleProviderFactory = require('./lib/scaling/ContextBasedScaleProviderFactory').ContextBasedScaleProviderFactory;

--- a/eyes.sdk.core/lib/renderer/EmulationDevice.js
+++ b/eyes.sdk.core/lib/renderer/EmulationDevice.js
@@ -10,6 +10,14 @@ class EmulationDevice {
     this._mobile = mobile;
   }
 
+    /**
+   * @param {Object} object
+   * @return {EmulationDevice}
+   */
+  static fromObject(object) {
+    return GeneralUtils.assignTo(new EmulationDevice(), object);
+  }
+
   /** @return {number} */
   getWidth() {
     return this._width;

--- a/eyes.sdk.core/lib/renderer/EmulationDevice.js
+++ b/eyes.sdk.core/lib/renderer/EmulationDevice.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { GeneralUtils } = require('../utils/GeneralUtils');
+
+class EmulationDevice {
+  constructor({width, height, deviceScaleFactor, mobile} = {}) {
+    this._width = width;
+    this._height = height;
+    this._deviceScaleFactor = deviceScaleFactor;
+    this._mobile = mobile;
+  }
+
+  /** @return {number} */
+  getWidth() {
+    return this._width;
+  }
+
+  /** @param {number} value */
+  setWidth(value) {
+    this._width = value;
+  }
+
+  /** @return {number} */
+  getHeight() {
+    return this._height;
+  }
+
+  /** @param {number} value */
+  setHeight(value) {
+    this._height = value;
+  }
+
+  /** @return {string} */
+  getDeviceScaleFactor() {
+    return this._deviceScaleFactor;
+  }
+
+  /** @param {string} value */
+  setDeviceScaleFactor(value) {
+    this._deviceScaleFactor = value;
+  }
+
+  /** @return {string} */
+  getMobile() {
+    return this._mobile;
+  }
+
+  /** @param {string} value */
+  setMobile(value) {
+    this._mobile = value;
+  }
+
+  /** @override */
+  toJSON() {
+    return GeneralUtils.toPlain(this);
+  }
+
+  /** @override */
+  toString() {
+    return `EmulationDevice { ${JSON.stringify(this)} }`;
+  }
+}
+
+exports.EmulationDevice = EmulationDevice;

--- a/eyes.sdk.core/lib/renderer/EmulationInfo.js
+++ b/eyes.sdk.core/lib/renderer/EmulationInfo.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { GeneralUtils } = require('../utils/GeneralUtils');
+const { Region } = require('../geometry/Region');
+const {ScreenOrientation} = require('./ScreenOrientation');
+
+class EmulationInfo {
+  /**
+   * @param {device: EmulationDevice, deviceName: string, screenOrientation: ScreenOrientation}
+   * @return {EmulationInfo}
+   */
+  constructor({device, deviceName, screenOrientation} = {}) {
+    this._device = device;
+    this._deviceName = deviceName;
+    this._screenOrientation = screenOrientation;
+  }
+
+  /** @return {EmulationDevice} */
+  getDevice() {
+    return this._device;
+  }
+
+  /** @param {EmulationDevice} value */
+  setDevice(value) {
+    this._device = value;
+  }
+
+  /** @return {string} */
+  getDeviceName() {
+    return this._deviceName;
+  }
+
+  /** @param {string} value */
+  setDeviceName(value) {
+    this._deviceName = value;
+  }
+
+  /** @return {ScreenOrientation} */
+  getScreenOrientation() {
+    return this._screenOrientation;
+  }
+
+  /** @param {ScreenOrientation} value */
+  setScreenOrientation(value) {
+    this._screenOrientation = value;
+  }
+
+  /** @override */
+  toJSON() {
+    if (this._device) {
+      return Object.assign({
+        screenOrientation: this._screenOrientation,
+      }, this._device.toJSON());
+    } else {
+      return GeneralUtils.toPlain(this, ['_device']);
+    }
+  }
+
+  /** @override */
+  toString() {
+    return `EmulationInfo { ${JSON.stringify(this)} }`;
+  }
+}
+
+exports.EmulationInfo = EmulationInfo;

--- a/eyes.sdk.core/lib/renderer/EmulationInfo.js
+++ b/eyes.sdk.core/lib/renderer/EmulationInfo.js
@@ -3,6 +3,7 @@
 const { GeneralUtils } = require('../utils/GeneralUtils');
 const { Region } = require('../geometry/Region');
 const {ScreenOrientation} = require('./ScreenOrientation');
+const {EmulationDevice} = require('./EmulationDevice');
 
 class EmulationInfo {
   /**
@@ -21,7 +22,7 @@ class EmulationInfo {
    */
   static fromObject(object) {
     const mapping = {};
-    if (object.device) mapping.region = EmulationDevice.fromObject;
+    if (object.device) mapping.device = EmulationDevice.fromObject;
     
     return GeneralUtils.assignTo(new EmulationInfo(), object, mapping);
   }

--- a/eyes.sdk.core/lib/renderer/EmulationInfo.js
+++ b/eyes.sdk.core/lib/renderer/EmulationInfo.js
@@ -15,6 +15,17 @@ class EmulationInfo {
     this._screenOrientation = screenOrientation;
   }
 
+  /**
+   * @param {Object} object
+   * @return {EmulationInfo}
+   */
+  static fromObject(object) {
+    const mapping = {};
+    if (object.device) mapping.region = EmulationDevice.fromObject;
+    
+    return GeneralUtils.assignTo(new EmulationInfo(), object, mapping);
+  }
+
   /** @return {EmulationDevice} */
   getDevice() {
     return this._device;

--- a/eyes.sdk.core/lib/renderer/RenderInfo.js
+++ b/eyes.sdk.core/lib/renderer/RenderInfo.js
@@ -2,6 +2,7 @@
 
 const { GeneralUtils } = require('../utils/GeneralUtils');
 const { Region } = require('../geometry/Region');
+const { EmulationInfo } = require('./EmulationInfo');
 
 class RenderInfo {
   constructor() {
@@ -10,6 +11,7 @@ class RenderInfo {
     this._sizeMode = undefined;
     this._selector = undefined;
     this._region = undefined;
+    this._emulationInfo = undefined;
   }
 
   /**
@@ -19,6 +21,7 @@ class RenderInfo {
   static fromObject(object) {
     const mapping = {};
     if (object.region) mapping.region = Region.fromObject;
+    if (object.emulationInfo) mapping.emulationInfo = EmulationInfo.fromObject;
     
     return GeneralUtils.assignTo(new RenderInfo(), object, mapping);
   }
@@ -86,10 +89,26 @@ class RenderInfo {
     this._region = value;
   }
 
+  // noinspection JSUnusedGlobalSymbols
+  /** @return {string} */
+  getEmulationInfo() {
+    return this._emulationInfo;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setEmulationInfo(value) {
+    this._emulationInfo = value;
+  }
+
   /** @override */
   toJSON() {
-    const obj = GeneralUtils.toPlain(this);
+    const obj = GeneralUtils.toPlain(this, ['_emulationInfo']);
     
+    if (this._emulationInfo) {
+      obj.emulationInfo = this._emulationInfo.toJSON();
+    }
+
     // TODO remove this when rendering-grid changes x/y to left/top
     if (obj.region) {
       obj.region.x = obj.region.left;

--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -13,8 +13,10 @@ class RenderRequest {
    * @param {RenderInfo} [renderInfo]
    * @param {string} [platform]
    * @param {string} [browserName]
+   * @param {Object} [scriptHooks]
+   * @param {EmulationInfo} [emulationInfo]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks) {
+  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, emulationInfo) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
@@ -27,6 +29,7 @@ class RenderRequest {
     this._browserName = browserName;
     this._renderId = undefined;
     this._scriptHooks = scriptHooks;
+    this._emulationInfo = emulationInfo
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -95,6 +98,18 @@ class RenderRequest {
     this._scriptHooks = value;
   }
 
+  // noinspection JSUnusedGlobalSymbols
+  /** @return {string} */
+  getEmulationInfo() {
+    return this._emulationInfo;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string} value */
+  setEmulationInfo(value) {
+    this._emulationInfo = value;
+  }
+
 
 
   /** @override */
@@ -131,6 +146,10 @@ class RenderRequest {
 
     if (this._scriptHooks) {
       object.scriptHooks = this._scriptHooks;
+    }
+
+    if (this._emulationInfo) {
+      object.emulationInfo = this._emulationInfo.toJSON();
     }
 
     return object;

--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -14,9 +14,8 @@ class RenderRequest {
    * @param {string} [platform]
    * @param {string} [browserName]
    * @param {Object} [scriptHooks]
-   * @param {EmulationInfo} [emulationInfo]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, emulationInfo) {
+  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
@@ -29,7 +28,6 @@ class RenderRequest {
     this._browserName = browserName;
     this._renderId = undefined;
     this._scriptHooks = scriptHooks;
-    this._emulationInfo = emulationInfo
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -98,20 +96,6 @@ class RenderRequest {
     this._scriptHooks = value;
   }
 
-  // noinspection JSUnusedGlobalSymbols
-  /** @return {string} */
-  getEmulationInfo() {
-    return this._emulationInfo;
-  }
-
-  // noinspection JSUnusedGlobalSymbols
-  /** @param {string} value */
-  setEmulationInfo(value) {
-    this._emulationInfo = value;
-  }
-
-
-
   /** @override */
   toJSON() {
     const resources = {};
@@ -146,10 +130,6 @@ class RenderRequest {
 
     if (this._scriptHooks) {
       object.scriptHooks = this._scriptHooks;
-    }
-
-    if (this._emulationInfo) {
-      object.emulationInfo = this._emulationInfo.toJSON();
     }
 
     return object;

--- a/eyes.sdk.core/lib/renderer/ScreenOrientation.js
+++ b/eyes.sdk.core/lib/renderer/ScreenOrientation.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+const ScreenOrientation = {
+  PORTRAIT: 'portrait',
+  LANDSCAPE: 'landscape',
+};
+
+Object.freeze(ScreenOrientation);
+exports.ScreenOrientation = ScreenOrientation;

--- a/eyes.sdk.core/test/unit/EmulationDevice.spec.js
+++ b/eyes.sdk.core/test/unit/EmulationDevice.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('assert');
+
+const { EmulationDevice } = require('../../index');
+
+describe('EmulationDevice', () => {
+  it('constructor without arguments', () => {
+    const emulationDevice = new EmulationDevice();
+    assert.equal(emulationDevice.hasOwnProperty('_width'), true);
+    assert.equal(emulationDevice.hasOwnProperty('_height'), true);
+    assert.equal(emulationDevice.hasOwnProperty('_deviceScaleFactor'), true);
+    assert.equal(emulationDevice.hasOwnProperty('_mobile'), true);
+  });
+
+  it('constructor with arguments', () => {
+    const emulationDevice = new EmulationDevice({ width: 1, height: 2, deviceScaleFactor: 3, mobile: true });
+    assert.equal(emulationDevice.getWidth(), 1);
+    assert.equal(emulationDevice.getHeight(), 2);
+    assert.equal(emulationDevice.getDeviceScaleFactor(), 3);
+    assert.equal(emulationDevice.getMobile(), true);
+  });
+
+  it('toJSON', () => {
+    const emulationDeviceObj = { width: 1, height: 2, deviceScaleFactor: 3, mobile: true };
+    const emulationDevice = new EmulationDevice(emulationDeviceObj);
+    assert.deepEqual(emulationDevice.toJSON(), emulationDeviceObj);
+  });
+
+  it('toString', () => {
+    const emulationDeviceObj = { width: 1, height: 2, deviceScaleFactor: 3, mobile: true };
+    const emulationDevice = new EmulationDevice(emulationDeviceObj);
+    assert.deepEqual(emulationDevice.toString(), 'EmulationDevice { {"width":1,"height":2,"deviceScaleFactor":3,"mobile":true} }');
+  });
+});

--- a/eyes.sdk.core/test/unit/EmulationInfo.spec.js
+++ b/eyes.sdk.core/test/unit/EmulationInfo.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('assert');
+
+const { EmulationDevice, EmulationInfo, ScreenOrientation } = require('../../index');
+
+describe('EmulationInfo', () => {
+  it('constructor without arguments', () => {
+    const emulationInfo = new EmulationInfo();
+    assert.equal(emulationInfo.hasOwnProperty('_device'), true);
+    assert.equal(emulationInfo.hasOwnProperty('_deviceName'), true);
+    assert.equal(emulationInfo.hasOwnProperty('_screenOrientation'), true);
+  });
+  
+  it('constructor with arguments', () => {
+    const device = new EmulationDevice({width: 1, height: 2});
+    const emulationInfo = new EmulationInfo({device, screenOrientation: ScreenOrientation.PORTRAIT});
+    assert.equal(emulationInfo.getDevice(), device);
+    assert.equal(emulationInfo.getDeviceName(), undefined);
+    assert.equal(emulationInfo.getScreenOrientation(), ScreenOrientation.PORTRAIT);
+
+    const emulationInfo2 = new EmulationInfo({deviceName: 'name'});
+    assert.equal(emulationInfo2.getDevice(), undefined);
+    assert.equal(emulationInfo2.getDeviceName(), 'name');
+    assert.equal(emulationInfo2.getScreenOrientation(), undefined);
+  });
+
+  it('toJSON', () => {
+    const device = new EmulationDevice({width: 1, height: 2});
+    const emulationInfo = new EmulationInfo({ device, screenOrientation: ScreenOrientation.LANDSCAPE });
+    assert.deepEqual(emulationInfo.toJSON(), { width: 1, height: 2, mobile: undefined, deviceScaleFactor: undefined, screenOrientation: ScreenOrientation.LANDSCAPE });
+
+    const emulationInfo2 = new EmulationInfo({ deviceName: 'name' });
+    assert.deepEqual(emulationInfo2.toJSON(), { deviceName: 'name', screenOrientation: undefined });
+  });
+
+  it('toString', () => {
+    const device = new EmulationDevice({width: 1, height: 2});
+    const emulationInfo = new EmulationInfo({ device, screenOrientation: ScreenOrientation.LANDSCAPE });
+    assert.deepEqual(emulationInfo.toString(), 'EmulationInfo { {"screenOrientation":"landscape","width":1,"height":2} }');
+
+    const emulationInfo2 = new EmulationInfo({ deviceName: 'name' });
+    assert.deepEqual(emulationInfo2.toString(), 'EmulationInfo { {"deviceName":"name"} }');
+  });
+});

--- a/eyes.sdk.core/test/unit/EmulationInfo.spec.js
+++ b/eyes.sdk.core/test/unit/EmulationInfo.spec.js
@@ -25,6 +25,19 @@ describe('EmulationInfo', () => {
     assert.equal(emulationInfo2.getScreenOrientation(), undefined);
   });
 
+  it('fromObject', () => {
+    const deviceObj = { width: 1, height: 2, deviceScaleFactor: 3, mobile: true };
+    const device = EmulationDevice.fromObject(deviceObj);
+    
+    const emulationInfo = EmulationInfo.fromObject({
+      screenOrientation: ScreenOrientation.LANDSCAPE,
+      device: deviceObj
+    });
+
+    assert.deepEqual(emulationInfo.getDevice(), device);
+    assert.equal(emulationInfo.getScreenOrientation(), ScreenOrientation.LANDSCAPE);
+  });
+
   it('toJSON', () => {
     const device = new EmulationDevice({width: 1, height: 2});
     const emulationInfo = new EmulationInfo({ device, screenOrientation: ScreenOrientation.LANDSCAPE });

--- a/eyes.sdk.core/test/unit/RenderInfo.spec.js
+++ b/eyes.sdk.core/test/unit/RenderInfo.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const { RenderInfo, Region, RectangleSize } = require('../../index');
 
-describe.only('RenderInfo', () => {
+describe('RenderInfo', () => {
   it('constructor', () => {
     const renderInfo = new RenderInfo();
     assert.equal(renderInfo.hasOwnProperty('_width'), true);

--- a/eyes.sdk.core/test/unit/RenderInfo.spec.js
+++ b/eyes.sdk.core/test/unit/RenderInfo.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const { RenderInfo, Region, RectangleSize } = require('../../index');
+const { RenderInfo, Region, RectangleSize, EmulationInfo, ScreenOrientation } = require('../../index');
 
 describe('RenderInfo', () => {
   it('constructor', () => {
@@ -12,26 +12,31 @@ describe('RenderInfo', () => {
     assert.equal(renderInfo.hasOwnProperty('_sizeMode'), true);
     assert.equal(renderInfo.hasOwnProperty('_selector'), true);
     assert.equal(renderInfo.hasOwnProperty('_region'), true);
+    assert.equal(renderInfo.hasOwnProperty('_emulationInfo'), true);
   });
 
   it('fromObject', () => {
     const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    const emulationInfoObj = {deviceName: 'deviceName'};
     
     const renderInfo = RenderInfo.fromObject({
       width: 1,
       height: 2,
       sizeMode: 'some size mode',
       selector: 'some selector',
-      region: regionObj
+      region: regionObj,
+      emulationInfo: emulationInfoObj
     });
 
     const region = Region.fromObject(regionObj);
+    const emulationInfo = EmulationInfo.fromObject(emulationInfoObj);
 
     assert.equal(renderInfo.getWidth(), 1);
     assert.equal(renderInfo.getHeight(), 2);
     assert.equal(renderInfo.getSizeMode(), 'some size mode');
     assert.equal(renderInfo.getSelector(), 'some selector');
     assert.deepEqual(renderInfo.getRegion(), region);
+    assert.deepEqual(renderInfo.getEmulationInfo(), emulationInfo);
   });
 
   it('fromObject handles undefined region', () => {
@@ -63,17 +68,19 @@ describe('RenderInfo', () => {
 
   it('toJSON', () => {
     const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    const emulationInfo = {deviceName: 'deviceName', screenOrientation: ScreenOrientation.PORTRAIT};
     const renderInfoObj = {
       width: 1,
       height: 2,
       sizeMode: 'some size mode',
       selector: 'some selector',
-      region: regionObj
+      region: regionObj,
+      emulationInfo,
     };
     
     const renderInfo = RenderInfo.fromObject(renderInfoObj);
     const renderInfoWithAdjustedLeftTop = Object.assign(renderInfoObj, {
-      region: { x: 3, y: 4, width: 5, height: 6 }
+      region: { x: 3, y: 4, width: 5, height: 6 },
     });
 
     assert.deepEqual(renderInfo.toJSON(), renderInfoWithAdjustedLeftTop);
@@ -81,15 +88,17 @@ describe('RenderInfo', () => {
 
   it('toString', () => {
     const regionObj = { left: 3, top: 4, width: 5, height: 6};
+    const emulationInfo = {deviceName: 'deviceName', screenOrientation: ScreenOrientation.PORTRAIT};
     const renderInfoObj = {
       width: 1,
       height: 2,
       sizeMode: 'some size mode',
       selector: 'some selector',
-      region: regionObj
+      region: regionObj,
+      emulationInfo,
     };
     
     const renderInfo = RenderInfo.fromObject(renderInfoObj);
-    assert.deepEqual(renderInfo.toString(), 'RenderInfo { {"width":1,"height":2,"sizeMode":"some size mode","selector":"some selector","region":{"width":5,"height":6,"x":3,"y":4}} }');
+    assert.deepEqual(renderInfo.toString(), 'RenderInfo { {"width":1,"height":2,"sizeMode":"some size mode","selector":"some selector","region":{"width":5,"height":6,"x":3,"y":4},"emulationInfo":{"deviceName":"deviceName","screenOrientation":"portrait"}} }');
   });
 });

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -20,7 +20,7 @@ describe('RenderRequest', () => {
     });
 
     it("fills values", () => {
-      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks');
+      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'emulationInfo');
       assert.equal(renderRequest.getWebhook(), 'webhook');
       assert.equal(renderRequest.getUrl(), 'url');
       assert.equal(renderRequest.getDom(), 'dom');
@@ -28,6 +28,7 @@ describe('RenderRequest', () => {
       assert.equal(renderRequest.getPlatform(), 'platform');
       assert.equal(renderRequest.getBrowserName(), 'browserName');
       assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
+      assert.equal(renderRequest.getEmulationInfo(), 'emulationInfo');
     });
   });
 
@@ -55,9 +56,13 @@ describe('RenderRequest', () => {
 
       const renderInfo = {
         toJSON() { return 'renderInfoToJSON'; }
-      }
+      };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
+      const emulationInfo = {
+        toJSON() { return 'emulationInfo'; }
+      };
+
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', emulationInfo);
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -71,7 +76,8 @@ describe('RenderRequest', () => {
           name: 'browserName',
           platform: 'platform',
         },
-        scriptHooks: 'scriptHooks'
+        scriptHooks: 'scriptHooks',
+        emulationInfo: 'emulationInfo',
       }
       assert.deepEqual(renderRequest.toJSON(), expected);
     });
@@ -110,10 +116,14 @@ describe('RenderRequest', () => {
 
       const renderInfo = {
         toJSON() { return 'renderInfoToJSON'; }
-      }
+      };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
-      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks"} }');
+      const emulationInfo = {
+        toJSON() { return 'emulationInfo'; }
+      };
+
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', emulationInfo);
+      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","emulationInfo":"emulationInfo"} }');
     });
   })
 });

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -20,7 +20,7 @@ describe('RenderRequest', () => {
     });
 
     it("fills values", () => {
-      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'emulationInfo');
+      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks');
       assert.equal(renderRequest.getWebhook(), 'webhook');
       assert.equal(renderRequest.getUrl(), 'url');
       assert.equal(renderRequest.getDom(), 'dom');
@@ -28,7 +28,6 @@ describe('RenderRequest', () => {
       assert.equal(renderRequest.getPlatform(), 'platform');
       assert.equal(renderRequest.getBrowserName(), 'browserName');
       assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
-      assert.equal(renderRequest.getEmulationInfo(), 'emulationInfo');
     });
   });
 
@@ -58,11 +57,7 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const emulationInfo = {
-        toJSON() { return 'emulationInfo'; }
-      };
-
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', emulationInfo);
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -77,7 +72,6 @@ describe('RenderRequest', () => {
           platform: 'platform',
         },
         scriptHooks: 'scriptHooks',
-        emulationInfo: 'emulationInfo',
       }
       assert.deepEqual(renderRequest.toJSON(), expected);
     });
@@ -118,12 +112,8 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const emulationInfo = {
-        toJSON() { return 'emulationInfo'; }
-      };
-
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', emulationInfo);
-      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","emulationInfo":"emulationInfo"} }');
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
+      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks"} }');
     });
   })
 });


### PR DESCRIPTION
This PR adds emulation info to RenderRequest, as documented in the rendering grid API [here](https://docs.google.com/document/d/1B1OtmNqJ7G7I6iedqYK3PwKC5_1ah_1uo9Kc_X8O858/edit#).

For code style consistency I created the EmuationInfo and EmulationDevice classes, plus ScreenOrientation enum.

Tests for these classes were added too.
