### PR TITLE
add sendDom flag to RenderRequest and separate resources from DOM

### DIFF
--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -15,7 +15,7 @@ class RenderRequest {
    * @param {string} [browserName]
    * @param {Object} [scriptHooks]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, selectorsToFindRegionsFor) {
+  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, selectorsToFindRegionsFor, sendDom) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
@@ -29,6 +29,7 @@ class RenderRequest {
     this._renderId = undefined;
     this._scriptHooks = scriptHooks;
     this._selectorsToFindRegionsFor = selectorsToFindRegionsFor;
+    this._sendDom = sendDom;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -109,6 +110,16 @@ class RenderRequest {
     this._selectorsToFindRegionsFor = value;
   }
 
+  /** @return {boolean} */
+  getSendDom() {
+    return this._sendDom;
+  }
+
+  /** @param {boolean} value */
+  setSendDom(value) {
+    this._sendDom = value;
+  }
+
   /** @override */
   toJSON() {
     const resources = {};
@@ -147,6 +158,10 @@ class RenderRequest {
 
     if (this._selectorsToFindRegionsFor) {
       object.selectorsToFindRegionsFor = this._selectorsToFindRegionsFor;
+    }
+
+    if (this._sendDom) {
+      object.sendDom = this._sendDom;
     }
 
     return object;

--- a/eyes.sdk.core/lib/renderer/RenderRequest.js
+++ b/eyes.sdk.core/lib/renderer/RenderRequest.js
@@ -15,14 +15,16 @@ class RenderRequest {
    * @param {string} [browserName]
    * @param {Object} [scriptHooks]
    */
-  constructor(webhook, url, dom, renderInfo, platform, browserName, scriptHooks, selectorsToFindRegionsFor, sendDom) {
+  constructor({webhook, url, dom, resources, renderInfo, platform, browserName, scriptHooks, selectorsToFindRegionsFor, sendDom} = {}) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook');
     ArgumentGuard.notNull(url, 'url');
     ArgumentGuard.notNull(dom, 'dom');
+    ArgumentGuard.notNull(resources, 'resources');
 
     this._webhook = webhook;
     this._url = url;
     this._dom = dom;
+    this._resources = resources;
     this._renderInfo = renderInfo;
     this._platform = platform;
     this._browserName = browserName;
@@ -53,7 +55,7 @@ class RenderRequest {
   // noinspection JSUnusedGlobalSymbols
   /** @return {RGridResource[]} */
   getResources() {
-    return this._dom.getResources();
+    return this._resources;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -123,7 +125,7 @@ class RenderRequest {
   /** @override */
   toJSON() {
     const resources = {};
-    this._dom.getResources().forEach(resource => {
+    this.getResources().forEach(resource => {
       resources[resource.getUrl()] = resource.getHashAsObject();
     });
 

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -8,35 +8,44 @@ describe('RenderRequest', () => {
   describe('constructor', () => {
     it("doesn't allow empty webhook", () => {
       assert.throws(() => new RenderRequest(), /IllegalArgument: webhook is null or empty/);
-      assert.throws(() => new RenderRequest(''), /IllegalArgument: webhook is null or empty/);
+      assert.throws(() => new RenderRequest({webhook: ''}), /IllegalArgument: webhook is null or empty/);
     });
     
     it("doesn't allow empty url", () => {
-      assert.throws(() => new RenderRequest('webhook'), /IllegalArgument: url is null or undefined/);
+      assert.throws(() => new RenderRequest({webhook: 'webhook'}), /IllegalArgument: url is null or undefined/);
     });
 
     it("doesn't allow empty dom", () => {
-      assert.throws(() => new RenderRequest('webhook', 'url'), /IllegalArgument: dom is null or undefined/);
+      assert.throws(() => new RenderRequest({webhook: 'webhook', url: 'url'}), /IllegalArgument: dom is null or undefined/);
+    });
+
+    it("doesn't allow empty resources", () => {
+      assert.throws(() => new RenderRequest({webhook: 'webhook', url: 'url', dom: 'dom'}), /IllegalArgument: resources is null or undefined/);
     });
 
     it("fills values", () => {
-      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
+      const renderRequest = new RenderRequest({
+        webhook: 'webhook',
+        url: 'url',
+        dom: 'dom',
+        resources: 'resources',
+        renderInfo: 'renderInfo',
+        platform: 'platform',
+        browserName: 'browserName',
+        scriptHooks: 'scriptHooks',
+        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
+        sendDom: 'sendDom'
+      });
       assert.equal(renderRequest.getWebhook(), 'webhook');
       assert.equal(renderRequest.getUrl(), 'url');
       assert.equal(renderRequest.getDom(), 'dom');
+      assert.equal(renderRequest.getResources(), 'resources');
       assert.equal(renderRequest.getRenderInfo(), 'renderInfo');
       assert.equal(renderRequest.getPlatform(), 'platform');
       assert.equal(renderRequest.getBrowserName(), 'browserName');
       assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
       assert.equal(renderRequest.getSelectorsToFindRegionsFor(), 'selectorsToFindRegionsFor');
       assert.equal(renderRequest.getSendDom(), 'sendDom');
-    });
-  });
-
-  describe('getResources', () => {
-    it('returns resources from dom', () => {
-      const renderRequest = new RenderRequest('webhook', 'url', { getResources: () => 'resources' });
-      assert.equal(renderRequest.getResources(), 'resources');
     });
   });
 
@@ -51,7 +60,6 @@ describe('RenderRequest', () => {
         getHashAsObject() { return 'hashAsObject2' }
       };
       const dom = {
-        getResources() { return [resource1, resource2]; },
         getHashAsObject() { return 'dom_hashAsObject'; }
       };
 
@@ -59,7 +67,18 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
+      const renderRequest = new RenderRequest({
+        webhook: 'webhook',
+        url: 'url',
+        resources: [resource1, resource2],
+        dom,
+        renderInfo,
+        platform: 'platform',
+        browserName: 'browserName',
+        scriptHooks: 'scriptHooks',
+        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
+        sendDom: 'sendDom'
+      });
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -82,11 +101,16 @@ describe('RenderRequest', () => {
 
     it('doesn\'t include platform if there is no browserName', () => {
       const dom = {
-        getResources() { return []; },
         getHashAsObject() { return 'dom_hashAsObject'; }
       };
-
-      const renderRequest = new RenderRequest('webhook', 'url', dom, null, 'platform');
+      const renderRequest = new RenderRequest({
+        webhook: 'webhook',
+        url: 'url',
+        dom,
+        resources: [],
+        renderInfo: null,
+        platform: 'platform'
+      });
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -108,7 +132,6 @@ describe('RenderRequest', () => {
         getHashAsObject() { return 'hashAsObject2' }
       };
       const dom = {
-        getResources() { return [resource1, resource2]; },
         getHashAsObject() { return 'dom_hashAsObject'; }
       };
 
@@ -116,7 +139,18 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
+      const renderRequest = new RenderRequest({
+        webhook: 'webhook',
+        url: 'url',
+        dom,
+        resources: [resource1, resource2],
+        renderInfo,
+        platform: 'platform',
+        browserName: 'browserName',
+        scriptHooks: 'scriptHooks',
+        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
+        sendDom: 'sendDom'
+      });
       assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor","sendDom":"sendDom"} }');
     });
   })

--- a/eyes.sdk.core/test/unit/RenderRequest.spec.js
+++ b/eyes.sdk.core/test/unit/RenderRequest.spec.js
@@ -20,7 +20,7 @@ describe('RenderRequest', () => {
     });
 
     it("fills values", () => {
-      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
+      const renderRequest = new RenderRequest('webhook', 'url', 'dom', 'renderInfo', 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
       assert.equal(renderRequest.getWebhook(), 'webhook');
       assert.equal(renderRequest.getUrl(), 'url');
       assert.equal(renderRequest.getDom(), 'dom');
@@ -29,6 +29,7 @@ describe('RenderRequest', () => {
       assert.equal(renderRequest.getBrowserName(), 'browserName');
       assert.equal(renderRequest.getScriptHooks(), 'scriptHooks');
       assert.equal(renderRequest.getSelectorsToFindRegionsFor(), 'selectorsToFindRegionsFor');
+      assert.equal(renderRequest.getSendDom(), 'sendDom');
     });
   });
 
@@ -58,7 +59,7 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
       const expected = {
         webhook: 'webhook',
         url: 'url',
@@ -73,7 +74,8 @@ describe('RenderRequest', () => {
           platform: 'platform',
         },
         scriptHooks: 'scriptHooks',
-        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor'
+        selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
+        sendDom: 'sendDom'
       }
       assert.deepEqual(renderRequest.toJSON(), expected);
     });
@@ -114,8 +116,8 @@ describe('RenderRequest', () => {
         toJSON() { return 'renderInfoToJSON'; }
       };
 
-      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor');
-      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor"} }');
+      const renderRequest = new RenderRequest('webhook', 'url', dom, renderInfo, 'platform', 'browserName', 'scriptHooks', 'selectorsToFindRegionsFor', 'sendDom');
+      assert.equal(renderRequest.toString(), 'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName","platform":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor","sendDom":"sendDom"} }');
     });
   })
 });


### PR DESCRIPTION
The `sendDom` flag provides the ability to enable/disable DOM snapshot capturing in the rendering grid.

*breaking change*: changing RenderRequest arguments to a single destructured object
