### PR TITLE
Added general util function to get property of object by path

### DIFF
--- a/packages/eyes-common/lib/utils/GeneralUtils.js
+++ b/packages/eyes-common/lib/utils/GeneralUtils.js
@@ -244,9 +244,9 @@ class GeneralUtils {
    * @param {string} properties The path of a the property (format: "KEY_1/KEY_2/.../KEY_N" ).
    */
   static getPropertyByPath(obj, path) {
-    if (!obj || !/^([a-zA-Z0-9-_.]+\/)*[a-zA-Z0-9-_.]+$/.test(path)) return;
+    if (!obj || !/^([a-zA-Z0-9-_.]+\.)*[a-zA-Z0-9-_.]+$/.test(path)) return;
     let val = obj;
-    for (let key of path.split('/')) {
+    for (let key of path.split('.')) {
       val = typeof val === 'object' ? val[key] : undefined;
       if (val === undefined) return;
     }

--- a/packages/eyes-common/lib/utils/GeneralUtils.js
+++ b/packages/eyes-common/lib/utils/GeneralUtils.js
@@ -236,6 +236,22 @@ class GeneralUtils {
     const prod = (a, ...rest) => (rest.length > 0 ? prod(prod2(a, rest.pop()), ...rest) : a);
     return prod([[]], ...arrays);
   }
+
+  /**
+   * Get property of obj with a a path string
+   *
+   * @param {object} object The input object.
+   * @param {string} properties The path of a the property (format: "KEY_1/KEY_2/.../KEY_N" ).
+   */
+  static getPropertyByPath(obj, path) {
+    if (!obj || !/^([a-zA-Z0-9-_.]+\/)*[a-zA-Z0-9-_.]+$/.test(path)) return;
+    let val = obj;
+    for (let key of path.split('/')) {
+      val = typeof val === 'object' ? val[key] : undefined;
+      if (val === undefined) return;
+    }
+    return val;
+  }
 }
 
 exports.GeneralUtils = GeneralUtils;

--- a/packages/eyes-common/test/unit/utils/GeneralUtils.spec.js
+++ b/packages/eyes-common/test/unit/utils/GeneralUtils.spec.js
@@ -110,4 +110,69 @@ describe('GeneralUtils', () => {
       ]);
     });
   });
+
+  describe('getPropertyByPath', () => {
+    it('works', async () => {
+      const obj = {one: {two: {three: 'ok'}}, another: false};
+      const result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      assert.strictEqual(result, 'ok');
+    });
+
+    it('works with 1 level', async () => {
+      const obj = {one: {two: {three: 'ok'}}, another: false};
+      const result = GeneralUtils.getPropertyByPath(obj, 'one');
+      assert.strictEqual(result, obj.one);
+    });
+
+    it('works with booleans', async () => {
+      let obj = {one: {two: {three: false}}, another: false};
+      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      assert.strictEqual(result, false);
+
+      obj = {one: {two: {three: true}}, another: false};
+      result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      assert.strictEqual(result, true);
+    });
+
+    it('works with numbers', async () => {
+      let obj = {one: {two: {three: 1}}, another: false};
+      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      assert.strictEqual(result, 1);
+
+      obj = {one: {two: {three: 0}}, another: false};
+      result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      assert.strictEqual(result, 0);
+    });
+
+    it('returns undefined for wrong path', async () => {
+      let obj = {one: {two: {three: false}}, another: false};
+      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/four');
+      assert.strictEqual(result, undefined);
+
+      obj = {one: {two: {three: true}}, another: false};
+      result = GeneralUtils.getPropertyByPath(obj, 'one/three');
+      assert.strictEqual(result, undefined);
+    });
+
+    it('returns undefined for bad path', async () => {
+      let obj = {one: {two: {three: false}}, another: false};
+      let result = GeneralUtils.getPropertyByPath(obj, 'one/two//three');
+      assert.strictEqual(result, undefined);
+
+      obj = {one: {two: {three: true}}, another: false};
+      result = GeneralUtils.getPropertyByPath(obj, 'one/three/');
+      assert.strictEqual(result, undefined);
+    });
+
+    it('returns undefined for bad obj', async () => {
+      let result = GeneralUtils.getPropertyByPath(null, 'one/two//three');
+      assert.strictEqual(result, undefined);
+
+      result = GeneralUtils.getPropertyByPath(undefined, 'one/three/');
+      assert.strictEqual(result, undefined);
+
+      result = GeneralUtils.getPropertyByPath(3, 'one/three/');
+      assert.strictEqual(result, undefined);
+    });
+  });
 });

--- a/packages/eyes-common/test/unit/utils/GeneralUtils.spec.js
+++ b/packages/eyes-common/test/unit/utils/GeneralUtils.spec.js
@@ -114,7 +114,7 @@ describe('GeneralUtils', () => {
   describe('getPropertyByPath', () => {
     it('works', async () => {
       const obj = {one: {two: {three: 'ok'}}, another: false};
-      const result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      const result = GeneralUtils.getPropertyByPath(obj, 'one.two.three');
       assert.strictEqual(result, 'ok');
     });
 
@@ -126,52 +126,52 @@ describe('GeneralUtils', () => {
 
     it('works with booleans', async () => {
       let obj = {one: {two: {three: false}}, another: false};
-      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      let result = GeneralUtils.getPropertyByPath(obj, 'one.two.three');
       assert.strictEqual(result, false);
 
       obj = {one: {two: {three: true}}, another: false};
-      result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      result = GeneralUtils.getPropertyByPath(obj, 'one.two.three');
       assert.strictEqual(result, true);
     });
 
     it('works with numbers', async () => {
       let obj = {one: {two: {three: 1}}, another: false};
-      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      let result = GeneralUtils.getPropertyByPath(obj, 'one.two.three');
       assert.strictEqual(result, 1);
 
       obj = {one: {two: {three: 0}}, another: false};
-      result = GeneralUtils.getPropertyByPath(obj, 'one/two/three');
+      result = GeneralUtils.getPropertyByPath(obj, 'one.two.three');
       assert.strictEqual(result, 0);
     });
 
     it('returns undefined for wrong path', async () => {
       let obj = {one: {two: {three: false}}, another: false};
-      let result = GeneralUtils.getPropertyByPath(obj, 'one/two/four');
+      let result = GeneralUtils.getPropertyByPath(obj, 'one.two.four');
       assert.strictEqual(result, undefined);
 
       obj = {one: {two: {three: true}}, another: false};
-      result = GeneralUtils.getPropertyByPath(obj, 'one/three');
+      result = GeneralUtils.getPropertyByPath(obj, 'one.three');
       assert.strictEqual(result, undefined);
     });
 
     it('returns undefined for bad path', async () => {
       let obj = {one: {two: {three: false}}, another: false};
-      let result = GeneralUtils.getPropertyByPath(obj, 'one/two//three');
+      let result = GeneralUtils.getPropertyByPath(obj, 'one.two..three');
       assert.strictEqual(result, undefined);
 
       obj = {one: {two: {three: true}}, another: false};
-      result = GeneralUtils.getPropertyByPath(obj, 'one/three/');
+      result = GeneralUtils.getPropertyByPath(obj, 'one.three.');
       assert.strictEqual(result, undefined);
     });
 
     it('returns undefined for bad obj', async () => {
-      let result = GeneralUtils.getPropertyByPath(null, 'one/two//three');
+      let result = GeneralUtils.getPropertyByPath(null, 'one.two..three');
       assert.strictEqual(result, undefined);
 
-      result = GeneralUtils.getPropertyByPath(undefined, 'one/three/');
+      result = GeneralUtils.getPropertyByPath(undefined, 'one.three.');
       assert.strictEqual(result, undefined);
 
-      result = GeneralUtils.getPropertyByPath(3, 'one/three/');
+      result = GeneralUtils.getPropertyByPath(3, 'one.three.');
       assert.strictEqual(result, undefined);
     });
   });


### PR DESCRIPTION
for doing :
getPropertyByPath(obj, "user.name.email") // return undefined or value - no exceptions
* this is instead of doing: obj && obj.user && obj.user.email && obj.user.address ..