### PR TITLE
Edge screenshot retry

### DIFF
--- a/packages/eyes-webdriverio-5/package.json
+++ b/packages/eyes-webdriverio-5/package.json
@@ -35,6 +35,7 @@
     "@applitools/dom-utils": "4.7.17",
     "@applitools/eyes-sdk-core": "10.2.0",
     "@applitools/visual-grid-client": "14.1.0",
+    "@applitools/bitmap-commons": "1.0.0",
     "selenium-webdriver": "^4.0.0-alpha.5",
     "webdriverio": "^5.18.6"
   },

--- a/packages/eyes-webdriverio-5/test/coverage/custom/blank-images-edge.spec.js
+++ b/packages/eyes-webdriverio-5/test/coverage/custom/blank-images-edge.spec.js
@@ -1,0 +1,45 @@
+// re: https://trello.com/c/EQD3JUOf
+const {remote} = require('webdriverio')
+const {Eyes, Target} = require('../../..')
+
+describe('JS Coverage Tests - WDIO5', async () => {
+  let eyes
+  let browser
+
+  before(async () => {
+    const browserOptions = {
+      host: 'ondemand.saucelabs.com',
+      hostname: 'ondemand.saucelabs.com',
+      port: 80,
+      path: '/wd/hub',
+      capabilities: {
+        browserName: 'MicrosoftEdge',
+        browserVersion: '18',
+        'sauce:options': {
+          screenResolution: '1920x1080',
+          username: process.env.SAUCE_USERNAME,
+          accesskey: process.env.SAUCE_ACCESS_KEY,
+        },
+      },
+    }
+    browser = await remote(browserOptions)
+    eyes = new Eyes()
+  })
+
+  after(async () => {
+    await browser.deleteSession()
+    await eyes.abortIfNotClosed()
+  })
+
+  // NOTE (from Dave H):
+  // Blank screenshots with Edge are intermittent.
+  // This test is added as an initial starting point but it does not reliably produce the error.
+  // Marking it as skipped for now.
+  it.skip('blank-image-edge-18', async function() {
+    eyes.setMatchTimeout(0)
+    await browser.url('http://applitools-dom-capture-origin-1.surge.sh/ie.html')
+    await eyes.open(browser, this.test.parent.title, 'blank-image-edge-18')
+    await eyes.check(undefined, Target.window())
+    await eyes.close(true)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,17 @@
 # yarn lockfile v1
 
 
+"@applitools/bitmap-commons@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@applitools/bitmap-commons/-/bitmap-commons-1.0.0.tgz#3379da2a54b89b5e305e2920c9b36738b1ddaf79"
+  integrity sha512-pTjCbVjgFR0OOi3iJE3n3hU/iSYMu/y4PKZA772NgzkodhUE3yYHAOW1QfuUj01vR85/yoTCN38k95gcV3jwcQ==
+  dependencies:
+    png-async "^0.9.4"
+
 "@applitools/dom-capture@7.1.3":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-7.1.3.tgz#4348bacc1e0bea937568ccfd454ddd0bad1ad133"
   integrity sha512-mR8UhWCtE9iIos6u0J5O/zzHZsUgzI2AepQ7xqTQtxoeT4gIGsHuxlVLVJb2ixuUtteMChrsaCPVWXNz8mRRtA==
-  dependencies:
-    "@applitools/functional-commons" "^1.5.4"
-
-"@applitools/dom-capture@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-capture/-/dom-capture-7.1.5.tgz#22942ced3fad22eb32bbee1167a1fea60e5fa8b1"
-  integrity sha512-Tmq6ca308FWXkC1MQlWXaQfLBJtzWyAgC7s0cl0piZeEO5mZkJy6r0rxmdRTgZptib8BGwfRsHaeLqWVFU1fjQ==
   dependencies:
     "@applitools/functional-commons" "^1.5.4"
 
@@ -22,23 +22,6 @@
   integrity sha512-qGiYHPbMO6rp7zZKZ5idLLpesPBy9ZzYNOEzX3d6PE7grq2OV8D6V67miqG4GiQY1o5owSuG+ieIuWkGiQJSoA==
   dependencies:
     "@applitools/functional-commons" "^1.5.4"
-
-"@applitools/dom-snapshot@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-3.5.0.tgz#eaef17065693a58f12b62828d8df799a2ae040f8"
-  integrity sha512-Nm3MAEJRHExf1u/7Fbshp0tR5wOmtQ8U7OCqRuXb3YNCZl7C+1PxV4ikYpkD/reoEE4zDcD7UjTEvCXeedoIQQ==
-  dependencies:
-    "@applitools/functional-commons" "^1.5.4"
-    css-tree "^1.0.0-alpha.39"
-
-"@applitools/dom-utils@4.7.14":
-  version "4.7.14"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-utils/-/dom-utils-4.7.14.tgz#7e5507941a4cfa16f112026d92be47429e5bdf7e"
-  integrity sha512-2JGNjGxmjPdNOtsU6tS1ugtxHKU0Zob3i73RLOdyVnrcDcw0aDulEVmZl3wiifRBQU5TEw9kcv0kZrMOrvQlyw==
-  dependencies:
-    "@applitools/dom-capture" "7.1.5"
-    "@applitools/eyes-common" "3.22.1"
-    axios "^0.19.0"
 
 "@applitools/dom-utils@4.7.16":
   version "4.7.16"
@@ -66,18 +49,6 @@
     png-async "^0.9.4"
     stack-trace "^0.0.10"
 
-"@applitools/eyes-common@3.22.1":
-  version "3.22.1"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-common/-/eyes-common-3.22.1.tgz#c81c13459d5df6b16e09ab7641a0b8959a3150a2"
-  integrity sha512-z8xsLKyfMCe0WQ7Vs3UGTIpH3GhOb0w8FfdfLsrTnpoeFS7bLaZzXrBMkxc4kHKpzEu0E6GbgswYFF2agpFBHw==
-  dependencies:
-    cosmiconfig "^6.0.0"
-    dateformat "^3.0.3"
-    debug "^4.1.1"
-    deepmerge "^4.2.2"
-    png-async "^0.9.4"
-    stack-trace "^0.0.10"
-
 "@applitools/eyes-common@3.23.1":
   version "3.23.1"
   resolved "https://registry.yarnpkg.com/@applitools/eyes-common/-/eyes-common-3.23.1.tgz#70a270662964a38259ac69236019314699352ad1"
@@ -96,18 +67,6 @@
   integrity sha512-pzOCgkTQ0hCZlUFUXRw7Ul5rFjVjrEEz0zIoKyQnm5BFmuDpDe9keihaicT5KHXUk1pInMNOA2HSJ+O+WTS94A==
   dependencies:
     "@applitools/eyes-sdk-core" "7.0.0"
-
-"@applitools/eyes-sdk-core@10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes-sdk-core/-/eyes-sdk-core-10.0.0.tgz#dd947f3b37d23618e163a6e9004510748cfa8e13"
-  integrity sha512-EHEsm9fQYW2740//mjrSinVKyOw8lzNPh06Zk1ej0LfVx1dHPJEG/2heOUD7kYen0pVljIVZ8KOs+9pJognGXg==
-  dependencies:
-    "@applitools/eyes-common" "3.22.1"
-    "@applitools/isomorphic-fetch" "3.0.0"
-    axios "0.19.2"
-    chalk "3.0.0"
-    es6-promise-pool "2.5.0"
-    tunnel "0.0.6"
 
 "@applitools/eyes-sdk-core@10.1.2":
   version "10.1.2"
@@ -132,20 +91,6 @@
     chalk "3.0.0"
     es6-promise-pool "2.5.0"
     tunnel "0.0.6"
-
-"@applitools/eyes.webdriverio@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@applitools/eyes.webdriverio/-/eyes.webdriverio-2.14.0.tgz#766e15774e2e7cc73639e0ea86920ebf6dcc380d"
-  integrity sha512-zMyQ0WLAt+HATjm8ZHLHUWm0QW0cbyutJ0tejyicNcf5NGz1hbmLgh7clHB/zkyQbmNP+h7Yd65avNGwF9/rjQ==
-  dependencies:
-    "@applitools/dom-utils" "4.7.14"
-    "@applitools/eyes-sdk-core" "10.0.0"
-    "@applitools/visual-grid-client" "13.7.5"
-    css "2.2.4"
-    css-url-parser "^1.1.3"
-    is-absolute-url "^2.1.0"
-    request-promise-native "^1.0.7"
-    webdriverio "~4.14.4"
 
 "@applitools/feature-flags@2.1.1":
   version "2.1.1"
@@ -233,26 +178,6 @@
     "@applitools/http-commons" "2.3.12"
     "@applitools/isomorphic-fetch" "3.0.0"
     "@applitools/jsdom" "1.0.2"
-    he "1.2.0"
-    lodash.mapvalues "^4.6.0"
-    mime-types "^2.1.24"
-    mkdirp "^0.5.1"
-    postcss-value-parser "^4.0.2"
-    throat "^5.0.0"
-
-"@applitools/visual-grid-client@13.7.5":
-  version "13.7.5"
-  resolved "https://registry.yarnpkg.com/@applitools/visual-grid-client/-/visual-grid-client-13.7.5.tgz#a758dce7f24931fe55c82ab38f81355ebb770b58"
-  integrity sha512-ytHHHS58dfblLALRfEI+XSj/aT/E/kNHHAxs6i6tEWWg1ooZPOA9oIjgUQjyTtw4xloi9J/12oVQDmQxmbs4aw==
-  dependencies:
-    "@applitools/dom-snapshot" "3.5.0"
-    "@applitools/eyes-sdk-core" "10.0.0"
-    "@applitools/feature-flags" "2.1.1"
-    "@applitools/functional-commons" "1.5.4"
-    "@applitools/http-commons" "2.3.12"
-    "@applitools/isomorphic-fetch" "3.0.0"
-    "@applitools/jsdom" "1.0.2"
-    chalk "3.0.0"
     he "1.2.0"
     lodash.mapvalues "^4.6.0"
     mime-types "^2.1.24"


### PR DESCRIPTION
Taking screenshots on Microsoft Edge sometimes yields blank images. This adds a one-time retry when that happens.

Note that it's hard to reliably reproduce this issue. So to start, there is a placeholder test that walks through the new code path end-to-end.