### PR TITLE
Support deviceInfo, hostAppInfo, hostOSInfo

### DIFF
--- a/packages/eyes-sdk-core/lib/AppEnvironment.js
+++ b/packages/eyes-sdk-core/lib/AppEnvironment.js
@@ -14,7 +14,7 @@ class AppEnvironment {
    * @param {string} [hostingApp]
    * @param {RectangleSize} [displaySize]
    */
-  constructor({ os, hostingApp, displaySize } = {}) {
+  constructor({ os, hostingApp, displaySize, deviceInfo, osInfo, hostingAppInfo } = {}) {
     if (displaySize && !(displaySize instanceof RectangleSize)) {
       displaySize = new RectangleSize(displaySize);
     }
@@ -22,6 +22,9 @@ class AppEnvironment {
     this._os = os;
     this._hostingApp = hostingApp;
     this._displaySize = displaySize;
+    this._deviceInfo = deviceInfo;
+    this._osInfo = osInfo;
+    this._hostingAppInfo = hostingAppInfo;
 
     /** @type {string} */
     this._inferred = undefined;
@@ -113,6 +116,62 @@ class AppEnvironment {
    */
   setDisplaySize(value) {
     this._displaySize = value;
+  }
+
+  /**
+   * Gets the OS hosting the application under test or {@code null} if unknown. (not part of test signature)
+   *
+   * @return {string}
+   */
+  getOsInfo() {
+    return this._osInfo;
+  }
+
+  /**
+   * Sets the OS hosting the application under test or {@code null} if unknown. (not part of test signature)
+   *
+   * @param {string} value
+   */
+  setOsInfo(value) {
+    this._osInfo = value;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * Gets the application hosting the application under test or {@code null} if unknown. (not part of test signature)
+   *
+   * @return {string}
+   */
+  getHostingAppInfo() {
+    return this._hostingAppInfo;
+  }
+  
+  /**
+   * Sets the application hosting the application under test or {@code null} if unknown. (not part of test signature)
+   *
+   * @param {string} value
+   */
+  setHostingAppInfo(value) {
+    this._hostingAppInfo = value;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * Gets the device info (not part of test signature)
+   *
+   * @return {string}
+   */
+  getDeviceInfo() {
+    return this._deviceInfo;
+  }
+
+  /**
+   * Sets the device info (not part of test signature)
+   *
+   * @param {string} value
+   */
+  setDeviceInfo(value) {
+    this._deviceInfo = value;
   }
 
   /** @override */

--- a/packages/eyes-sdk-core/lib/EyesBase.js
+++ b/packages/eyes-sdk-core/lib/EyesBase.js
@@ -1049,6 +1049,75 @@ class EyesBase {
 
   // noinspection JSUnusedGlobalSymbols
   /**
+   * Sets the host OS name - overrides the one in the agent string.
+   *
+   * @param {string} hostOS The host OS running the AUT.
+   */
+  setHostOSInfo(hostOSInfo) {
+    this._logger.log(`Host OS Info: ${hostOSInfo}`);
+    if (hostOS) {
+      this._hostOSInfo = hostOSInfo.trim();
+    } else {
+      this._hostOSInfo = undefined;
+    }
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * @return {string} The host OS as set by the user.
+   */
+  getHostOSInfo() {
+    return this._hostOSInfo;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * Sets the host application - overrides the one in the agent string.
+   *
+   * @param {string} hostApp The application running the AUT (e.g., Chrome).
+   */
+  setHostAppInfo(hostAppInfo) {
+    this._logger.log(`Host App Info: ${hostAppInfo}`);
+    if (hostAppInfo) {
+      this._hostAppInfo = hostAppInfo.trim();
+    } else {
+      this._hostAppInfo = undefined;
+    }
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * @return {string} The application name running the AUT.
+   */
+  getHostAppInfo() {
+    return this._hostAppInfo;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * Sets the host application - overrides the one in the agent string.
+   *
+   * @param {string} hostApp The application running the AUT (e.g., Chrome).
+   */
+  setDeviceInfo(deviceInfo) {
+    this._logger.log(`Device Info: ${deviceInfo}`);
+    if (deviceInfo) {
+      this._deviceInfo = deviceInfo.trim();
+    } else {
+      this._deviceInfo = undefined;
+    }
+  }
+  
+  // noinspection JSUnusedGlobalSymbols
+  /**
+   * @return {string} The application name running the AUT.
+   */
+  getDeviceInfo() {
+    return this._deviceInfo;
+  }
+
+  // noinspection JSUnusedGlobalSymbols
+  /**
    * @deprecated Only available for backward compatibility. See {@link #setBaselineEnvName(string)}.
    * @param baselineName {string} If specified, determines the baseline to compare with and disables automatic baseline
    *   inference.
@@ -1700,6 +1769,18 @@ class EyesBase {
 
     if (this._hostApp) {
       appEnv.setHostingApp(this._hostApp);
+    }
+
+    if (this._deviceInfo) {
+      appEnv.setDeviceInfo(this._deviceInfo);
+    }
+
+    if (this._hostAppInfo) {
+      appEnv.setHostingAppInfo(this._hostAppInfo);
+    }
+
+    if (this._hostOSInfo) {
+      appEnv.setOsInfo(this._hostOSInfo);
     }
 
     const inferred = await this.getInferredEnvironment();

--- a/packages/eyes-sdk-core/lib/EyesBase.js
+++ b/packages/eyes-sdk-core/lib/EyesBase.js
@@ -151,6 +151,9 @@ class EyesBase {
     /** @type {BatchInfo} */ this._batch = undefined;
     /** @type {string} */ this._hostApp = undefined;
     /** @type {string} */ this._hostOS = undefined;
+    /** @type {string} */ this._hostAppInfo = undefined;
+    /** @type {string} */ this._hostOSInfo = undefined;
+    /** @type {string} */ this._deviceInfo = undefined;
     /** @type {string} */ this._baselineEnvName = undefined;
     /** @type {string} */ this._environmentName = undefined;
     /** @type {string} */ this._branchName = undefined;
@@ -1107,7 +1110,7 @@ class EyesBase {
       this._deviceInfo = undefined;
     }
   }
-  
+
   // noinspection JSUnusedGlobalSymbols
   /**
    * @return {string} The application name running the AUT.

--- a/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
+++ b/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
@@ -167,7 +167,7 @@ class RenderRequest {
       object.selectorsToFindRegionsFor = this._selectorsToFindRegionsFor;
     }
 
-    if (this._sendDom) {
+    if (this._sendDom !== undefined) {
       object.sendDom = this._sendDom;
     }
 


### PR DESCRIPTION
We lost this feature in Cypress and Storybook after the `visual-grid-client` updated to `eyes-sdk-core` v4.
It was added to v2.0.1 not through git :(