### PR TITLE
set apiUrls to step info instance in constructor

### DIFF
--- a/packages/eyes-sdk-core/lib/TestResults.js
+++ b/packages/eyes-sdk-core/lib/TestResults.js
@@ -246,6 +246,7 @@ class StepInfo {
     this._hasBaselineImage = hasBaselineImage
     this._hasCurrentImage = hasCurrentImage
     this._appUrls = appUrls
+    this._apiUrls = apiUrls
     this._renderId = renderId
   }
 

--- a/packages/eyes-sdk-core/test/unit/TestResults.spec.js
+++ b/packages/eyes-sdk-core/test/unit/TestResults.spec.js
@@ -202,10 +202,20 @@ describe('TestResults', () => {
         '"https://eyesapi.applitools.com/api/sessions/batches/123/567"},"stepsInfo":[{"name":"Partial window",' +
         '"isDifferent":false,"hasBaselineImage":true,"hasCurrentImage":true,"appUrls":{"step":' +
         '"https://eyes.applitools.com/app/test-results/123/567/steps/1?accountId=abc","stepEditor":' +
-        '"https://eyes.applitools.com/app/test-results/123/567/steps/1/edit?accountId=abc"}},{"name":"Entire window",' +
+        '"https://eyes.applitools.com/app/test-results/123/567/steps/1/edit?accountId=abc"},"apiUrls":{' +
+        '"baselineImage":"https://eyesapi.applitools.com/api/images/se~c96494e0-4010-4107-a4bf-c21e97370700",' +
+        '"currentImage":"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/1/images/checkpoint",' +
+        '"checkpointImage":"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/1/images/checkpoint",' +
+        '"checkpointImageThumbnail":"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/1/images/...",' +
+        '"diffImage":"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/1/images/diff"}},{"name":"Entire window",' +
         '"isDifferent":false,"hasBaselineImage":true,"hasCurrentImage":true,"appUrls":{"step":' +
         '"https://eyes.applitools.com/app/test-results/123/567/steps/2?accountId=abc","stepEditor":' +
-        '"https://eyes.applitools.com/app/test-results/123/567/steps/2/edit?accountId=abc"}}],"steps":2,"matches":2,' +
+        '"https://eyes.applitools.com/app/test-results/123/567/steps/2/edit?accountId=abc"},"apiUrls":{"baselineImage":' +
+        '"https://eyesapi.applitools.com/api/images/se~47d0195f-170e-4468-ae35-421903166e60","currentImage":' +
+        '"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/2/images/checkpoint","checkpointImage":' +
+        '"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/2/images/checkpoint","checkpointImageThumbnail":' +
+        '"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/2/images/...","diffImage":' +
+        '"https://eyesapi.applitools.com/api/sessions/batches/123/567/steps/2/images/diff"}}],"steps":2,"matches":2,' +
         '"mismatches":0,"missing":0,"exactMatches":0,"strictMatches":0,"contentMatches":0,"layoutMatches":0,' +
         '"noneMatches":0,"url":null,"accessibilityStatus":{"status":"Failed","level":"AA"}}',
     )

--- a/packages/visual-grid-client/test/it/testWindow.it.test.js
+++ b/packages/visual-grid-client/test/it/testWindow.it.test.js
@@ -137,6 +137,7 @@ describe('testWindow', () => {
             _hasCurrentImage: undefined,
             _isDifferent: undefined,
             _name: undefined,
+            _apiUrls: undefined,
             _renderId: '{"isGood":true,"sizeMode":"full-page"}',
           },
         ],


### PR DESCRIPTION
Fix wrong behavior of StepInfo constructor.
I have a question about should `apiUrls` be stringified when we call `toString` method?
In the current implementation, it is stringified, so I update tests as well.