### PR TITLE
Avoid error.getTestResults error

### DIFF
--- a/packages/eyes-sdk-core/lib/EyesClassic.js
+++ b/packages/eyes-sdk-core/lib/EyesClassic.js
@@ -798,7 +798,7 @@ class EyesClassic extends EyesCore {
           this._runner._allTestResult.push(results)
         }
         if (isErrorCaught) {
-          if (throwEx) throw results
+          if (throwEx || !results.getTestResults) throw results
           else return results.getTestResults()
         }
         return results

--- a/packages/eyes-sdk-core/lib/EyesVisualGrid.js
+++ b/packages/eyes-sdk-core/lib/EyesVisualGrid.js
@@ -344,7 +344,7 @@ class EyesVisualGrid extends EyesCore {
         }
         if (isErrorCaught) {
           const error = TypeUtils.isArray(results) ? results[0] : results
-          if (throwEx) throw error
+          if (throwEx || !error.getTestResults) throw error
           else return error.getTestResults()
         }
         return TypeUtils.isArray(results) ? results[0] : results

--- a/packages/eyes-sdk-core/test/unit/EyesClassic.spec.js
+++ b/packages/eyes-sdk-core/test/unit/EyesClassic.spec.js
@@ -38,6 +38,16 @@ describe('EyesClassic', () => {
     })
   })
 
+  describe('#close()', () => {
+    it('should throw if an internal exception happened during close(false)', async () => {
+      eyes._serverConnector.stopSession = () => Promise.reject('some error')
+      eyes.setMatchTimeout(0)
+      await eyes.open(driver, 'FakeApp', 'FakeTest')
+      await eyes.check(FakeCheckSettings.window())
+      await assertRejects(eyes.close(false), /^some error$/)
+    })
+  })
+
   describe('should work wait before viewport screenshot after setWaitBeforeScreenshots', () => {
     let checkTimestamp, networkTimestamp, duration, eyes
 


### PR DESCRIPTION
https://trello.com/c/XAmA255U
https://trello.com/c/1Bl2EaDE

Suppose this case:
```
eyes.close(false)
```
And there was an internal error. It might be due to our bug and it might be something else, but it's not a `TestFailedError`.
What should be the return value? Should the method still throw in spite of the false argument?
Ultimately if the user calls `runner.getAllTestResults` then they would get the exception inside the `TestResultContainer`, but the question is regarding the `eyes.close` itself.
I'm inclined to say that it should throw the exception. The alternative is to return a `TestResultsError` instance, which is something we already use in storybook.