### PR TITLE
Fix issue with scaling on mobile browsers during FPS

### DIFF
--- a/packages/eyes-selenium/lib/EyesSelenium.js
+++ b/packages/eyes-selenium/lib/EyesSelenium.js
@@ -783,13 +783,13 @@ class EyesSelenium extends Eyes {
   async _getScaleProviderFactory() {
     const element = await this._driver.findElement(By.css('html'))
     const entireSize = await EyesSeleniumUtils.getEntireElementSize(this._jsExecutor, element)
-
+    const isMobile = await this._driver.isMobile() || await this._driver.isMobileBrowser()
     return new ContextBasedScaleProviderFactory(
       this._logger,
       entireSize,
       this._viewportSizeHandler.get(),
       this._devicePixelRatio,
-      false,
+      isMobile,
       this._scaleProviderHandler,
     )
   }

--- a/packages/eyes-selenium/lib/EyesSeleniumUtils.js
+++ b/packages/eyes-selenium/lib/EyesSeleniumUtils.js
@@ -196,6 +196,22 @@ class EyesSeleniumUtils extends EyesJsBrowserUtils {
     const browserName = capabilities.get('browserName')
     return platformName && ['ANDROID', 'IOS'].includes(platformName.toUpperCase()) && !browserName
   }
+  /**
+   * @param {IWebDriver} driver - The driver for which to check if it represents a mobile browser.
+   * @return {Promise<boolean>} {@code true} if the browser running the test is a mobile browser. {@code false} otherwise.
+   */
+  static async isMobileBrowser(driver) {
+    const userAgent = await driver.executeScript("return navigator.userAgent;")
+    return EyesSeleniumUtils.isMobileBrowserFromUserAgent(userAgent)
+  }
+
+  /**
+   * @param {string} userAgent - The user-agent string.
+   * @return {boolean} {@code true} if the browser running the test is a mobile browser. {@code false} otherwise.
+   */
+  static isMobileBrowserFromUserAgent(userAgent) {
+    return /Mobile/.test(userAgent)
+  }
 
   /**
    * @param {IWebDriver} driver - The driver for which to check the orientation.

--- a/packages/eyes-selenium/lib/wrappers/EyesWebDriver.js
+++ b/packages/eyes-selenium/lib/wrappers/EyesWebDriver.js
@@ -112,6 +112,20 @@ class EyesWebDriver extends IWebDriver {
   }
 
   /**
+   * Returns {@code true} if current WebDriver is open for mobile browser
+   *
+   * @package
+   * @return {boolean}
+   */
+  async isMobileBrowser() {
+    if (this._isMobileBrowser === undefined) {
+      this._isMobileBrowser = await EyesSeleniumUtils.isMobileBrowser(this)
+    }
+
+    return this._isMobileBrowser
+  }
+
+  /**
    * Returns {@code true} if current WebDriver is not mobile web driver (not Android and not IOS)
    *
    * @package


### PR DESCRIPTION
This PR fixes the issue founded by @Artem-applitools. The issue is happening during FPS on mobile browsers (created by chrome mobile emulator).
Since mobile browsers are using `viewport` to present a page this means that on the screenshot with width 382px can be 980px of information. To fix the issue I'm doing an additional check for User-Agent to detect mobile browsers.
I'm sure that regex can be improved and this feature can be implemented in other SDKs (it's selenium4 only for now). Do I need to invest extra time in it? Or it could be solved in a better way?

Test results to demonstrate wrong behavior: https://eyes.applitools.com/app/test-results/00000251819153792597/?accountId=UAujt6tHnEKUivQXIz7G6A~~