### PR TITLE
Add location info for image in checkRegion

### DIFF
--- a/eyes.sdk.core/lib/EyesBase.js
+++ b/eyes.sdk.core/lib/EyesBase.js
@@ -1974,6 +1974,7 @@ class EyesBase {
           title = newTitle;
           domUrl = newDomUrl;
           imageLocation = newImageLocation;
+          that._logger.verbose('Done getting title, domUrl, imageLocation!')
         });
       })
       .then(() => {

--- a/eyes.sdk.core/lib/EyesBase.js
+++ b/eyes.sdk.core/lib/EyesBase.js
@@ -1914,7 +1914,7 @@ class EyesBase {
     const that = this;
     that._logger.verbose('getting screenshot...');
     // Getting the screenshot (abstract function implemented by each SDK).
-    let title, screenshot, screenshotBuffer, screenshotUrl, domUrl;
+    let title, screenshot, screenshotBuffer, screenshotUrl, domUrl, imageLocation;
     return that.getScreenshot()
       .then(newScreenshot => {
         that._logger.verbose('Done getting screenshot!');
@@ -1964,21 +1964,20 @@ class EyesBase {
           });
       })
       .then(() => {
-        that._logger.verbose('Getting domUrl...');
-        return that.getDomUrl().then(newDomUrl => {
-          domUrl = newDomUrl;
-          that._logger.verbose('Done!');
-        });
-      })
-      .then(() => {
-        that._logger.verbose('Getting title...');
-        return that.getTitle().then(newTitle => {
+        that._logger.verbose('Getting title, domUrl, imageLocation...');
+        return that._promiseFactory.all([
+          that.getTitle(),
+          that.getDomUrl(),
+          that.getImageLocation(),
+
+        ]).then(([newTitle, newDomUrl, newImageLocation]) => {
           title = newTitle;
-          that._logger.verbose('Done!');
+          domUrl = newDomUrl;
+          imageLocation = newImageLocation;
         });
       })
       .then(() => {
-        const result = new AppOutputWithScreenshot(new AppOutput(title, screenshotBuffer, screenshotUrl, domUrl), screenshot);
+        const result = new AppOutputWithScreenshot(new AppOutput(title, screenshotBuffer, screenshotUrl, domUrl, imageLocation), screenshot);
         that._logger.verbose('Done!');
         return result;
       });
@@ -2154,6 +2153,19 @@ class EyesBase {
   getDomUrl() {
     return this.getPromiseFactory().resolve();
   }
+  
+  /**
+   * The location of the image relative to the logical full page image, when cropping an image e.g. with checkRegion 
+   *
+   * @protected
+   * @abstract
+   * @return {Promise<Location>}
+   */
+  getImageLocation() {
+    return this.getPromiseFactory().resolve();
+  }
+
+
 
   /**
    * @return {PromiseFactory}

--- a/eyes.sdk.core/lib/match/AppOutput.js
+++ b/eyes.sdk.core/lib/match/AppOutput.js
@@ -10,6 +10,7 @@ class AppOutput {
    *   or uncompressed form)
    * @param {string} [screenshotUrl] The URL that points to the screenshot
    * @param {string} [domUrl] URL that points to a dom capture of the provided screenshot
+   * @param {Location} [imageLocation] Location of the provided screenshot relative to the logical full-page screenshot (e.g. in checkRegion)
    */
   constructor(title, screenshot64, screenshotUrl, domUrl, imageLocation) {
     this._title = title;
@@ -66,12 +67,12 @@ class AppOutput {
   }
 
   /** @return {Location} */
-  getLocation() {
+  getImageLocation() {
     return this._imageLocation;
   }
 
   /** @param {Location} value */
-  setDomUrl(value) {
+  setImageLocation(value) {
     this._imageLocation = value;
   }
 

--- a/eyes.sdk.core/lib/match/AppOutput.js
+++ b/eyes.sdk.core/lib/match/AppOutput.js
@@ -11,11 +11,12 @@ class AppOutput {
    * @param {string} [screenshotUrl] The URL that points to the screenshot
    * @param {string} [domUrl] URL that points to a dom capture of the provided screenshot
    */
-  constructor(title, screenshot64, screenshotUrl, domUrl) {
+  constructor(title, screenshot64, screenshotUrl, domUrl, imageLocation) {
     this._title = title;
     this._screenshot64 = screenshot64;
     this._screenshotUrl = screenshotUrl;
     this._domUrl = domUrl;
+    this._imageLocation = imageLocation;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -64,6 +65,16 @@ class AppOutput {
     this._domUrl = value;
   }
 
+  /** @return {Location} */
+  getLocation() {
+    return this._imageLocation;
+  }
+
+  /** @param {Location} value */
+  setDomUrl(value) {
+    this._imageLocation = value;
+  }
+
   /** @override */
   toJSON() {
     const object = {
@@ -80,6 +91,10 @@ class AppOutput {
 
     if (this._domUrl) {
       object.domUrl = this._domUrl;
+    }
+
+    if (this._imageLocation) {
+      object.location = this._imageLocation.toJSON();
     }
 
     return object;

--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -15,7 +15,7 @@ class RenderRequest {
    * @param {string} [browserName]
    * @param {Object} [scriptHooks]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks) {
+  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, selectorsToFindRegionsFor) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
@@ -28,6 +28,7 @@ class RenderRequest {
     this._browserName = browserName;
     this._renderId = undefined;
     this._scriptHooks = scriptHooks;
+    this._selectorsToFindRegionsFor = selectorsToFindRegionsFor;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -96,6 +97,18 @@ class RenderRequest {
     this._scriptHooks = value;
   }
 
+  // noinspection JSUnusedGlobalSymbols
+  /** @return {string[]} */
+  getSelectorsToFindRegionsFor() {
+    return this._selectorsToFindRegionsFor;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /** @param {string[]} value */
+  setSelectorsToFindRegionsFor(value) {
+    this._selectorsToFindRegionsFor = value;
+  }
+
   /** @override */
   toJSON() {
     const resources = {};
@@ -130,6 +143,10 @@ class RenderRequest {
 
     if (this._scriptHooks) {
       object.scriptHooks = this._scriptHooks;
+    }
+
+    if (this._selectorsToFindRegionsFor) {
+      object.selectorsToFindRegionsFor = this._selectorsToFindRegionsFor;
     }
 
     return object;

--- a/eyes.sdk.core/lib/renderer/RenderStatusResults.js
+++ b/eyes.sdk.core/lib/renderer/RenderStatusResults.js
@@ -2,6 +2,7 @@
 
 const { GeneralUtils } = require('../utils/GeneralUtils');
 const { RectangleSize } = require('../geometry/RectangleSize');
+const { Region } = require('../geometry/Region');
 
 /**
  * Encapsulates data for the render currently running in the client.
@@ -15,6 +16,7 @@ class RenderStatusResults {
     this._os = undefined;
     this._userAgent = undefined;
     this._deviceSize = undefined;
+    this._selectorRegions = undefined;
   }
 
   /**
@@ -24,7 +26,8 @@ class RenderStatusResults {
   static fromObject(object) {
     const mapping = {};
     if (object.deviceSize) mapping.deviceSize = RectangleSize.fromObject;
-    return GeneralUtils.assignTo(new RenderStatusResults(), object);
+    if (object.selectorRegions) mapping.selectorRegions = regions => regions ? regions.map(regionFromRGridObj) : regions;
+    return GeneralUtils.assignTo(new RenderStatusResults(), object, mapping);
   }
 
   /** @return {boolean} */
@@ -36,7 +39,8 @@ class RenderStatusResults {
       this._error === undefined &&
       this._os === undefined &&
       this._userAgent === undefined &&
-      this._deviceSize === undefined
+      this._deviceSize === undefined &&
+      this._selectorRegions === undefined
     );
   }
 
@@ -110,6 +114,16 @@ class RenderStatusResults {
     this._deviceSize = value;
   }
 
+  /** @return {Region[]} */
+  getSelectorRegions() {
+    return this._selectorRegions;
+  }
+
+  /** @param {Region[]} value */
+  setSelectorRegions(value) {
+    this._selectorRegions = value;
+  }
+
   /** @override */
   toJSON() {
     return GeneralUtils.toPlain(this);
@@ -119,6 +133,15 @@ class RenderStatusResults {
   toString() {
     return `RenderStatusResults { ${JSON.stringify(this)} }`;
   }
+}
+
+function regionFromRGridObj({x, y, width, height}) {
+  return Region.fromObject({
+    left: x,
+    top: y,
+    width,
+    height
+  });
 }
 
 exports.RenderStatusResults = RenderStatusResults;

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -20,7 +20,7 @@ describe('RenderRequest', () => {
     });
 
     it("fills values", () => {
-      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks');
+      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
       assert.equal(renderRequest.getWebhook(), 'webhook');
       assert.equal(renderRequest.getUrl(), 'url');
       assert.equal(renderRequest.getDom(), 'dom');
@@ -28,6 +28,7 @@ describe('RenderRequest', () => {
       assert.equal(renderRequest.getPlatform(), 'platform');
       assert.equal(renderRequest.getBrowserName(), 'browserName');
       assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
+      assert.equal(renderRequest.getSelectorsToFindRegionsFor(), 'selectorsToFindRegionsFor');
     });
   });
 
@@ -57,7 +58,7 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -72,6 +73,7 @@ describe('RenderRequest', () => {
           platform: 'platform',
         },
         scriptHooks: 'scriptHooks',
+        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor'
       }
       assert.deepEqual(renderRequest.toJSON(), expected);
     });
@@ -112,8 +114,8 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks');
-      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks"} }');
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
+      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor"} }');
     });
   })
 });

--- a/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
+++ b/eyes.sdk.core/test/unit/RenderStatusResults.spec.js
@@ -14,6 +14,7 @@ describe('RenderStatusResults', () => {
     assert.equal(results.hasOwnProperty('_os'), true);
     assert.equal(results.hasOwnProperty('_userAgent'), true);
     assert.equal(results.hasOwnProperty('_deviceSize'), true);
+    assert.equal(results.hasOwnProperty('_selectorRegions'), true);
   });
 
   it('fromObject', () => {
@@ -23,15 +24,17 @@ describe('RenderStatusResults', () => {
     const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
-    const deviceSize = 'deviceSize';
-      const results = RenderStatusResults.fromObject({
+    const deviceSize = {width: 1, height: 2};
+    const selectorRegions = [{x: 1, y: 2, width: 3, height: 4}];
+    const results = RenderStatusResults.fromObject({
       status,
       error,
       imageLocation,
       domLocation,
       os,
       userAgent,
-      deviceSize
+      deviceSize,
+      selectorRegions
     });
 
     assert.equal(results.getStatus(), status);
@@ -40,7 +43,8 @@ describe('RenderStatusResults', () => {
     assert.equal(results.getDomLocation(), domLocation);
     assert.equal(results.getOS(), os);
     assert.equal(results.getUserAgent(), userAgent);
-    assert.equal(results.getDeviceSize(), deviceSize);
+    assert.deepEqual(results.getDeviceSize().toJSON(), deviceSize);
+    assert.deepEqual(results.getSelectorRegions().map(region => region.toJSON()), [{left: 1, top: 2, width: 3, height: 4, coordinatesType: 'SCREENSHOT_AS_IS'}]);
   });
 
   it('toJSON', () => {
@@ -50,7 +54,8 @@ describe('RenderStatusResults', () => {
     const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
-    const deviceSize = 'deviceSize';
+    const deviceSize = {width: 1, height: 2};
+    const selectorRegions = [{x: 1, y: 2, width: 3, height: 4}];
     const results = RenderStatusResults.fromObject({
       status,
       error,
@@ -58,10 +63,11 @@ describe('RenderStatusResults', () => {
       domLocation,
       os,
       userAgent,
-      deviceSize
+      deviceSize,
+      selectorRegions
     });
 
-    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"}');
+    assert.equal(JSON.stringify(results), '{"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":{"width":1,"height":2},"selectorRegions":[{"left":1,"top":2,"width":3,"height":4,"coordinatesType":"SCREENSHOT_AS_IS"}]}');
   });
 
   it('toString', () => {
@@ -71,7 +77,8 @@ describe('RenderStatusResults', () => {
     const domLocation = 'some dom location';
     const os = 'some os';
     const userAgent = 'some user agent';
-    const deviceSize = 'deviceSize';
+    const deviceSize = {width: 1, height: 2};
+    const selectorRegions = [{x: 1, y: 2, width: 3, height: 4}];
     const results = RenderStatusResults.fromObject({
       status,
       error,
@@ -79,9 +86,10 @@ describe('RenderStatusResults', () => {
       domLocation,
       os,
       userAgent,
-      deviceSize
+      deviceSize,
+      selectorRegions
     });
 
-    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":"deviceSize"} }');
+    assert.equal(results.toString(), 'RenderStatusResults { {"status":"some status","imageLocation":"some image location","domLocation":"some dom location","error":"some error","os":"some os","userAgent":"some user agent","deviceSize":{"width":1,"height":2},"selectorRegions":[{"left":1,"top":2,"width":3,"height":4,"coordinatesType":"SCREENSHOT_AS_IS"}]} }');
   })
 })


### PR DESCRIPTION
When taking a screenshot of a region using the visual-grid, the relative offset of the image is reported back from the visual-grid and should be uploaded as part of the `AppOutput` object on the image.

This PR adds the necessary properties to the visual-grid's API objects `RenderRequest` and `RenderStatusResults` including tests, and adds `imageLocation` as part of `AppOutput` sent in `matchWindow`.

See the visual-grid's API for `selectorsToFindRegionsFor` and `selectorRegions` here:
https://docs.google.com/document/d/1B1OtmNqJ7G7I6iedqYK3PwKC5_1ah_1uo9Kc_X8O858/edit# 