### PR TITLE
Add test coverage for EyesFactory static method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 .eslintcache
 *.swp
 *~
+yarn.lock

--- a/packages/eyes-selenium/test/unit/Eyes.spec.js
+++ b/packages/eyes-selenium/test/unit/Eyes.spec.js
@@ -18,6 +18,10 @@ describe('Eyes', function () {
     assert.ok(eyes instanceof EyesVisualGrid);
   });
 
+  it('should create an Eyes instance through fromBrowserInfo', () => {
+    assert.doesNotThrow(() => { Eyes.fromBrowserInfo(); });
+  });
+
   it('set configuration from object', async function () {
     const eyes = new Eyes(new VisualGridRunner());
     const date = new Date();


### PR DESCRIPTION
`fromBrowserInfo` is used by the Eyes extension for Selenium IDE, and there is no coverage for it.