### PR TITLE
added new customization

### DIFF
--- a/packages/sdk-coverage-tests/src/cli.js
+++ b/packages/sdk-coverage-tests/src/cli.js
@@ -49,6 +49,10 @@ yargs
     describe: 'number of parallel executions to run at once',
     default: 15,
   })
+  .option('reportId', {
+    alias: 'id',
+    describe: 'Id of the report which will be displayed at the dashboard',
+  })
   .demandCommand(1, 'You need to specify a command before moving on')
 ;(async () => {
   try {

--- a/packages/sdk-coverage-tests/src/cli/commands/process-report.js
+++ b/packages/sdk-coverage-tests/src/cli/commands/process-report.js
@@ -11,7 +11,7 @@ async function processReport(args) {
   })
   const isSandbox = args.sendReport === 'sandbox' ? true : false
   process.stdout.write(`\nSending report to QA dashboard ${isSandbox ? '(sandbox)' : ''}... `)
-  const report = createReport({sdkName, xmlResult: results, sandbox: isSandbox})
+  const report = createReport({sdkName, xmlResult: results, sandbox: isSandbox, id: args.reportId})
   logDebug(report)
   const result = await sendReport(report)
   process.stdout.write(result.isSuccessful ? 'Done!\n' : 'Failed!\n')

--- a/packages/sdk-coverage-tests/src/report/index.js
+++ b/packages/sdk-coverage-tests/src/report/index.js
@@ -29,12 +29,13 @@ function convertSdkNameToReportName(sdkName) {
   }
 }
 
-function createReport({sdkName, xmlResult, browser, group, sandbox} = {}) {
+function createReport({sdkName, xmlResult, browser, group, sandbox, id} = {}) {
   return {
     sdk: convertSdkNameToReportName(sdkName),
     group: group ? group : 'selenium',
     sandbox: sandbox !== undefined ? sandbox : true,
     results: convertJunitXmlToResultSchema({xmlResult, browser}),
+    id,
   }
 }
 

--- a/packages/sdk-coverage-tests/test/report/index.spec.js
+++ b/packages/sdk-coverage-tests/test/report/index.spec.js
@@ -118,7 +118,7 @@ describe('Report', () => {
       },
     ])
   })
-  it('should create a report payload', () => {
+  it('should create a report payload without id', () => {
     assert.deepStrictEqual(createReport({sdkName: 'eyes-selenium', xmlResult}), {
       sdk: 'js_selenium_4',
       group: 'selenium',
@@ -149,6 +149,42 @@ describe('Report', () => {
           passed: true,
         },
       ],
+      id: undefined,
+    })
+  })
+
+  it('should create a report payload with id', () => {
+    assert.deepStrictEqual(createReport({sdkName: 'eyes-selenium', id: '111111', xmlResult}), {
+      sdk: 'js_selenium_4',
+      group: 'selenium',
+      sandbox: true,
+      results: [
+        {
+          test_name: 'TestCheckWindow',
+          parameters: {
+            browser: 'chrome',
+            mode: 'visualgrid',
+          },
+          passed: false,
+        },
+        {
+          test_name: 'TestCheckWindow',
+          parameters: {
+            browser: 'chrome',
+            mode: 'css',
+          },
+          passed: true,
+        },
+        {
+          test_name: 'TestCheckWindow',
+          parameters: {
+            browser: 'chrome',
+            mode: 'scroll',
+          },
+          passed: true,
+        },
+      ],
+      id: '111111',
     })
   })
 })


### PR DESCRIPTION
New option reportId used for the request to the dashboard. (--reportId 'value' or -id 'value')
By default value is set to undefined, so after JSON.stringify() it's became empty and won't be sent to the server. Behaviour should be the same as it was before.
Feature required to make possible combine results from the generic and original testsuites from different languages.