### PR TITLE
Enable HTTP only corporate proxies

### DIFF
--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const axios = require('axios');
+const Axios = require('axios');
 const zlib = require('zlib');
+const tunnel = require('tunnel')
 
 const { GeneralUtils, TypeUtils, ArgumentGuard, DateTimeUtils } = require('@applitools/eyes-common');
 
@@ -12,6 +13,19 @@ const { MatchResult } = require('../match/MatchResult');
 
 const { RunningRender } = require('../renderer/RunningRender');
 const { RenderStatusResults } = require('../renderer/RenderStatusResults');
+
+const agent = tunnel.httpsOverHttp({
+  proxy: {
+      host: 'proxy.domain.net',
+      port: 8080,
+      proxyAuth: 'username:password',
+    },
+});
+
+const axios = Axios.create({
+  httpsAgent: agent,
+  proxy: false, // this is important: we must not use the corporate proxy if its a HTTP only proxy, instead we use our tunnel.
+});
 
 // Constants
 const EYES_API_PATH = '/api/sessions';


### PR DESCRIPTION
Axios doesn't support HTTP only proxies. In order to use this in HTTP only corporate environment we can add an HTTPS over HTTP tunnel to the proxy.

This is not production ready but a POC hack to show how you can enable it.

See: https://janmolak.com/node-js-axios-behind-corporate-proxies-8b17a6f31f9d