### PR TITLE
Add width and height to RenderStatusResults

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderStatusResults.js
+++ b/eyes.sdk.core/lib/renderer/RenderStatusResults.js
@@ -12,6 +12,8 @@ class RenderStatusResults {
     this._error = undefined;
     this._os = undefined;
     this._userAgent = undefined;
+    this._width = undefined;
+    this._height = undefined;
   }
 
   /**
@@ -38,7 +40,6 @@ class RenderStatusResults {
     return this._status;
   }
 
-  // noinspection JSUnusedGlobalSymbols
   /** @param {string} value */
   setStatus(value) {
     this._status = value;
@@ -49,7 +50,6 @@ class RenderStatusResults {
     return this._imageLocation;
   }
 
-  // noinspection JSUnusedGlobalSymbols
   /** @param {string} value */
   setImageLocation(value) {
     this._imageLocation = value;
@@ -60,7 +60,6 @@ class RenderStatusResults {
     return this._error;
   }
 
-  // noinspection JSUnusedGlobalSymbols
   /** @param {string} value */
   setError(value) {
     this._error = value;
@@ -71,7 +70,6 @@ class RenderStatusResults {
     return this._os;
   }
 
-  // noinspection JSUnusedGlobalSymbols
   /** @param {string} value */
   setOS(value) {
     this._os = value;
@@ -82,10 +80,29 @@ class RenderStatusResults {
     return this._userAgent;
   }
 
-  // noinspection JSUnusedGlobalSymbols
   /** @param {string} value */
   setUserAgent(value) {
     this._userAgent = value;
+  }
+
+  /** @return {number} */
+  getWidth() {
+    return this._width;
+  }
+
+  /** @param {number} value */
+  setWidth(value) {
+    this._width = value;
+  }
+
+  /** @return {number} */
+  getHeight() {
+    return this._height;
+  }
+
+  /** @param {number} value */
+  setHeight(value) {
+    this._height = value;
   }
   
   /** @override */

--- a/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
+++ b/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
@@ -12,6 +12,8 @@ describe('RenderStatusResults', () => {
     assert.equal(results.hasOwnProperty('_error'), true);
     assert.equal(results.hasOwnProperty('_os'), true);
     assert.equal(results.hasOwnProperty('_userAgent'), true);
+    assert.equal(results.hasOwnProperty('_width'), true);
+    assert.equal(results.hasOwnProperty('_height'), true);
   });
 
   it('fromObject', () => {
@@ -25,7 +27,9 @@ describe('RenderStatusResults', () => {
       error,
       imageLocation,
       os,
-      userAgent
+      userAgent,
+      width: 1,
+      height: 2,
     });
 
     assert.equal(results.getStatus(), status);
@@ -33,6 +37,8 @@ describe('RenderStatusResults', () => {
     assert.equal(results.getImageLocation(), imageLocation);
     assert.equal(results.getOS(), os);
     assert.equal(results.getUserAgent(), userAgent);
+    assert.equal(results.getWidth(), 1);
+    assert.equal(results.getHeight(), 2);
   });
 
   it('toJSON', () => {
@@ -46,10 +52,12 @@ describe('RenderStatusResults', () => {
       error,
       imageLocation,
       os,
-      userAgent
+      userAgent,
+      width: 1,
+      height: 2,
     });
 
-    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent"}');
+    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent","width":1,"height":2}');
   });
 
   it('toString', () => {
@@ -63,9 +71,11 @@ describe('RenderStatusResults', () => {
       error,
       imageLocation,
       os,
-      userAgent
+      userAgent,
+      width: 1,
+      height: 2,
     });
 
-    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent"} }');
+    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent","width":1,"height":2} }');
   })
 })


### PR DESCRIPTION
To accommodate device emulation, it's possible to pass `emulationInfo` with `deviceName` to the visual grid. In this case, the viewport size is determined by the visual grid, so it is returned in the render-status response.
This PR adds `width` and `height` properties to `RenderStatusResults`.