### PR TITLE
Use tunnel for vg resources

### DIFF
--- a/packages/eyes-sdk-core/index.js
+++ b/packages/eyes-sdk-core/index.js
@@ -199,6 +199,7 @@ exports.ScaleProviderIdentityFactory = require('./lib/scaling/ScaleProviderIdent
 exports.RenderingInfo = require('./lib/server/RenderingInfo')
 exports.RunningSession = require('./lib/server/RunningSession')
 exports.ServerConnector = require('./lib/server/ServerConnector')
+exports.getTunnelAgentFromProxy = require('./lib/server/getTunnelAgentFromProxy')
 exports.SessionStartInfo = require('./lib/server/SessionStartInfo')
 
 exports.MouseTrigger = require('./lib/triggers/MouseTrigger')

--- a/packages/eyes-sdk-core/lib/config/ProxySettings.js
+++ b/packages/eyes-sdk-core/lib/config/ProxySettings.js
@@ -10,6 +10,15 @@ const ArgumentGuard = require('../utils/ArgumentGuard')
  */
 
 /**
+ * @typedef ProxyObject
+ * @param {string} protocol
+ * @param {string} host
+ * @param {number} port
+ * @param {{username: string, password: string}} auth
+ * @param {boolean} isHttpOnly
+ */
+
+/**
  * Encapsulates settings for sending Eyes communication via proxy.
  */
 class ProxySettings {

--- a/packages/eyes-sdk-core/lib/server/getTunnelAgentFromProxy.js
+++ b/packages/eyes-sdk-core/lib/server/getTunnelAgentFromProxy.js
@@ -1,0 +1,32 @@
+'use strict'
+const tunnel = require('tunnel')
+
+// TODO proper types
+/**
+ * @typedef {import('../config/ProxySettings').ProxyObject} ProxyObject
+ */
+
+/**
+ * @param {proxyObject} proxyObject
+ * @return {Agent}
+ */
+function getTunnelAgentFromProxy(proxyObject) {
+  if (tunnel.httpsOverHttp === undefined) {
+    throw new Error('http only proxy is not supported in the browser')
+  }
+
+  const proxyAuth =
+    proxyObject.auth && proxyObject.auth.username
+      ? `${proxyObject.auth.username}:${proxyObject.auth.password}`
+      : undefined
+
+  return tunnel.httpsOverHttp({
+    proxy: {
+      host: proxyObject.host,
+      port: proxyObject.port || 8080,
+      proxyAuth,
+    },
+  })
+}
+
+module.exports = getTunnelAgentFromProxy

--- a/packages/eyes-sdk-core/lib/server/requestHelpers.js
+++ b/packages/eyes-sdk-core/lib/server/requestHelpers.js
@@ -1,4 +1,4 @@
-const tunnel = require('tunnel')
+const getTunnelAgentFromProxy = require('./getTunnelAgentFromProxy')
 
 const {GeneralUtils, DateTimeUtils, TypeUtils} = require('../..')
 
@@ -32,32 +32,15 @@ const CUSTOM_HEADER_NAMES = {
 }
 
 function configAxiosProxy({axiosConfig, proxy, logger}) {
-  if (!proxy.getIsHttpOnly()) {
-    axiosConfig.proxy = proxy.toProxyObject()
-    logger.log('using proxy', axiosConfig.proxy.host, axiosConfig.proxy.port)
-    return axiosConfig
-  }
-
-  if (tunnel.httpsOverHttp === undefined) {
-    throw new Error('http only proxy is not supported in the browser')
-  }
-
   const proxyObject = proxy.toProxyObject()
-  const proxyAuth =
-    proxyObject.auth && proxyObject.auth.username
-      ? `${proxyObject.auth.username}:${proxyObject.auth.password}`
-      : undefined
-  const agent = tunnel.httpsOverHttp({
-    proxy: {
-      host: proxyObject.host,
-      port: proxyObject.port || 8080,
-      proxyAuth,
-    },
-  })
-  axiosConfig.httpsAgent = agent
-  axiosConfig.proxy = false // don't use the proxy, we use tunnel.
-
-  logger.log('proxy is set as http only, using tunnel', proxyObject.host, proxyObject.port)
+  if (proxy.getIsHttpOnly()) {
+    axiosConfig.httpsAgent = getTunnelAgentFromProxy(proxyObject)
+    axiosConfig.proxy = false // don't use the proxy, we use tunnel.
+    logger.log('proxy is set as http only, using tunnel', proxyObject.host, proxyObject.port)
+  } else {
+    axiosConfig.proxy = proxyObject
+    logger.log('using proxy', axiosConfig.proxy.host, axiosConfig.proxy.port)
+  }
 }
 
 function configureAxios({axiosConfig, configuration, agentId, logger}) {

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -1,7 +1,5 @@
 'use strict'
 
-// Region must come from sdk-core o.w when initailizing Region with
-// Region we fail on not being an instance of Region.
 const {Region} = require('@applitools/eyes-sdk-core')
 const {presult} = require('@applitools/functional-commons')
 const saveData = require('../troubleshoot/saveData')
@@ -94,6 +92,7 @@ function makeCheckWindow({
       frames,
       userAgent,
       referer: url,
+      proxySettings: wrappers[0].getProxy(),
     })
 
     const noOffsetSelectors = {

--- a/packages/visual-grid-client/src/sdk/createRGridDOMAndGetResourceMapping.js
+++ b/packages/visual-grid-client/src/sdk/createRGridDOMAndGetResourceMapping.js
@@ -10,12 +10,14 @@ function makeCreateRGridDOMAndGetResourceMapping({getAllResources}) {
     frames = [],
     userAgent,
     referer,
+    proxySettings,
   }) {
     const resources = await getAllResources({
       resourceUrls,
       preResources: resourceContents,
       userAgent,
       referer,
+      proxySettings,
     })
     const allResources = Object.assign({}, resources)
 

--- a/packages/visual-grid-client/src/sdk/getAllResources.js
+++ b/packages/visual-grid-client/src/sdk/getAllResources.js
@@ -6,6 +6,7 @@ const absolutizeUrl = require('./absolutizeUrl')
 const resourceType = require('./resourceType')
 const toCacheEntry = require('./toCacheEntry')
 const extractSvgResources = require('./extractSvgResources')
+const getFetchOptions = require('./getFetchOptions')
 
 function assignContentfulResources(obj1, obj2) {
   for (const p in obj2) {
@@ -38,7 +39,7 @@ function makeGetAllResources({resourceCache, fetchResource, extractCssResources,
     return rGridResource
   }
 
-  return function getAllResources({resourceUrls, preResources, userAgent, referer}) {
+  return function getAllResources({resourceUrls, preResources, userAgent, referer, proxySettings}) {
     const handledResources = new Set()
     return getOrFetchResources(resourceUrls, preResources)
 
@@ -66,11 +67,7 @@ function makeGetAllResources({resourceCache, fetchResource, extractCssResources,
 
       await Promise.all(
         missingResourceUrls.map(url => {
-          const fetchOptions = {headers: {Referer: referer}}
-          if (!/https:\/\/fonts.googleapis.com/.test(url)) {
-            fetchOptions.headers['User-Agent'] = userAgent
-          }
-
+          const fetchOptions = getFetchOptions({url, referer, userAgent, proxySettings})
           return fetchResource(url, fetchOptions)
             .then(async resource =>
               assignContentfulResources(resources, await processResource(resource)),

--- a/packages/visual-grid-client/src/sdk/getFetchOptions.js
+++ b/packages/visual-grid-client/src/sdk/getFetchOptions.js
@@ -1,0 +1,16 @@
+'use strict'
+const {getTunnelAgentFromProxy} = require('@applitools/eyes-sdk-core')
+
+function getFetchOptions({url, referer, userAgent, proxySettings}) {
+  const fetchOptions = {headers: {Referer: referer}}
+  if (!/https:\/\/fonts.googleapis.com/.test(url)) {
+    fetchOptions.headers['User-Agent'] = userAgent
+  }
+
+  if (proxySettings && proxySettings.getIsHttpOnly()) {
+    fetchOptions.agent = getTunnelAgentFromProxy(proxySettings.toProxyObject())
+  }
+  return fetchOptions
+}
+
+module.exports = getFetchOptions

--- a/packages/visual-grid-client/test/unit/sdk/getFetchOptions.test.js
+++ b/packages/visual-grid-client/test/unit/sdk/getFetchOptions.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const {ProxySettings} = require('@applitools/eyes-sdk-core')
+const getFetchOptions = require('../../../src/sdk/getFetchOptions')
+const {expect} = require('chai')
+
+describe('getFetchOptions', () => {
+  it('adds user-agent and referer header', async () => {
+    const url = 'https://some/url'
+    const userAgent = 'bla'
+    expect(
+      getFetchOptions({
+        url,
+        userAgent,
+      }),
+    ).to.eql({
+      headers: {Referer: url, 'User-Agent': userAgent},
+    })
+  })
+
+  it("doesn't add user-agent header when fetching google fonts", async () => {
+    const url = 'https://fonts.googleapis.com/css?family=Zilla+Slab'
+    expect(
+      getFetchOptions({
+        url,
+        userAgent: 'bla',
+      }),
+    ).to.eql({
+      headers: {Referer: url},
+    })
+  })
+
+  it('adds user-agent and referer header', async () => {
+    const proxySettings = new ProxySettings('http://localhost:8888', 'user', 'pass', true)
+    const url = 'https://some/url'
+    const userAgent = 'bla'
+    expect(
+      getFetchOptions({
+        url,
+        userAgent,
+        proxySettings,
+      }).agent.constructor.name,
+    ).to.equal('TunnelingAgent')
+  })
+})

--- a/packages/visual-grid-client/test/util/FakeEyesWrapper.js
+++ b/packages/visual-grid-client/test/util/FakeEyesWrapper.js
@@ -466,6 +466,10 @@ class FakeEyesWrapper extends EventEmitter {
   getUserSetBatchId() {
     return this.batchId
   }
+
+  getProxy() {
+    return this.proxy
+  }
 }
 
 module.exports = FakeEyesWrapper


### PR DESCRIPTION
Currently we have 2 network libraries: `axios` and `node-fetch`. This is not ideal, but to change it would be risky and well thought.

In the meantime, we have an issue where the user specified a proxy with `isHttpOnly` and a tunnel was not created for `node-fetch`.

The better solution is to use https://github.com/TooTallNate/node-http-proxy-agent or https://github.com/TooTallNate/node-https-proxy-agent also when `isHttpOnly === false`, but the best solution would be to use only `axios` or `node-fetch` for everything.