### PR TITLE
Add fetch time limit

### DIFF
--- a/packages/dom-capture/src/browser/captureFrame.js
+++ b/packages/dom-capture/src/browser/captureFrame.js
@@ -18,6 +18,7 @@ async function captureFrame(
   {styleProps, rectProps, ignoredTagNames} = defaultDomProps,
   doc = document,
   addStats = false,
+  fetchTimeLimit = 30000,
 ) {
   const performance = {total: {}, prefetchCss: {}, doCaptureFrame: {}, waitForImages: {}};
   function startTime(obj) {
@@ -36,7 +37,7 @@ async function captureFrame(
   const separator = '-----';
 
   startTime(performance.prefetchCss);
-  const prefetchAllCss = makePrefetchAllCss(makeFetchCss(fetch));
+  const prefetchAllCss = makePrefetchAllCss(makeFetchCss(fetch, {fetchTimeLimit}));
   const getCssFromCache = await prefetchAllCss(doc);
   endTime(performance.prefetchCss);
 

--- a/packages/dom-capture/src/browser/fetchCss.js
+++ b/packages/dom-capture/src/browser/fetchCss.js
@@ -16,7 +16,7 @@ function makeFetchCss(fetch, {fetchTimeLimit} = {}) {
     const result = [response];
     if (!Number.isNaN(Number(fetchTimeLimit))) {
       result.push(
-        new Promise(resolve => setTimeout(resolve, fetchTimeLimit)).then(() => controller.abort())
+        new Promise(resolve => setTimeout(resolve, fetchTimeLimit)).then(() => controller.abort()),
       );
     }
     return Promise.race(result);

--- a/packages/dom-capture/tests/captureFrame.test.js
+++ b/packages/dom-capture/tests/captureFrame.test.js
@@ -11,15 +11,17 @@ const {loadFixture} = require('./util/loadFixture');
 const {version} = require('../package.json');
 
 describe('captureFrame', () => {
-  let browser, page, baseUrl, closeTestServer, captureFrameWithMetrics, captureFrame;
+  let browser, page, baseUrl, closeTestServer, captureFrameWithMetrics, captureFrameWithFetchTimeLimit, captureFrame;
 
   before(async () => {
     browser = await puppeteer.launch();
     const testServer = await startTestServer({port: 50993});
     baseUrl = `http://localhost:${testServer.port}`;
     closeTestServer = testServer.close;
-    captureFrameWithMetrics = `(${await getCaptureDomScript()})(undefined, undefined, true)`;
-    captureFrame = `(${await getCaptureDomScript()})()`;
+    const captureDomScript = await getCaptureDomScript()
+    captureFrame = `(${captureDomScript})()`;
+    captureFrameWithMetrics = `(${captureDomScript})(undefined, undefined, true)`;
+    captureFrameWithFetchTimeLimit = `(${captureDomScript})(undefined, undefined, true, 5000)`;
   });
 
   after(async () => {
@@ -124,6 +126,30 @@ describe('captureFrame', () => {
     }
 
     const expected = loadFixture('crossOrigin.dom.json').replace(
+      'DOM_CAPTURE_SCRIPT_VERSION_TO_BE_REPLACED',
+      version,
+    );
+
+    try {
+      expect(domStr).to.eql(expected);
+    } finally {
+      await anotherTestServer.close();
+    }
+  });
+
+  it.only("don't fetch css if fetching is to long", async () => {
+    const port = 7272;
+    const anotherTestServer = await startTestServer({port, delayRecourses: 10000});
+
+    await page.goto(`http://localhost:${port}/longCss.html`);
+
+    const domStr = beautifyOutput(await page.evaluate(captureFrameWithFetchTimeLimit));
+
+    if (process.env.APPLITOOLS_UPDATE_FIXTURES) {
+      fs.writeFileSync('tests/fixtures/longCss.dom.json', domStr);
+    }
+
+    const expected = loadFixture('longCss.dom.json').replace(
       'DOM_CAPTURE_SCRIPT_VERSION_TO_BE_REPLACED',
       version,
     );

--- a/packages/dom-capture/tests/captureFrame.test.js
+++ b/packages/dom-capture/tests/captureFrame.test.js
@@ -11,14 +11,20 @@ const {loadFixture} = require('./util/loadFixture');
 const {version} = require('../package.json');
 
 describe('captureFrame', () => {
-  let browser, page, baseUrl, closeTestServer, captureFrameWithMetrics, captureFrameWithFetchTimeLimit, captureFrame;
+  let browser,
+    page,
+    baseUrl,
+    closeTestServer,
+    captureFrameWithMetrics,
+    captureFrameWithFetchTimeLimit,
+    captureFrame;
 
   before(async () => {
     browser = await puppeteer.launch();
     const testServer = await startTestServer({port: 50993});
     baseUrl = `http://localhost:${testServer.port}`;
     closeTestServer = testServer.close;
-    const captureDomScript = await getCaptureDomScript()
+    const captureDomScript = await getCaptureDomScript();
     captureFrame = `(${captureDomScript})()`;
     captureFrameWithMetrics = `(${captureDomScript})(undefined, undefined, true)`;
     captureFrameWithFetchTimeLimit = `(${captureDomScript})(undefined, undefined, true, 5000)`;
@@ -137,7 +143,7 @@ describe('captureFrame', () => {
     }
   });
 
-  it.only("don't fetch css if fetching is to long", async () => {
+  it("don't fetch css if fetching is to long", async () => {
     const port = 7272;
     const anotherTestServer = await startTestServer({port, delayRecourses: 10000});
 

--- a/packages/dom-capture/tests/fixtures/longCss.dom.json
+++ b/packages/dom-capture/tests/fixtures/longCss.dom.json
@@ -1,0 +1,107 @@
+{"separator":"-----","cssStartToken":"#####","cssEndToken":"#####","iframeStartToken":"\"@@@@@","iframeEndToken":"@@@@@\""}
+-----
+-----
+{
+  "tagName": "HTML",
+  "style": {
+    "background-repeat": "repeat",
+    "background-origin": "padding-box",
+    "background-position": "0% 0%",
+    "background-color": "rgba(0, 0, 0, 0)",
+    "background-image": "none",
+    "background-size": "auto",
+    "border-width": "0px",
+    "border-color": "rgb(0, 0, 0)",
+    "border-style": "none",
+    "color": "rgb(0, 0, 0)",
+    "display": "block",
+    "font-size": "16px",
+    "line-height": "normal",
+    "margin": "0px",
+    "opacity": "1",
+    "overflow": "visible",
+    "padding": "0px",
+    "visibility": "visible"
+  },
+  "rect": {
+    "width": 800,
+    "height": 600,
+    "top": 0,
+    "left": 0
+  },
+  "childNodes": [
+    {
+      "tagName": "BODY",
+      "style": {
+        "background-repeat": "repeat",
+        "background-origin": "padding-box",
+        "background-position": "0% 0%",
+        "background-color": "rgba(0, 0, 0, 0)",
+        "background-image": "none",
+        "background-size": "auto",
+        "border-width": "0px",
+        "border-color": "rgb(0, 0, 0)",
+        "border-style": "none",
+        "color": "rgb(0, 0, 0)",
+        "display": "block",
+        "font-size": "24px",
+        "line-height": "36px",
+        "margin": "8px",
+        "opacity": "1",
+        "overflow": "visible",
+        "padding": "0px",
+        "visibility": "visible"
+      },
+      "rect": {
+        "width": 784,
+        "height": 584,
+        "top": 8,
+        "left": 8
+      },
+      "childNodes": [
+        {
+          "tagName": "DIV",
+          "style": {
+            "background-repeat": "repeat",
+            "background-origin": "padding-box",
+            "background-position": "0% 0%",
+            "background-color": "rgba(0, 0, 0, 0)",
+            "background-image": "none",
+            "background-size": "auto",
+            "border-width": "0px",
+            "border-color": "rgb(0, 0, 255)",
+            "border-style": "none",
+            "color": "rgb(0, 0, 255)",
+            "display": "block",
+            "font-size": "24px",
+            "line-height": "36px",
+            "margin": "0px",
+            "opacity": "1",
+            "overflow": "visible",
+            "padding": "0px",
+            "visibility": "visible"
+          },
+          "rect": {
+            "width": 784,
+            "height": 36,
+            "top": 8,
+            "left": 8
+          },
+          "attributes": {
+            "class": "blue"
+          },
+          "childNodes": [
+            {
+              "tagName": "#text",
+              "text": "hi there"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "css": "\n/** http://localhost:7272/test.css **/\n@font-face {\n  font-family: 'Montaga';\n  font-style: normal;\n  font-weight: 400;\n  src: local('Montaga-Regular');\n}\n\nbody {\n  font: 400 24px/1.5 Montaga;\n}\n\n.blue {\n  color: blue;\n}\n\nimg {\n  display: block;\n}\n\n.bg-smurfs {\n  background: url('smurfs.jpg');\n  width: 151px;\n  height: 227px;\n  filter: hue-rotate(60deg);\n}",
+  "images": {},
+  "version": "1.1.0",
+  "scriptVersion": "7.1.3"
+}

--- a/packages/dom-capture/tests/fixtures/longCss.html
+++ b/packages/dom-capture/tests/fixtures/longCss.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="http://localhost:7272/test.css">
+<div class="blue">hi there</div>

--- a/packages/dom-capture/tests/util/testServer.js
+++ b/packages/dom-capture/tests/util/testServer.js
@@ -4,10 +4,10 @@ const express = require('express');
 module.exports = ({port, delayRecourses} = {port: 0}) => {
   const app = express();
   if (delayRecourses > 0) {
-    app.use((req, res, next) => {
-      if (/\.(css|jpe?g)$/.test(req.url)) setTimeout(next, delayRecourses)
-      else next()
-    })
+    app.use((req, _, next) => {
+      if (/\.(css|jpe?g)$/.test(req.url)) setTimeout(next, delayRecourses);
+      else next();
+    });
   }
   app.use('/', express.static(path.resolve(__dirname, '../fixtures')));
 

--- a/packages/dom-capture/tests/util/testServer.js
+++ b/packages/dom-capture/tests/util/testServer.js
@@ -1,8 +1,14 @@
 const path = require('path');
 const express = require('express');
 
-module.exports = ({port} = {port: 0}) => {
+module.exports = ({port, delayRecourses} = {port: 0}) => {
   const app = express();
+  if (delayRecourses > 0) {
+    app.use((req, res, next) => {
+      if (/\.(css|jpe?g)$/.test(req.url)) setTimeout(next, delayRecourses)
+      else next()
+    })
+  }
   app.use('/', express.static(path.resolve(__dirname, '../fixtures')));
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Add time-limit for fetches to the `captureFrame`. I used `AbortController` to abort the request and combinate it with `Promise.race()` in case request will not be aborted (this bug exists in Safari browser)