### PR TITLE
Add domLocation to RenderStatusResults

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderStatusResults.js
+++ b/eyes.sdk.core/lib/renderer/RenderStatusResults.js
@@ -10,6 +10,7 @@ class RenderStatusResults {
   constructor() {
     this._status = undefined;
     this._imageLocation = undefined;
+    this._domLocation = undefined;
     this._error = undefined;
     this._os = undefined;
     this._userAgent = undefined;
@@ -31,6 +32,7 @@ class RenderStatusResults {
     return (
       this._status === undefined &&
       this._imageLocation === undefined &&
+      this._domLocation === undefined &&
       this._error === undefined &&
       this._os === undefined &&
       this._userAgent === undefined &&
@@ -56,6 +58,16 @@ class RenderStatusResults {
   /** @param {string} value */
   setImageLocation(value) {
     this._imageLocation = value;
+  }
+
+  /** @return {string} */
+  getDomLocation() {
+    return this._domLocation;
+  }
+
+  /** @param {string} value */
+  setDomLocation(value) {
+    this._domLocation = value;
   }
 
   /** @return {string} */

--- a/eyes.sdk.core/test/unit/RenderInfo.spec.js
+++ b/eyes.sdk.core/test/unit/RenderInfo.spec.js
@@ -80,7 +80,7 @@ describe('RenderInfo', () => {
     
     const renderInfo = RenderInfo.fromObject(renderInfoObj);
     const renderInfoWithAdjustedLeftTop = Object.assign(renderInfoObj, {
-      region: { x: 3, y: 4, width: 5, height: 6 },
+      region: { x: 3, y: 4, width: 5, height: 6, coordinatesType: "SCREENSHOT_AS_IS" },
     });
 
     assert.deepEqual(renderInfo.toJSON(), renderInfoWithAdjustedLeftTop);
@@ -99,6 +99,6 @@ describe('RenderInfo', () => {
     };
     
     const renderInfo = RenderInfo.fromObject(renderInfoObj);
-    assert.deepEqual(renderInfo.toString(), 'RenderInfo { {"width":1,"height":2,"sizeMode":"some size mode","selector":"some selector","region":{"width":5,"height":6,"x":3,"y":4},"emulationInfo":{"deviceName":"deviceName","screenOrientation":"portrait"}} }');
+    assert.deepEqual(renderInfo.toString(), 'RenderInfo { {"width":1,"height":2,"sizeMode":"some size mode","selector":"some selector","region":{"width":5,"height":6,"coordinatesType":"SCREENSHOT_AS_IS","x":3,"y":4},"emulationInfo":{"deviceName":"deviceName","screenOrientation":"portrait"}} }');
   });
 });

--- a/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
+++ b/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
@@ -9,6 +9,7 @@ describe('RenderStatusResults', () => {
     const results = new RenderStatusResults();
     assert.equal(results.hasOwnProperty('_status'), true);
     assert.equal(results.hasOwnProperty('_imageLocation'), true);
+    assert.equal(results.hasOwnProperty('_domLocation'), true);
     assert.equal(results.hasOwnProperty('_error'), true);
     assert.equal(results.hasOwnProperty('_os'), true);
     assert.equal(results.hasOwnProperty('_userAgent'), true);
@@ -19,13 +20,15 @@ describe('RenderStatusResults', () => {
     const status = 'some status';
     const error = 'some error';
     const imageLocation = 'some image location';
+    const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
     const deviceSize = 'deviceSize';
-    const results = RenderStatusResults.fromObject({
+      const results = RenderStatusResults.fromObject({
       status,
       error,
       imageLocation,
+      domLocation,
       os,
       userAgent,
       deviceSize
@@ -34,6 +37,7 @@ describe('RenderStatusResults', () => {
     assert.equal(results.getStatus(), status);
     assert.equal(results.getError(), error);
     assert.equal(results.getImageLocation(), imageLocation);
+    assert.equal(results.getDomLocation(), domLocation);
     assert.equal(results.getOS(), os);
     assert.equal(results.getUserAgent(), userAgent);
     assert.equal(results.getDeviceSize(), deviceSize);
@@ -43,6 +47,7 @@ describe('RenderStatusResults', () => {
     const status = 'some status';
     const error = 'some error';
     const imageLocation = 'some image location';
+    const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
     const deviceSize = 'deviceSize';
@@ -50,18 +55,20 @@ describe('RenderStatusResults', () => {
       status,
       error,
       imageLocation,
+      domLocation,
       os,
       userAgent,
       deviceSize
     });
 
-    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"}');
+    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"}');
   });
 
   it('toString', () => {
     const status = 'some status';
     const error = 'some error';
     const imageLocation = 'some image location';
+    const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
     const deviceSize = 'deviceSize';
@@ -69,11 +76,12 @@ describe('RenderStatusResults', () => {
       status,
       error,
       imageLocation,
+      domLocation,
       os,
       userAgent,
       deviceSize
     });
 
-    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"} }');
+    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"} }');
   })
 })


### PR DESCRIPTION
Rendering grid takes a dom capture and uploads to eyes server, then provides the uploaded URL in the response of `/render-status` when the image is rendered.

Rendering grid protocol doc:
https://docs.google.com/document/d/1B1OtmNqJ7G7I6iedqYK3PwKC5_1ah_1uo9Kc_X8O858/edit#