### PR TITLE
handle null render status result

### DIFF
--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -758,7 +758,7 @@ class ServerConnector {
     const response = await sendRequest(this, 'renderStatus', options, 3, true);
     const validStatusCodes = [HTTP_STATUS_CODES.OK];
     if (validStatusCodes.includes(response.status)) {
-      let renderStatus = Array.from(response.data).map(resultsData => new RenderStatusResults(resultsData));
+      let renderStatus = Array.from(response.data).map(resultsData => resultsData === null ? null : new RenderStatusResults(resultsData));
       if (!isBatch) {
         renderStatus = renderStatus[0]; // eslint-disable-line prefer-destructuring
       }


### PR DESCRIPTION
when the rendering grid doesn't have a job for a certain renderId yet, and gets a request for status, it returns null (since it doesn't have any info about it).
This PR aims to handle this situation