### PR TITLE
update to xml parser

### DIFF
--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -56,7 +56,9 @@ function parseJunitXmlForTests(xmlResult) {
     return Array.isArray(testsuite)
       ? testsuite
           .map(suite => suite.testcase)
-          .reduce((flatten, testcase) => flatten.concat(testcase))
+          .reduce((flatten, testcase) => flatten.concat(testcase), [])
+      : Array.isArray(testsuite.testcase)
+      ? testsuite.testcase
       : [testsuite.testcase]
   } else if (jsonResult.hasOwnProperty('testsuite')) {
     const testCase = jsonResult.testsuite.testcase

--- a/packages/sdk-coverage-tests/test/report/fixtures/multiple-suites-multiple-tests-each.xml
+++ b/packages/sdk-coverage-tests/test/report/fixtures/multiple-suites-multiple-tests-each.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="3" failures="1" time="40.117">
+  <testsuite name="Coverage Tests" errors="0" failures="1" skipped="0" timestamp="2020-04-13T16:50:42" time="31.828" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_VG" name="Coverage Tests TestCheckWindow_VG" time="27.808">
+      <failure>DiffsFoundError: Test &apos;TestCheckWindow_VG&apos; of &apos;Eyes Selenium SDK - Classic API&apos; detected differences!. See details at: https://eyes.applitools.com/app/batches/00000251815504138512/00000251815504137477?accountId=xIpd7EWjhU6cjJzDGrMcUw~~
+    at EyesWrapper.close (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/node_modules/@applitools/eyes-sdk-core/lib/EyesBase.js:1201:19)
+    at processTicksAndRejections (internal/process/task_queues.js:94:5)
+    at /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/src/sdk/makeClose.js:50:41
+    at async Promise.all (index 0)
+    at Object.&lt;anonymous&gt; (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-selenium/test/coverage/generic/TestCheckWindow_VG.spec.js:46:5)</failure>
+    </testcase>
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+  </testsuite>
+  <testsuite name="Coverage Tests" errors="0" failures="0" skipped="0" timestamp="2020-04-13T16:50:42" time="38.052" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+  </testsuite>
+  <testsuite name="Coverage Tests" errors="0" failures="0" skipped="0" timestamp="2020-04-13T16:50:42" time="39.486" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_Scroll" name="Coverage Tests TestCheckWindow_Scroll" time="35.484">
+    </testcase>
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/packages/sdk-coverage-tests/test/report/fixtures/multiple-suites-multiple-tests-one.xml
+++ b/packages/sdk-coverage-tests/test/report/fixtures/multiple-suites-multiple-tests-one.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="3" failures="1" time="40.117">
+  <testsuite name="Coverage Tests" errors="0" failures="1" skipped="0" timestamp="2020-04-13T16:50:42" time="31.828" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_VG" name="Coverage Tests TestCheckWindow_VG" time="27.808">
+      <failure>DiffsFoundError: Test &apos;TestCheckWindow_VG&apos; of &apos;Eyes Selenium SDK - Classic API&apos; detected differences!. See details at: https://eyes.applitools.com/app/batches/00000251815504138512/00000251815504137477?accountId=xIpd7EWjhU6cjJzDGrMcUw~~
+    at EyesWrapper.close (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/node_modules/@applitools/eyes-sdk-core/lib/EyesBase.js:1201:19)
+    at processTicksAndRejections (internal/process/task_queues.js:94:5)
+    at /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/src/sdk/makeClose.js:50:41
+    at async Promise.all (index 0)
+    at Object.&lt;anonymous&gt; (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-selenium/test/coverage/generic/TestCheckWindow_VG.spec.js:46:5)</failure>
+    </testcase>
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/packages/sdk-coverage-tests/test/report/index.spec.js
+++ b/packages/sdk-coverage-tests/test/report/index.spec.js
@@ -29,6 +29,16 @@ describe('Report', () => {
       const result = parseJunitXmlForTests(xmlResult)
       assert(result[0].hasOwnProperty('_attributes'))
     })
+    it('should support multiple suites with multiple tests at every suite', () => {
+      const altXmlResult = loadFixture('multiple-suites-multiple-tests-each.xml')
+      const result = parseJunitXmlForTests(altXmlResult)
+      assert(result[0].hasOwnProperty('_attributes'))
+    })
+    it('should support multiple suites with one suite with multiple tests', () => {
+      const altXmlResult = loadFixture('multiple-suites-multiple-tests-one.xml')
+      const result = parseJunitXmlForTests(altXmlResult)
+      assert(result[0].hasOwnProperty('_attributes'))
+    })
     it('should support multiple suites with a single test', () => {
       const altXmlResult = loadFixture('multiple-suites-single-test.xml')
       const result = parseJunitXmlForTests(altXmlResult)


### PR DESCRIPTION
fixed error when there are many testcases in one testsuite inside testsuites tag. Which wasn't properly covered earlier. 
ex:
```
<testsuites>
  <testsuite>
    <testcase/>
    <testcase/>
  </testsuite>
</testsuites>
```
added testcases for the coverage-tool parser