### PR TITLE
Test kit: ability to filter by name with glob pattern

### DIFF
--- a/packages/sdk-test-kit/package.json
+++ b/packages/sdk-test-kit/package.json
@@ -34,15 +34,16 @@
   },
   "dependencies": {
     "chromedriver": "^80.0.0",
+    "micromatch": "^4.0.2",
     "node-fetch": "^2.6.0",
     "throat": "^5.0.0",
     "yargs": "^15.0.2"
   },
   "devDependencies": {
     "@applitools/sdk-release-kit": "0.1.0",
+    "@typescript-eslint/parser": "^2.14.0",
     "mocha": "^6.2.2",
-    "typescript": "^3.7.4",
-    "@typescript-eslint/parser": "^2.14.0"
+    "typescript": "^3.7.4"
   },
   "bin": {
     "coverage-tests": "./src/coverage-tests/cli.js"

--- a/packages/sdk-test-kit/src/coverage-tests/cli-util.js
+++ b/packages/sdk-test-kit/src/coverage-tests/cli-util.js
@@ -1,6 +1,7 @@
 const {findDifferencesBetweenCollections} = require('./common-util')
 const {makeCoverageTests} = require('./index')
 const {supportedCommands} = require('./tests')
+const {isMatch} = require('micromatch')
 
 function findUnsupportedTests(sdkImplementation) {
   const allTests = makeCoverageTests()
@@ -17,7 +18,7 @@ function findUnimplementedCommands(sdkImplementation) {
 function filterTestsByName(filter, tests) {
   if (!filter) return tests
   return tests.filter(test => {
-    return test.name.includes(filter)
+    return isMatch(test.name, filter)
   })
 }
 

--- a/packages/sdk-test-kit/test/coverage-tests/cli-util.spec.js
+++ b/packages/sdk-test-kit/test/coverage-tests/cli-util.spec.js
@@ -17,6 +17,14 @@ describe('cli-util', () => {
     it('filter tests by name', () => {
       assert.deepStrictEqual(filterTestsByName('a', [{name: 'a'}, {name: 'b'}]), [{name: 'a'}])
     })
+    it('filter tests by name - exact match', () => {
+      assert.deepStrictEqual(filterTestsByName('a', [{name: 'abc'}, {name: 'bbc'}]), [])
+    })
+    it('filter tests by name - glob wildcard', () => {
+      assert.deepStrictEqual(filterTestsByName('a*', [{name: 'abc'}, {name: 'bbc'}]), [
+        {name: 'abc'},
+      ])
+    })
     it('filter tests by mode', () => {
       assert.deepStrictEqual(
         filterTestsByMode('isBlah', [

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,15 @@
     "@applitools/eyes-common" "3.19.0"
     axios "^0.19.0"
 
+"@applitools/dom-utils@4.7.8":
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/@applitools/dom-utils/-/dom-utils-4.7.8.tgz#c9d9053bb009fe2ad2d8dc688bf4c2406a897f2c"
+  integrity sha512-jH/L4VaOcN3ZKyR+0ODxfVYQIvt2Q2pd2XC1Kir8TzDanBmKsjCf6ds21AGLtu3eCzpFHolFSkxg5pfx5B7AAA==
+  dependencies:
+    "@applitools/dom-capture" "7.1.3"
+    "@applitools/eyes-common" "3.20.1"
+    axios "^0.19.0"
+
 "@applitools/eslint-plugin-compat@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@applitools/eslint-plugin-compat/-/eslint-plugin-compat-0.7.0.tgz#61785cfb4156ddbb06141116b7fd381ecf11afea"


### PR DESCRIPTION
Currently, running the following will result in 12 executions:
```
npx coverage-tests run --fn TestCheckRegion --fm isScrollStitching
```
(It's essentially `*TestCheckRegion*`)

With this PR, it will result in 1 execution, which is the desired state (otherwise there's no way to just run TestCheckRegion except by index which is not user friendly).
