### PR TITLE
Add 'edgelegacy' and 'edgechromium' to supported browsers

### DIFF
--- a/packages/visual-grid-client/src/sdk/openEyes.js
+++ b/packages/visual-grid-client/src/sdk/openEyes.js
@@ -25,6 +25,8 @@ const SUPPORTED_BROWSERS = {
   ie10: 'ie10',
   ie11: 'ie11',
   edge: 'edge',
+  edgelegacy: 'edgelegacy',
+  edgechromium: 'edgechromium',
   ie: 'ie',
   safari: 'safari',
   [translateBrowserNameVersion('chrome-1')]: 'chrome-1',


### PR DESCRIPTION
VG supports these new names. We'd like to add it to enable testing