### PR TITLE
update xml parsing for sdk-coverage-tests package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "packages/eyes-storybook",
       "packages/eyes-leanft",
       "packages/side-eyes",
-      "packages/sdk-shared"
+      "packages/sdk-shared",
+      "packages/ruby"
     ],
     "nohoist": [
       "**/@wdio/*",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
       "packages/eyes-storybook",
       "packages/eyes-leanft",
       "packages/side-eyes",
-      "packages/sdk-shared",
-      "packages/ruby"
+      "packages/sdk-shared"
     ],
     "nohoist": [
       "**/@wdio/*",

--- a/packages/sdk-coverage-tests/src/report/index.js
+++ b/packages/sdk-coverage-tests/src/report/index.js
@@ -20,6 +20,10 @@ function convertSdkNameToReportName(sdkName) {
       return 'python'
     case 'eyes_selenium_ruby':
       return 'ruby'
+    case 'eyes_selenium_java':
+      return 'java'
+    case 'eyes_selenium_dotnet':
+      return 'dotnet'
     default:
       throw new Error('Unsupported SDK')
   }

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -53,7 +53,11 @@ function parseJunitXmlForTests(xmlResult) {
   const jsonResult = JSON.parse(convert.xml2json(xmlResult, {compact: true, spaces: 2}))
   if (jsonResult.hasOwnProperty('testsuites')) {
     const testsuite = jsonResult.testsuites.testsuite
-    return Array.isArray(testsuite) ? testsuite.map(suite => suite.testcase) : [testsuite.testcase]
+    return Array.isArray(testsuite)
+      ? testsuite
+          .map(suite => suite.testcase)
+          .reduce((flatten, testcase) => flatten.concat(testcase))
+      : [testsuite.testcase]
   } else if (jsonResult.hasOwnProperty('testsuite')) {
     const testCase = jsonResult.testsuite.testcase
     return testCase.hasOwnProperty('_attributes') ? [testCase] : testCase


### PR DESCRIPTION
it junit report have a <testsutes> tag it was parsed to the array of the arrays instead of array of the testcases.
For the report with a structure 
```
<testsuites>
 <testsuite>
  <testcase>
  </testcase>
 </testsuite>
 <testsuite>
  <testcase>
  </testcase>
 </testsuite>
</testsuites>
```
process-report command is failed with an error "Cannot read property 'name' of undefined"
Parsing such junit reports is required for the some SDKs. 