### PR TITLE
Shared custom coverage tests

### DIFF
--- a/packages/eyes-webdriverio-4/package.json
+++ b/packages/eyes-webdriverio-4/package.json
@@ -14,7 +14,7 @@
     "coverage:sandbox": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report",
     "coverage:prod": "coverage-tests create-tests --remote=$CVG_TEST_REMOTE && yarn test:coverage && coverage-tests process-report --send-report prod",
     "test:coverage": "yarn start-chromedriver && env APPLITOOLS_BATCH_NAME='JS Coverage Tests: eyes-webdriverio-4' APPLITOOLS_BATCH_ID=$(uuidgen) XUNIT_FILE=coverage-test-report.xml mocha-parallel-tests --no-timeouts --reporter spec-xunit-file --max-parallel 15 test/coverage/generic/*.spec.js",
-    "test:coverage:custom": "mocha --no-timeouts ./test/coverage/custom/*.js",
+    "test:coverage:custom": "mocha --no-timeouts ../sdk-coverage-tests/coverage-tests/*.js",
     "preversion": "bongo preversion && yarn coverage:prod",
     "version": "bongo version",
     "postversion": "bongo postversion",

--- a/packages/eyes-webdriverio-4/src/wrappers/WDIODriverController.js
+++ b/packages/eyes-webdriverio-4/src/wrappers/WDIODriverController.js
@@ -13,6 +13,10 @@ class WDIODriverController {
     this._driver = driver
   }
 
+  async visit(url) {
+    return this._driver.url(url)
+  }
+
   async getWindowRect(handle) {
     const [location, size] = await Promise.all([
       this.getWindowLocation(handle),

--- a/packages/eyes-webdriverio-4/src/wrappers/interface.js
+++ b/packages/eyes-webdriverio-4/src/wrappers/interface.js
@@ -1,0 +1,1 @@
+module.exports = require('./WDIODriver')

--- a/packages/eyes-webdriverio-4/test/util/getDriver.js
+++ b/packages/eyes-webdriverio-4/test/util/getDriver.js
@@ -1,0 +1,13 @@
+'use strict'
+const {remote} = require('webdriverio')
+
+async function getDriver({capabilities}) {
+  const browser = remote({
+    logLevel: 'error',
+    desiredCapabilities: capabilities,
+  })
+  await browser.init()
+  return {driver: browser}
+}
+
+module.exports = getDriver

--- a/packages/sdk-coverage-tests/coverage-tests/TestSimple.js
+++ b/packages/sdk-coverage-tests/coverage-tests/TestSimple.js
@@ -1,0 +1,35 @@
+'use strict'
+const path = require('path')
+const cwd = process.cwd()
+const {ConsoleLogHandler, Eyes, Target, StitchMode} = require(cwd)
+const getDriver = require(path.resolve(cwd, 'test/util/getDriver'))
+const EyesWrappedDriver = require(path.resolve(cwd, 'src/wrappers/interface'))
+
+describe('Coverage tests', async () => {
+  it('TestSimple', async () => {
+    const eyes = new Eyes()
+    if (process.env.APPLITOOLS_SHOW_LOGS) {
+      eyes.setLogHandler(new ConsoleLogHandler(true))
+    }
+    const configuration = eyes.getConfiguration()
+    configuration.setStitchMode(StitchMode.CSS)
+    eyes.setConfiguration(configuration)
+    const {driver} = await getDriver({
+      capabilities: {
+        browserName: 'chrome',
+        'goog:chromeOptions': {
+          args: ['--headless'],
+        },
+      },
+    })
+    const wrappedDriver = new EyesWrappedDriver(eyes.getLogger(), driver)
+    await wrappedDriver.controller.visit(
+      'https://applitools.github.io/demo/TestPages/FramesTestPage/index.html',
+    )
+    const el = await wrappedDriver.finder.findElement('#overflowing-div')
+    await eyes.open(driver, 'TestSimple', 'TestSimple', {width: 460, height: 700})
+    await eyes.check('', Target.region(el))
+    const testResults = await eyes.close()
+    console.log(testResults.getStatus(), testResults.getUrl())
+  })
+})


### PR DESCRIPTION
This is a quick and dirty demo for how we can do shared custom coverage tests.

1. The SDK needs to externalize its EyesWrappedDriver in `wrappers/interface.js` and provide a `getDriver` function in `test/util` (everything is debatable of course).

2. The controller gets another function, `visit`.

3. The actual custom tests (and its future utilities) are written in the `sdk-coverage-tests` package.