### PR TITLE
Support visual locators

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- support visual locators
 
 ## 11.2.2 - 2020/7/5
 

--- a/packages/eyes-sdk-core/lib/EyesCore.js
+++ b/packages/eyes-sdk-core/lib/EyesCore.js
@@ -9,6 +9,19 @@ const TestFailedError = require('./errors/TestFailedError')
 const EyesUtils = require('./EyesUtils')
 const EyesBase = require('./EyesBase')
 const Logger = require('./logging/Logger')
+const NullCutProvider = require('./cropping/NullCutProvider')
+const EyesScreenshot = require('./capture/EyesScreenshotNew')
+const GeneralUtils = require('./utils/GeneralUtils')
+const SimplePropertyHandler = require('./handler/SimplePropertyHandler')
+const NullScaleProvider = require('./scaling/NullScaleProvider')
+const ScaleProviderIdentityFactory = require('./scaling/ScaleProviderIdentityFactory')
+const FixedScaleProviderFactory = require('./scaling/FixedScaleProviderFactory')
+const ContextBasedScaleProviderFactory = require('./scaling/ContextBasedScaleProviderFactory')
+const UserAgent = require('./useragent/UserAgent')
+const ImageProviderFactory = require('./capture/ImageProviderFactory')
+
+const UNKNOWN_DEVICE_PIXEL_RATIO = 0
+const DEFAULT_DEVICE_PIXEL_RATIO = 1
 
 /**
  * @template TDriver, TElement, TSelector
@@ -31,6 +44,45 @@ const Logger = require('./logging/Logger')
  * @template TSelector
  */
 class EyesCore extends EyesBase {
+  constructor(serverUrl, isDisabled) {
+    super(serverUrl, isDisabled)
+
+    /** @type {EyesWrappedDriver<TDriver, TElement, TSelector>} */
+    this._driver = undefined
+    /** @private @type {EyesJsExecutor<TDriver, TElement, TSelector>} */
+    this._executor = undefined
+    /** @private @type {EyesElementFinder<TDriver, TElement, TSelector>} */
+    this._finder = undefined
+    /** @private @type {EyesBrowsingContext<TDriver, TElement, TSelector>} */
+    this._context = undefined
+    /** @private @type {EyesDriverController<TDriver, TElement, TSelector>} */
+    this._controller = undefined
+    /** @private @type {boolean} */
+    this._dontGetTitle = false
+
+    /** @private @type {number} */
+    this._devicePixelRatio = UNKNOWN_DEVICE_PIXEL_RATIO
+    /** @private */
+    this._rotation = undefined
+  }
+
+  async _initCommon() {
+    this._devicePixelRatio = UNKNOWN_DEVICE_PIXEL_RATIO
+
+    const userAgentString = await this._controller.getUserAgent()
+    if (userAgentString) {
+      this._userAgent = UserAgent.parseUserAgentString(userAgentString, true)
+    }
+
+    this._imageProvider = ImageProviderFactory.getImageProvider(
+      this._logger,
+      this._driver,
+      this._rotation,
+      this,
+      this._userAgent,
+    )
+  }
+
   /* ------------ Classic API ------------ */
   /**
    * Takes a snapshot of the application under test and matches it with the expected output.
@@ -338,6 +390,134 @@ class EyesCore extends EyesBase {
 
     this._viewportSizeHandler.set(new RectangleSize(viewportSize))
   }
+
+  /**
+   * Run visual locators
+   * @param visualLocatorSettings
+   * @param {string[]} visualLocatorSettings.locatorNames
+   * @param {boolean} visualLocatorSettings.firstOnly
+   * @return {Promise<{[key: string]: import('../typings/lib/geometry/Region').RegionObject[]}>}
+   */
+  async locate(visualLocatorSettings) {
+    ArgumentGuard.notNull(visualLocatorSettings, 'visualLocatorSettings')
+    this._logger.verbose('Get locators with given names: ', visualLocatorSettings.locatorNames)
+    const screenshot = await this._getViewportScreenshot()
+    const screenshotBuffer = await screenshot.getImage().getImageBuffer()
+    const id = GeneralUtils.guid()
+    await this.getAndSaveRenderingInfo()
+    const imageUrl = await this._serverConnector.uploadScreenshot(id, screenshotBuffer)
+    const appName = this._configuration.getAppName()
+    return this._serverConnector.postLocators({
+      appName,
+      imageUrl,
+      locatorNames: visualLocatorSettings.locatorNames,
+      firstOnly: visualLocatorSettings.firstOnly,
+    })
+  }
+
+  /**
+   * Create a viewport page screenshot
+   * @return {Promise<EyesScreenshot>}
+   */
+  async _getViewportScreenshot() {
+    this._logger.verbose('Screenshot requested...')
+    const scaleProviderFactory = await this._updateScalingParams()
+
+    let screenshotImage = await this._imageProvider.getImage()
+    await this._debugScreenshotsProvider.save(screenshotImage, 'original')
+
+    const scaleProvider = scaleProviderFactory.getScaleProvider(screenshotImage.getWidth())
+    if (scaleProvider.getScaleRatio() !== 1) {
+      this._logger.verbose('scaling...')
+      screenshotImage = await screenshotImage.scale(scaleProvider.getScaleRatio())
+      await this._debugScreenshotsProvider.save(screenshotImage, 'scaled')
+    }
+
+    const cutProvider = this._cutProviderHandler.get()
+    if (!(cutProvider instanceof NullCutProvider)) {
+      this._logger.verbose('cutting...')
+      screenshotImage = await cutProvider.cut(screenshotImage)
+      await this._debugScreenshotsProvider.save(screenshotImage, 'cut')
+    }
+
+    this._logger.verbose('Building screenshot object...')
+    return EyesScreenshot.fromScreenshotType(this._logger, this, screenshotImage)
+  }
+
+  /**
+   * @private
+   * @return {Promise<ScaleProviderFactory>}
+   */
+  async _updateScalingParams() {
+    // Update the scaling params only if we haven't done so yet, and the user hasn't set anything else manually.
+    if (
+      this._devicePixelRatio !== UNKNOWN_DEVICE_PIXEL_RATIO &&
+      !(this._scaleProviderHandler.get() instanceof NullScaleProvider)
+    ) {
+      // If we already have a scale provider set, we'll just use it, and pass a mock as provider handler.
+      const nullProvider = new SimplePropertyHandler()
+      return new ScaleProviderIdentityFactory(this._scaleProviderHandler.get(), nullProvider)
+    }
+
+    this._logger.verbose('Trying to extract device pixel ratio...')
+    this._devicePixelRatio = await EyesUtils.getDevicePixelRatio(this._logger, this._driver)
+      .catch(async err => {
+        const isNative = await this._controller.isNative()
+        if (!isNative) throw err
+        const viewportSize = await this.getViewportSize()
+        return EyesUtils.getMobilePixelRatio(this._logger, this._driver, viewportSize)
+      })
+      .catch(err => {
+        this._logger.verbose('Failed to extract device pixel ratio! Using default.', err)
+        return DEFAULT_DEVICE_PIXEL_RATIO
+      })
+
+    this._logger.verbose(`Device pixel ratio: ${this._devicePixelRatio}`)
+    this._logger.verbose('Setting scale provider...')
+    const factory = await this._getScaleProviderFactory().catch(err => {
+      this._logger.verbose('Failed to set ContextBasedScaleProvider.', err)
+      this._logger.verbose('Using FixedScaleProvider instead...')
+      return new FixedScaleProviderFactory(1 / this._devicePixelRatio, this._scaleProviderHandler)
+    })
+    this._logger.verbose('Done!')
+    return factory
+  }
+
+  /**
+   * @private
+   * @return {Promise<ScaleProviderFactory>}
+   */
+  async _getScaleProviderFactory() {
+    const entireSize = await EyesUtils.getCurrentFrameContentEntireSize(
+      this._logger,
+      this._executor,
+    )
+    return new ContextBasedScaleProviderFactory(
+      this._logger,
+      entireSize,
+      this._viewportSizeHandler.get(),
+      this._devicePixelRatio,
+      false,
+      this._scaleProviderHandler,
+    )
+  }
+
+  /**
+   * @private
+   */
+  async _getAndSaveBatchInfoFromServer(batchId) {
+    ArgumentGuard.notNullOrEmpty(batchId, 'batchId')
+    return this._runner.getBatchInfoWithCache(batchId)
+  }
+
+  /**
+   * @private
+   */
+  async getAndSaveRenderingInfo() {
+    const renderingInfo = await this._runner.getRenderingInfoWithCache()
+    this._serverConnector.setRenderingInfo(renderingInfo)
+  }
+
   async getAUTSessionId() {
     if (!this._driver) {
       return undefined

--- a/packages/eyes-sdk-core/lib/EyesCore.js
+++ b/packages/eyes-sdk-core/lib/EyesCore.js
@@ -24,6 +24,10 @@ const UNKNOWN_DEVICE_PIXEL_RATIO = 0
 const DEFAULT_DEVICE_PIXEL_RATIO = 1
 
 /**
+ * @typedef {import('./geometry/Region').RegionObject} RegionObject
+ */
+
+/**
  * @template TDriver, TElement, TSelector
  * @typedef {import('./wrappers/EyesWrappedDriver')<TDriver, TElement, TSelector>} EyesWrappedDriver
  */
@@ -393,10 +397,11 @@ class EyesCore extends EyesBase {
 
   /**
    * Run visual locators
-   * @param visualLocatorSettings
-   * @param {string[]} visualLocatorSettings.locatorNames
+   * @template {string} TLocatorName
+   * @param {Object} visualLocatorSettings
+   * @param {Readonly<TLocatorName[]>} visualLocatorSettings.locatorNames
    * @param {boolean} visualLocatorSettings.firstOnly
-   * @return {Promise<{[key: string]: import('../typings/lib/geometry/Region').RegionObject[]}>}
+   * @return {Promise<{[TKey in TLocatorName]: RegionObject[]}>}
    */
   async locate(visualLocatorSettings) {
     ArgumentGuard.notNull(visualLocatorSettings, 'visualLocatorSettings')

--- a/packages/eyes-sdk-core/lib/EyesVisualGrid.js
+++ b/packages/eyes-sdk-core/lib/EyesVisualGrid.js
@@ -4,7 +4,6 @@ const BrowserType = require('./config/BrowserType')
 const Configuration = require('./config/Configuration')
 const TypeUtils = require('./utils/TypeUtils')
 const ArgumentGuard = require('./utils/ArgumentGuard')
-const RectangleSize = require('./geometry/RectangleSize')
 const TestResultsFormatter = require('./TestResultsFormatter')
 const MatchResult = require('./match/MatchResult')
 const CorsIframeHandler = require('./capture/CorsIframeHandler')
@@ -224,6 +223,8 @@ class EyesVisualGrid extends EyesCore {
     this._closeCommand = close
     this._abortCommand = abort
 
+    this._initCommon()
+
     return this._driver
   }
   /**
@@ -374,13 +375,6 @@ class EyesVisualGrid extends EyesCore {
    */
   async getInferredEnvironment() {
     return undefined
-  }
-  /**
-   * @private
-   */
-  async _getAndSaveBatchInfoFromServer(batchId) {
-    ArgumentGuard.notNullOrEmpty(batchId, 'batchId')
-    return this._runner.getBatchInfoWithCache(batchId)
   }
 }
 module.exports = EyesVisualGrid

--- a/packages/eyes-sdk-core/lib/runner/ClassicRunner.js
+++ b/packages/eyes-sdk-core/lib/runner/ClassicRunner.js
@@ -1,31 +1,7 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
 const EyesRunner = require('./EyesRunner')
 
-class ClassicRunner extends EyesRunner {
-  constructor() {
-    super()
-    this._getRenderingInfo = undefined
-  }
-
-  attachEyes(eyes, serverConnector) {
-    super.attachEyes(eyes, serverConnector)
-    if (!this._getRenderingInfo) {
-      const getRenderingInfo = serverConnector.renderInfo.bind(serverConnector)
-      this._getRenderingInfo = GeneralUtils.cachify(getRenderingInfo)
-    }
-  }
-
-  async getRenderingInfoWithCache() {
-    if (this._getRenderingInfo) {
-      return this._getRenderingInfo()
-    } else {
-      throw new Error(
-        'Eyes runner could not get rendering info since attachEyes was not called before',
-      )
-    }
-  }
-}
+class ClassicRunner extends EyesRunner {}
 
 module.exports = ClassicRunner

--- a/packages/eyes-sdk-core/lib/runner/EyesRunner.js
+++ b/packages/eyes-sdk-core/lib/runner/EyesRunner.js
@@ -18,6 +18,10 @@ class EyesRunner {
       const fetchBatchInfo = serverConnector.batchInfo.bind(serverConnector)
       this._getBatchInfo = GeneralUtils.cachify(fetchBatchInfo)
     }
+    if (!this._getRenderingInfo) {
+      const getRenderingInfo = serverConnector.renderInfo.bind(serverConnector)
+      this._getRenderingInfo = GeneralUtils.cachify(getRenderingInfo)
+    }
   }
 
   async getBatchInfoWithCache(batchId) {
@@ -25,6 +29,16 @@ class EyesRunner {
       return this._getBatchInfo(batchId)
     } else {
       throw new Error('Eyes runner could not get batch info since attachEyes was not called before')
+    }
+  }
+
+  async getRenderingInfoWithCache() {
+    if (this._getRenderingInfo) {
+      return this._getRenderingInfo()
+    } else {
+      throw new Error(
+        'Eyes runner could not get rendering info since attachEyes was not called before',
+      )
     }
   }
 

--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -748,6 +748,39 @@ class ServerConnector {
       throw new Error(`ServerConnector.getUserAgents - unexpected status (${response.statusText})`)
     }
   }
+
+  /**
+   * Visual locators
+   *
+   * @param visualLocatorData
+   * @param {string} visualLocatorData.appName
+   * @param {string} visualLocatorData.imageUrl
+   * @param {string} visualLocatorData.locatorNames
+   * @param {string} visualLocatorData.firstOnly
+   * @return {Promise<{[key: string]: import('../../typings/lib/geometry/Region').RegionObject[]}>}
+   */
+  async postLocators(visualLocatorData) {
+    ArgumentGuard.notNull(visualLocatorData, 'visualLocatorData')
+    this._logger.verbose(
+      `ServerConnector.postLocators called with ${JSON.stringify(visualLocatorData)}`,
+    )
+
+    const config = {
+      name: 'postLocators',
+      method: 'POST',
+      url: GeneralUtils.urlConcat(this._configuration.getServerUrl(), 'api/locators/locate'),
+      data: visualLocatorData,
+    }
+
+    const response = await this._axios.request(config)
+    const validStatusCodes = [HTTP_STATUS_CODES.OK]
+    if (validStatusCodes.includes(response.status)) {
+      this._logger.verbose('ServerConnector.postLocators - post succeeded', response.data)
+      return response.data
+    }
+
+    throw new Error(`ServerConnector.postLocators - unexpected status (${response.statusText})`)
+  }
 }
 
 module.exports = ServerConnector

--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -17,6 +17,10 @@ const MatchResult = require('../match/MatchResult')
 const RunningRender = require('../renderer/RunningRender')
 const RenderStatusResults = require('../renderer/RenderStatusResults')
 
+/**
+ * @typedef {import('../geometry/Region').RegionObject} RegionObject
+ */
+
 // Constants
 const EYES_API_PATH = '/api/sessions'
 const DEFAULT_TIMEOUT_MS = 300000 // ms (5 min)
@@ -757,7 +761,7 @@ class ServerConnector {
    * @param {string} visualLocatorData.imageUrl
    * @param {Readonly<TLocatorName[]>} visualLocatorData.locatorNames
    * @param {string} visualLocatorData.firstOnly
-   * @return {Promise<{[TKey in TLocatorName]: import('../../typings/lib/geometry/Region').RegionObject[]}>}
+   * @return {Promise<{[TKey in TLocatorName]: RegionObject[]}>}
    */
   async postLocators(visualLocatorData) {
     ArgumentGuard.notNull(visualLocatorData, 'visualLocatorData')

--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -751,13 +751,13 @@ class ServerConnector {
 
   /**
    * Visual locators
-   *
-   * @param visualLocatorData
+   * @template {string} TLocatorName
+   * @param {Object} visualLocatorData
    * @param {string} visualLocatorData.appName
    * @param {string} visualLocatorData.imageUrl
-   * @param {string} visualLocatorData.locatorNames
+   * @param {Readonly<TLocatorName[]>} visualLocatorData.locatorNames
    * @param {string} visualLocatorData.firstOnly
-   * @return {Promise<{[key: string]: import('../../typings/lib/geometry/Region').RegionObject[]}>}
+   * @return {Promise<{[TKey in TLocatorName]: import('../../typings/lib/geometry/Region').RegionObject[]}>}
    */
   async postLocators(visualLocatorData) {
     ArgumentGuard.notNull(visualLocatorData, 'visualLocatorData')

--- a/packages/sdk-coverage-tests/src/spec-emitter.js
+++ b/packages/sdk-coverage-tests/src/spec-emitter.js
@@ -240,6 +240,9 @@ function makeSpecEmitter(options) {
     getViewportSize() {
       return tracker.storeCommand(js`await eyes.getViewportSize()`).type('RectangleSize')
     },
+    locate(visualLocatorSettings) {
+      return tracker.storeCommand(js`await eyes.locate(${visualLocatorSettings})`)
+    },
   }
 
   const assert = {
@@ -256,7 +259,7 @@ function makeSpecEmitter(options) {
       tracker.storeCommand(js`assert.notDeepStrictEqual(${actual}, ${expected}, ${message})`)
     },
     ok(value, message) {
-      tracker.storeCommand(js`assert.value(${value}, ${message})`)
+      tracker.storeCommand(js`assert.ok(${value}, ${message})`)
     },
   }
 

--- a/packages/sdk-coverage-tests/src/supported-tests.js
+++ b/packages/sdk-coverage-tests/src/supported-tests.js
@@ -311,4 +311,6 @@ module.exports = [
   {name: 'TestWindowWithModal_Fully', executionMode: {isScrollStitching: true}},
   {name: 'TestTooBigViewportSize', executionMode: {isCssStitching: true}},
   {name: 'TestSetViewportSize', executionMode: {isCssStitching: true}},
+  {name: 'TestVisualLocators', executionMode: {isCssStitching: true}},
+  {name: 'TestVisualLocators', executionMode: {isVisualGrid: true}},
 ]

--- a/packages/sdk-coverage-tests/src/tests.js
+++ b/packages/sdk-coverage-tests/src/tests.js
@@ -427,4 +427,16 @@ module.exports = {
       .ref('actualViewportSize')
     assert.deepStrictEqual(actualViewportSize, expectedViewportSize)
   },
+  TestVisualLocators: ({driver, eyes, assert}) => {
+    driver.visit(url)
+    eyes.open({appName: 'Applitools Eyes SDK'})
+    const regionsMap = eyes
+      .locate({locatorNames: ['applitools_title']})
+      .type('Map<String, List<Region>>')
+      .ref('regionsMap')
+    eyes.close(false)
+    assert.deepStrictEqual(regionsMap, {
+      applitools_title: [{left: 2, top: 11, width: 173, height: 58}],
+    })
+  },
 }


### PR DESCRIPTION
- Add `eyes.locate` API.
- Types are provided instead of fluent API or data classes.
- Generic coverage test for classic and VG.

The tricky part was to take a viewport screenshot with `EyesVisualGrid`. For that I moved all the necessary properties and methods from `EyesClassic` to `EyesCore`.
I didn't want to take it all the way to merge the Eyes classes. That's a desired refactor, but not critical ATM. So only the minimal changes were made.

The part I was forced to do and is ugly is to call `this.getAndSaveRenderingInfo` from inside `eyes.locate`, since `EyesVisualGrid` doesn't call `serverConnector.renderInfo()` - because it does everything inside VGC. Because it's cached it's not a redundant network call.