### PR TITLE
interop deepmerge beetween commonjs and esmodules

### DIFF
--- a/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
@@ -1,10 +1,11 @@
 'use strict';
 
-const merge = require('deepmerge');
+const _merge = require('deepmerge');
 const dateFormat = require('dateformat');
 
 const { TypeUtils } = require('./TypeUtils');
 
+const merge = _merge.default ? _merge.default : _merge;
 const DATE_FORMAT_ISO8601 = "yyyy-mm-dd'T'HH:MM:ss'Z'";
 const DATE_FORMAT_RFC1123 = "ddd, dd mmm yyyy HH:MM:ss 'GMT'";
 const DATE_FORMAT_LOGFILE = 'yyyy_mm_dd_HH_MM_ss_l';


### PR DESCRIPTION
`deepmerge` returns an esmodule for browser packages, and a commonjs version for Node.  
Which means that for Node you get back a `function` while in the browser you get
```js
{
  default: function,
  __es_module: true
}
```

But since the file uses `require`, it only evaluates modules as commonjs, which means that in the browser when you call merge, you don't call the function, but an object.  
This will interop the two, if it finds the esmodule version of `deepmerge` it will set `merge` to the `default`, while otherwise to the function.