### PR TITLE
merge global and local capabilities before render story

### DIFF
--- a/packages/eyes-storybook/src/eyesStorybook.js
+++ b/packages/eyes-storybook/src/eyesStorybook.js
@@ -80,6 +80,7 @@ async function eyesStorybook({
 
     const getStoryData = makeGetStoryData({logger, processPageAndSerialize, waitBeforeScreenshot});
     const renderStory = makeRenderStory({
+      config,
       logger: logger.extend('renderStory'),
       testWindow,
       performance,

--- a/packages/eyes-storybook/src/renderStory.js
+++ b/packages/eyes-storybook/src/renderStory.js
@@ -2,17 +2,27 @@
 const getStoryTitle = require('./getStoryTitle');
 const deprecationWarning = require('./deprecationWarning');
 
-function makeRenderStory({logger, testWindow, performance, timeItAsync}) {
+function makeRenderStory({config, logger, testWindow, performance, timeItAsync}) {
+  const {
+    ignore: globalIgnore = [],
+    accessibility: globalAccessibility = [],
+    floating: globalFloating = [],
+    strict: globalStrict = [],
+    content: globalContent = [],
+    layout: globalLayout = [],
+  } = config;
+
   return function renderStory({story, resourceUrls, resourceContents, frames, cdt, url}) {
     const {name, kind, parameters} = story;
     const title = getStoryTitle({name, kind, parameters});
     const eyesOptions = (parameters && parameters.eyes) || {};
     const {
-      ignore,
-      accessibility,
-      floating,
-      strict,
-      layout,
+      ignore = [],
+      accessibility = [],
+      floating = [],
+      strict = [],
+      content = [],
+      layout = [],
       scriptHooks,
       sizeMode,
       target,
@@ -42,11 +52,12 @@ function makeRenderStory({logger, testWindow, performance, timeItAsync}) {
       resourceContents,
       url,
       frames,
-      ignore,
-      accessibility,
-      floating,
-      strict,
-      layout,
+      ignore: globalIgnore.concat(ignore),
+      floating: globalFloating.concat(floating),
+      layout: globalLayout.concat(layout),
+      strict: globalStrict.concat(strict),
+      content: globalContent.concat(content),
+      accessibility: globalAccessibility.concat(accessibility),
       scriptHooks,
       sizeMode,
       target,


### PR DESCRIPTION
This PR adds the possibility to specify capabilities with the global config. 

[trello] https://trello.com/c/NNko9uQr/200-storybook-add-capability-to-add-layout-strict-content-floating-regions-via-the-config?menu=filter&filter=*