### PR TITLE
coverage-tests: `--all` flag

### DIFF
--- a/packages/eyes-webdriverio-4/package.json
+++ b/packages/eyes-webdriverio-4/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "mocha --no-timeouts \"test/e2e/*.js\"",
     "test:it": "mocha --no-timeouts \"test/it/**/*.js\"",
     "test:unit": "mocha \"test/unit/**/*.js\"",
-    "coverage:sandbox": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE --all && yarn test:coverage && coverage-tests process-report",
+    "coverage:sandbox": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report",
     "coverage:prod": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report --send-report prod",
     "test:coverage": "yarn start-chromedriver && env APPLITOOLS_BATCH_NAME='JS Coverage Tests: eyes-webdriverio-4' APPLITOOLS_BATCH_ID=$(uuidgen) XUNIT_FILE=coverage-test-report.xml mocha-parallel-tests --no-timeouts --reporter spec-xunit-file --max-parallel 15 test/coverage/generic/*.spec.js",
     "test:coverage:custom": "mocha --no-timeouts ./test/coverage/custom/*.js",

--- a/packages/eyes-webdriverio-4/package.json
+++ b/packages/eyes-webdriverio-4/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "mocha --no-timeouts \"test/e2e/*.js\"",
     "test:it": "mocha --no-timeouts \"test/it/**/*.js\"",
     "test:unit": "mocha \"test/unit/**/*.js\"",
-    "coverage:sandbox": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report",
+    "coverage:sandbox": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE --all && yarn test:coverage && coverage-tests process-report",
     "coverage:prod": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report --send-report prod",
     "test:coverage": "yarn start-chromedriver && env APPLITOOLS_BATCH_NAME='JS Coverage Tests: eyes-webdriverio-4' APPLITOOLS_BATCH_ID=$(uuidgen) XUNIT_FILE=coverage-test-report.xml mocha-parallel-tests --no-timeouts --reporter spec-xunit-file --max-parallel 15 test/coverage/generic/*.spec.js",
     "test:coverage:custom": "mocha --no-timeouts ./test/coverage/custom/*.js",

--- a/packages/sdk-coverage-tests/src/cli.js
+++ b/packages/sdk-coverage-tests/src/cli.js
@@ -15,6 +15,10 @@ yargs
     describe: 'path to implementation file',
     default: 'test/coverage/index.js',
   })
+  .option('all', {
+    alias: 'a',
+    describe: 'run all of the tests and ignore filtering',
+  })
   .option('filterName', {
     alias: 'fn',
     describe: 'filter which tests are run by name',

--- a/packages/sdk-coverage-tests/src/cli/cli-util.js
+++ b/packages/sdk-coverage-tests/src/cli/cli-util.js
@@ -48,12 +48,17 @@ function filterTests({tests, args}) {
   return result
 }
 
-function numberOfUniqueTests(tests) {
-  return [...new Set(tests.map(t => t.name))].length
+function numberOfUniqueTests({tests, args}) {
+  return tests.reduce((set, t) => {
+    if (args.all || !t.disabled) {
+      set.add(t.name)
+    }
+    return set
+  }, new Set()).size
 }
 
-function numberOfTestVariations(tests) {
-  return tests.filter(t => !t.disabled).length
+function numberOfTestVariations({tests, args}) {
+  return tests.filter(t => args.all || !t.disabled).length
 }
 
 function sortErrorsByType(errors) {

--- a/packages/sdk-coverage-tests/src/cli/commands/create-tests.js
+++ b/packages/sdk-coverage-tests/src/cli/commands/create-tests.js
@@ -9,12 +9,17 @@ async function createTests(args) {
   const supportedTests = filterTests({tests: sdkImplementation.supportedTests, args})
   const emittedTests = makeEmitTests(sdkImplementation.initialize).emitTests(supportedTests, {
     host: args.remote,
+    all: args.all,
   })
   await createTestFiles(emittedTests, sdkImplementation.testFrameworkTemplate)
   console.log(
-    `\nCreated ${numberOfTestVariations(supportedTests)} test files for ${numberOfUniqueTests(
-      supportedTests,
-    )} unique tests.`,
+    `\nCreated ${numberOfTestVariations({
+      tests: supportedTests,
+      args,
+    })} test files for ${numberOfUniqueTests({
+      tests: supportedTests,
+      args,
+    })} unique tests.`,
   )
 }
 

--- a/packages/sdk-coverage-tests/src/code-export/emit.js
+++ b/packages/sdk-coverage-tests/src/code-export/emit.js
@@ -15,9 +15,9 @@ function convertExecutionModeToSuffix(executionMode) {
 
 function makeEmitTests(initializeSdkImplementation, makeCoverageTests = doMakeCoverageTests) {
   let output = []
-  function emitTests(supportedTests, {branchName = 'master', host} = {}) {
+  function emitTests(supportedTests, {branchName = 'master', host, all = false} = {}) {
     supportedTests.forEach(supportedTest => {
-      if (supportedTest.disabled) return
+      if (!all && supportedTest.disabled) return
       const sdkImplementation = initializeSdkImplementation()
       const baselineTestName = `${supportedTest.name}${convertExecutionModeToSuffix(
         supportedTest.executionMode,


### PR DESCRIPTION
Here I added an `--all` for ignoring the `disabled` flag on supported tests.
I have a question in addition. Why the filtering out of disabled tests is not a part of `filterTests` function? Does it have some reason?