### PR TITLE
Bump @appitools/dom-snapshot version

### DIFF
--- a/packages/eyes-selenium/package.json
+++ b/packages/eyes-selenium/package.json
@@ -36,7 +36,7 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "@applitools/dom-snapshot": "^1.4.5",
+    "@applitools/dom-snapshot": "^1.4.9",
     "@applitools/dom-utils": "^4.6.24",
     "@applitools/eyes-common": "^3.8.2",
     "@applitools/eyes-sdk-core": "^5.12.2",


### PR DESCRIPTION
Bumping `@applitools/dom-snapshot` to fix the `extractResourceUrlsFromStyleTags is not a function` error:

```sh
TypeError: extractResourceUrlsFromStyleTags is not a function
    at /Users/adierkens/Developer/design-systems/cgds/node_modules/@applitools/dom-snapshot/src/browser/makeExtractResourcesFromSvg.js:18:27
    at extractSvgResources (/Users/adierkens/Developer/design-systems/cgds/node_modules/@applitools/visual-grid-client/src/sdk/extractSvgResources.js:12:10)
    at getDependantResources (/Users/adierkens/Developer/design-systems/cgds/node_modules/@applitools/visual-grid-client/src/sdk/getAllResources.js:91:30)
    at processResource (/Users/adierkens/Developer/design-systems/cgds/node_modules/@applitools/visual-grid-client/src/sdk/getAllResources.js:78:58)
    at getOrFetchResources (/Users/adierkens/Developer/design-systems/cgds/node_modules/@applitools/visual-grid-client/src/sdk/getAllResources.js:47:52)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```


forcing the resolution of `@appitools/dom-snapshot` `1.4.9` in my `package.json` fixes the issue:

```json
"resolutions": {
    "@applitools/dom-snapshot": "1.4.9"
  }
```