### PR TITLE
Add contentType to resource in renderRequest

### DIFF
--- a/eyes.sdk.core/lib/renderer/RGridResource.js
+++ b/eyes.sdk.core/lib/renderer/RGridResource.js
@@ -75,6 +75,7 @@ class RGridResource {
     return {
       hashFormat: 'sha256',
       hash: this.getSha256Hash(),
+      contentType: this.getContentType(),
     };
   }
 


### PR DESCRIPTION
The rendering-grid needs to know the content-type of iframe resources.
This PR adds content-type to all resources. There's a bit redundancy in that only `x-applitools-cdt/html` content-type needs to be sent, but this can be done later if we find it's necessary.