### PR TITLE
Xml parser skipped

### DIFF
--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -3,7 +3,7 @@ const {logDebug} = require('../log')
 
 function convertJunitXmlToResultSchema({xmlResult, browser}) {
   let result = []
-  const tests = parseJunitXmlForTests(xmlResult)
+  const tests = parseJunitXmlForTests(xmlResult).filter(test => !test.skipped)
   logDebug(tests)
   tests.forEach(test => {
     const testName = parseBareTestName(test._attributes.name)

--- a/packages/sdk-coverage-tests/test/report/fixtures/single-suite-multiple-tests-with-skipped.xml
+++ b/packages/sdk-coverage-tests/test/report/fixtures/single-suite-multiple-tests-with-skipped.xml
@@ -9,4 +9,7 @@
   <testcase classname="TestCheckWindow_Fluent" name="TestCheckWindow_Fluent (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots/.applitools-70dea208-3333-4f0a-b7e8-0b1fb3e40a43/screenshot.png)" time="22.338">
   <skipped/>
   </testcase>
+  <testcase classname="coverage.generic.TestCheckOverflowingRegionByCoordinates_Fluent_Scroll" file="coverage/generic/TestCheckOverflowingRegionByCoordinates_Fluent_Scroll.py" line="18" name="test_TestCheckOverflowingRegionByCoordinates_Fluent_Scroll" time="0.005">
+    <skipped message="generated" type="pytest.skip">coverage/generic/TestCheckOverflowingRegionByCoordinates_Fluent_Scroll.py:19: generated</skipped>
+  </testcase>
 </testsuite>

--- a/packages/sdk-coverage-tests/test/report/fixtures/single-suite-multiple-tests-with-skipped.xml
+++ b/packages/sdk-coverage-tests/test/report/fixtures/single-suite-multiple-tests-with-skipped.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite name="TestCafe Tests: Chrome 81.0.4044.113 / macOS 10.15.4" tests="4" failures="0" skipped="0" errors="0" time="143.544" timestamp="Tue, 21 Apr 2020 12:11:41 GMT" >
+  <testcase classname="TestCheckPageWithHeader_Window_Fully_Scroll" name="TestCheckPageWithHeader_Window_Fully_Scroll (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots)" time="48.94">
+  </testcase>
+  <testcase classname="TestCheckPageWithHeader_Window_Fully" name="TestCheckPageWithHeader_Window_Fully (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots)" time="48.117">
+  </testcase>
+  <testcase classname="TestCheckWindow_Fluent_Scroll" name="TestCheckWindow_Fluent_Scroll (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots/.applitools-d78b8a0c-95d0-4820-a5f0-b86b464d22cd/screenshot.png)" time="24.101">
+  </testcase>
+  <testcase classname="TestCheckWindow_Fluent" name="TestCheckWindow_Fluent (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots/.applitools-70dea208-3333-4f0a-b7e8-0b1fb3e40a43/screenshot.png)" time="22.338">
+  <skipped/>
+  </testcase>
+</testsuite>

--- a/packages/sdk-coverage-tests/test/report/fixtures/single-suite-skipped-test.xml
+++ b/packages/sdk-coverage-tests/test/report/fixtures/single-suite-skipped-test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite name="TestCafe Tests: Chrome 81.0.4044.113 / macOS 10.15.4" tests="1" failures="0" skipped="0" errors="0" time="23.818" timestamp="Mon, 20 Apr 2020 17:46:36 GMT" >
+  <testcase classname="TestCheckWindow_Fluent" name="TestCheckWindow_Fluent (screenshots: /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-testcafe/screenshots/.applitools-abe4123e-d970-44da-8c3c-220fb9b47640/screenshot.png)" time="23.788">
+  <skipped/>
+  </testcase>
+</testsuite>

--- a/packages/sdk-coverage-tests/test/report/index.spec.js
+++ b/packages/sdk-coverage-tests/test/report/index.spec.js
@@ -82,11 +82,13 @@ describe('Report', () => {
   })
   it(`should omit skipped testcases`, () => {
     const altXmlResult = loadFixture('single-suite-skipped-test.xml')
-    convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+    const result = convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+    assert.deepStrictEqual(result.length, 0)
   })
   it(`should omit skipped testcases with multiple testcases`, () => {
     const altXmlResult = loadFixture('single-suite-multiple-tests-with-skipped.xml')
-    convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+    const result = convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+    assert.deepStrictEqual(result.length, 3)
   })
   it('should convert xml report to QA report schema as JSON', () => {
     assert.deepStrictEqual(convertJunitXmlToResultSchema({xmlResult}), [

--- a/packages/sdk-coverage-tests/test/report/index.spec.js
+++ b/packages/sdk-coverage-tests/test/report/index.spec.js
@@ -80,6 +80,14 @@ describe('Report', () => {
     assert.deepStrictEqual(parseExecutionMode('TestCheckWindow_Scroll'), 'scroll')
     assert.deepStrictEqual(parseExecutionMode('TestCheckWindow'), 'css')
   })
+  it(`should omit skipped testcases`, () => {
+    const altXmlResult = loadFixture('single-suite-skipped-test.xml')
+    convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+  })
+  it(`should omit skipped testcases with multiple testcases`, () => {
+    const altXmlResult = loadFixture('single-suite-multiple-tests-with-skipped.xml')
+    convertJunitXmlToResultSchema({xmlResult: altXmlResult})
+  })
   it('should convert xml report to QA report schema as JSON', () => {
     assert.deepStrictEqual(convertJunitXmlToResultSchema({xmlResult}), [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,6 +215,20 @@
     xml-js "^1.6.11"
     yargs "^15.0.2"
 
+"@applitools/sdk-coverage-tests@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@applitools/sdk-coverage-tests/-/sdk-coverage-tests-1.0.0.tgz#3173aaa71d8b37378519fc65f2a16b073fcea8cb"
+  integrity sha512-Me0dpql5/N7E7XStHNnaja3iIujwGHKKc2XX36uWFqM8THKrsH3MEVRu3WuoMqskDPe8j0RG5mxnJynf/8NT/A==
+  dependencies:
+    "@applitools/sdk-shared" "0.1.0"
+    chai "^4.2.0"
+    chai-as-promised "^7.1.1"
+    chalk "3.0.0"
+    micromatch "^4.0.2"
+    node-fetch "^2.6.0"
+    xml-js "^1.6.11"
+    yargs "^15.0.2"
+
 "@applitools/visual-grid-client@14.0.1":
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/@applitools/visual-grid-client/-/visual-grid-client-14.0.1.tgz#479f37c54fc9f05eeccc28de561ad6280d458ccf"


### PR DESCRIPTION
Updated xml parser to filter tests which have property `skipped` so they weren't sent to the dashboard 
Added the tests for the new testcases
Examples of the xml with `skipped` property added to the fixtures