### PR TITLE
eyes-storybook: add viewportSize property to set puppeteer page viewport

### DIFF
--- a/packages/eyes-storybook/src/defaultConfig.js
+++ b/packages/eyes-storybook/src/defaultConfig.js
@@ -10,6 +10,7 @@ module.exports = {
   showStorybookOutput: false,
   waitBeforeScreenshot: 50,
   waitBeforeScreenshots: 50, // backward compatibility
+  viewportSize: undefined,
   tapFilePath: undefined,
   exitcode: true,
   readStoriesTimeout: 60000,

--- a/packages/eyes-storybook/src/eyesStorybook.js
+++ b/packages/eyes-storybook/src/eyesStorybook.js
@@ -127,6 +127,9 @@ async function eyesStorybook({
   async function initPage(pageId) {
     logger.log('initializing puppeteer page number ', pageId);
     const page = await browser.newPage();
+    if (config.viewportSize) {
+      await page.setViewport(config.viewportSize);
+    }
     if (config.showLogs) {
       browserLog({
         page,

--- a/packages/eyes-storybook/src/initPage.js
+++ b/packages/eyes-storybook/src/initPage.js
@@ -1,0 +1,48 @@
+const {presult} = require('@applitools/functional-commons');
+const browserLog = require('./browserLog');
+
+function makeInitPage({iframeUrl, config, browser, logger}) {
+  return async function initPage({pageId, pagePool}) {
+    logger.log('initializing puppeteer page number ', pageId);
+    const page = await browser.newPage();
+    if (config.viewportSize) {
+      await page.setViewport(config.viewportSize);
+    }
+    if (config.showLogs) {
+      browserLog({
+        page,
+        onLog: text => {
+          if (text.match(/\[dom-snapshot\]/)) {
+            logger.log(`tab ${pageId}: ${text}`);
+          }
+        },
+      });
+    }
+    page.on('error', async err => {
+      logger.log(`Puppeteer error for page ${pageId}:`, err);
+      pagePool.removePage(pageId);
+      const {pageId} = await pagePool.createPage();
+      pagePool.addToPool(pageId);
+    });
+    page.on('close', async () => {
+      if (pagePool.isInPool(pageId)) {
+        logger.log(
+          `Puppeteer page closed [page ${pageId}] while still in page pool, creating a new one instead`,
+        );
+        pagePool.removePage(pageId);
+        const {pageId} = await pagePool.createPage();
+        pagePool.addToPool(pageId);
+      }
+    });
+    const [err] = await presult(page.goto(iframeUrl, {timeout: config.readStoriesTimeout}));
+    if (err) {
+      logger.log(`error navigating to iframe.html`, err);
+      if (pagePool.isInPool(pageId)) {
+        throw err;
+      }
+    }
+    return page;
+  };
+}
+
+module.exports = makeInitPage;

--- a/packages/eyes-storybook/src/pagePool.js
+++ b/packages/eyes-storybook/src/pagePool.js
@@ -1,11 +1,11 @@
 'use strict';
 
-function createPagePool({logger, initPage}) {
+function createPagePool({initPage, logger}) {
   let counter = 0;
   const fullPageObjs = [];
   logger.log(`[page pool] created`);
   let currWaitOnFreePage = Promise.resolve();
-  return {
+  const pagePool = {
     getFreePage,
     createPage: async () => {
       const fullPageObj = await createPage();
@@ -30,6 +30,8 @@ function createPagePool({logger, initPage}) {
     },
   };
 
+  return pagePool;
+
   async function getFreePage() {
     logger.log(`[page pool] waiting for free page`);
     await currWaitOnFreePage;
@@ -53,7 +55,7 @@ function createPagePool({logger, initPage}) {
     let resolveWork;
     let isActive;
     let createdAt;
-    const page = await initPage(pageId);
+    const page = await initPage({pageId, pagePool});
     return {
       page,
       pageId,

--- a/packages/eyes-storybook/test/it/renderStories.test.js
+++ b/packages/eyes-storybook/test/it/renderStories.test.js
@@ -16,7 +16,7 @@ describe('renderStories', () => {
   it('returns empty array for 0 stories', async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => ({evaluate: async () => index + 1}),
+      initPage: async ({pageId}) => ({evaluate: async () => pageId + 1}),
     });
     const {stream, getEvents} = testStream();
     const renderStories = makeRenderStories({
@@ -35,7 +35,7 @@ describe('renderStories', () => {
   it('returns results from renderStory', async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => ({evaluate: async () => index + 1}),
+      initPage: async ({pageId}) => ({evaluate: async () => pageId + 1}),
     });
     pagePool.addToPool((await pagePool.createPage()).pageId);
     pagePool.addToPool((await pagePool.createPage()).pageId);
@@ -103,7 +103,7 @@ describe('renderStories', () => {
   it('passes waitBeforeScreenshot to getStoryData', async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => ({evaluate: async () => index + 1}),
+      initPage: async ({pageId}) => ({evaluate: async () => pageId + 1}),
     });
     pagePool.addToPool((await pagePool.createPage()).pageId);
 
@@ -145,7 +145,7 @@ describe('renderStories', () => {
   it('returns errors from getStoryData', async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => ({evaluate: async () => index + 1}),
+      initPage: async ({pageId}) => ({evaluate: async () => pageId + 1}),
     });
     pagePool.addToPool((await pagePool.createPage()).pageId);
     const getStoryData = async () => {
@@ -181,7 +181,7 @@ describe('renderStories', () => {
   it('returns errors from renderStory', async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => ({evaluate: async () => index + 1}),
+      initPage: async ({pageId}) => ({evaluate: async () => pageId + 1}),
     });
     pagePool.addToPool((await pagePool.createPage()).pageId);
     const getStoryData = async () => ({});
@@ -219,7 +219,7 @@ describe('renderStories', () => {
       try {
         const pagePool = createPagePool({
           logger,
-          initPage: async index => (index === 0 ? page : browser.newPage()),
+          initPage: async ({pageId}) => (pageId === 0 ? page : browser.newPage()),
         });
         pagePool.addToPool((await pagePool.createPage()).pageId);
         await page.close();
@@ -281,9 +281,9 @@ describe('renderStories', () => {
       try {
         const pagePool = createPagePool({
           logger,
-          initPage: async index => {
+          initPage: async ({pageId}) => {
             const page = await browser.newPage();
-            if (index === 1) {
+            if (pageId === 1) {
               await page.evaluate(() => (window.__failTest = true)); // eslint-disable-line no-undef
             }
             return page;
@@ -363,7 +363,7 @@ describe('renderStories', () => {
   it.skip("doesn't have memory issues", async () => {
     const pagePool = createPagePool({
       logger,
-      initPage: async index => index + 1,
+      initPage: async ({pageId}) => pageId + 1,
     });
     pagePool.addToPool((await pagePool.createPage()).pageId);
     const length = 1000;

--- a/packages/eyes-storybook/test/unit/initPage.test.js
+++ b/packages/eyes-storybook/test/unit/initPage.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {describe, it, before, after} = require('mocha');
+const {expect} = require('chai');
+const puppeteer = require('puppeteer');
+const makeInitPage = require('../../src/initPage');
+const logger = require('../util/testLogger');
+
+describe('init page', () => {
+  let browser;
+
+  before(async () => {
+    browser = await puppeteer.launch();
+  });
+
+  after(async () => {
+    browser.close();
+  });
+
+  it('set configurations', async () => {
+    const iframeUrl = 'about:blank';
+    const config = {
+      viewportSize: {width: 400, height: 600},
+    };
+    const initPage = makeInitPage({iframeUrl, config, browser, logger});
+
+    const page = await initPage({pageId: 0});
+
+    expect(page.viewport()).to.eql(config.viewportSize);
+    expect(page.url()).to.eql(iframeUrl);
+  });
+});

--- a/packages/eyes-storybook/test/unit/pagePool.test.js
+++ b/packages/eyes-storybook/test/unit/pagePool.test.js
@@ -9,7 +9,7 @@ const logger = require('../util/testLogger');
 // TODO (amit): unskip
 describe.skip('page pool', () => {
   it('starts with "x" free pages', async () => {
-    const initPage = async index => index;
+    const initPage = async ({pageId}) => pageId;
     const {getFreePage} = await createPagePool({logger, numOfPages: 3, initPage});
     const p1 = await getFreePage();
     expect(p1.page).to.equal(0);
@@ -23,7 +23,7 @@ describe.skip('page pool', () => {
   });
 
   it("doesn't provide a page if pool is full", async () => {
-    const initPage = async index => index;
+    const initPage = async ({pageId}) => pageId;
     const {getFreePage} = await createPagePool({logger, numOfPages: 1, initPage});
     const {markPageAsFree} = await getFreePage();
     delay(100).then(markPageAsFree);
@@ -32,7 +32,7 @@ describe.skip('page pool', () => {
   });
 
   it('returns free pages in FIFO order', async () => {
-    const initPage = async index => index;
+    const initPage = async ({pageId}) => pageId;
     const {getFreePage} = await createPagePool({logger, numOfPages: 2, initPage});
     const p1 = await getFreePage();
     expect(p1.pageId).to.equal(0);


### PR DESCRIPTION
This PR provides the logic to set the viewport size of a puppeteer page. The problem I faced is the inability to test function `initPage()`, which should apply the configuration to the page. I have a suggestion to move this function to the separate file and make it more testable. WDYT?