### PR TITLE
Fix duplicate copies of SDK

### DIFF
--- a/packages/eyes-sdk-core/lib/geometry/Location.js
+++ b/packages/eyes-sdk-core/lib/geometry/Location.js
@@ -1,4 +1,5 @@
 const ArgumentGuard = require('../utils/ArgumentGuard')
+const TypeUtils = require('../utils/TypeUtils')
 
 /**
  * @typedef {{x: number, y: number}} LocationObject
@@ -18,7 +19,7 @@ class Location {
       return new Location({x: varArg1, y: varArg2})
     }
 
-    if (varArg1 instanceof Location) {
+    if (TypeUtils.instanceOf(varArg1, Location)) {
       return new Location({x: varArg1.getX(), y: varArg1.getY()})
     }
 
@@ -29,6 +30,10 @@ class Location {
     // TODO: remove call to Math.ceil
     this._x = Math.ceil(x)
     this._y = Math.ceil(y)
+  }
+
+  static get __Location() {
+    return true
   }
 
   /**

--- a/packages/eyes-sdk-core/lib/geometry/Region.js
+++ b/packages/eyes-sdk-core/lib/geometry/Region.js
@@ -153,7 +153,7 @@ class Region {
       })
     }
 
-    if (varArg1 instanceof Region) {
+    if (TypeUtils.instanceOf(varArg1, Region)) {
       // eslint-disable-next-line max-len
       return new Region({
         left: varArg1.getLeft(),
@@ -181,6 +181,10 @@ class Region {
       this._height = height
       this._coordinatesType = coordinatesType || CoordinatesTypes.SCREENSHOT_AS_IS
     }
+  }
+
+  static get __Region() {
+    return true
   }
 
   /**

--- a/packages/eyes-sdk-core/lib/utils/TypeUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/TypeUtils.js
@@ -213,6 +213,18 @@ function isIterator(value) {
   return Boolean(value) && isFunction(value.next)
 }
 
+/**
+ * Checks if `obj` is an instance of `constructor`
+ *
+ * @param {*} obj
+ * @param {Function} constructor
+ * @return {boolean}
+ */
+function instanceOf(obj, constructor) {
+  return obj && obj.constructor[`__${constructor.name}`]
+}
+
+
 module.exports = {
   isNull,
   isNotNull,
@@ -231,4 +243,5 @@ module.exports = {
   getOrDefault,
   isFunction,
   isIterator,
+  instanceOf,
 }

--- a/packages/eyes-sdk-core/lib/wrappers/EyesJsExecutor.js
+++ b/packages/eyes-sdk-core/lib/wrappers/EyesJsExecutor.js
@@ -1,5 +1,6 @@
 'use strict'
 const EyesWrappedElement = require('./EyesWrappedElement')
+const TypeUtils = require('../utils/TypeUtils')
 
 /**
  * @typedef {import('../logging/Logger')} Logger
@@ -79,7 +80,7 @@ class EyesJsExecutor {
       const result = await this.spec.executeScript(
         this._driver.unwrapped,
         script,
-        ...args.map(arg => (arg instanceof EyesWrappedElement ? arg.unwrapped : arg)),
+        ...args.map(arg => (TypeUtils.instanceOf(arg, EyesWrappedElement) ? arg.unwrapped : arg)),
       )
       this._logger.verbose('Done!')
       return result

--- a/packages/eyes-sdk-core/lib/wrappers/EyesWrappedElement.js
+++ b/packages/eyes-sdk-core/lib/wrappers/EyesWrappedElement.js
@@ -114,6 +114,11 @@ class EyesWrappedElement {
       this._driver = driver
     }
   }
+
+  static get __EyesWrappedElement() {
+    return true
+  }
+
   /**
    * Create partial wrapped element object from the element, this object need to be initialized before use
    * @template TDriver, TElement, TSelector

--- a/packages/eyes-selenium/package.json
+++ b/packages/eyes-selenium/package.json
@@ -53,6 +53,7 @@
     "chromedriver": "^83.0.0",
     "mocha": "^8.0.1",
     "module-alias": "^2.2.2",
+    "ncp": "^2.0.0",
     "selenium-webdriver": "^4.0.0-alpha.7",
     "selenium-webdriver-3": "npm:selenium-webdriver@^3.6.0",
     "selenium-webdriver-4": "npm:selenium-webdriver@^4.0.0-alpha.7",

--- a/packages/eyes-selenium/src/selenium3/SpecWrappedElement.js
+++ b/packages/eyes-selenium/src/selenium3/SpecWrappedElement.js
@@ -1,5 +1,5 @@
 const {TypeUtils} = require('@applitools/eyes-sdk-core')
-const {WebElement, By} = require('selenium-webdriver')
+const {By} = require('selenium-webdriver')
 
 /**
  * @typedef {import('./SpecWrappedDriver').Driver} Driver
@@ -10,7 +10,8 @@ const {WebElement, By} = require('selenium-webdriver')
  */
 
 function isCompatible(element) {
-  return element instanceof WebElement
+  const ctorName = element && element.constructor && element.constructor.name
+  return ctorName === 'WebElement'
 }
 function isSelector(selector) {
   if (!selector) return false

--- a/packages/eyes-selenium/src/selenium4/SpecWrappedElement.js
+++ b/packages/eyes-selenium/src/selenium4/SpecWrappedElement.js
@@ -1,5 +1,5 @@
 const {TypeUtils} = require('@applitools/eyes-sdk-core')
-const {WebElement, By} = require('selenium-webdriver')
+const {By} = require('selenium-webdriver')
 
 /**
  * @typedef {import('./SpecWrappedDriver').Driver} Driver
@@ -10,7 +10,8 @@ const {WebElement, By} = require('selenium-webdriver')
  */
 
 function isCompatible(element) {
-  return element instanceof WebElement
+  const ctorName = element && element.constructor && element.constructor.name
+  return ctorName === 'WebElement'
 }
 function isSelector(selector) {
   if (!selector) return false

--- a/packages/eyes-selenium/test/it/app-with-nodemodules/duplicate-driver.spec.js
+++ b/packages/eyes-selenium/test/it/app-with-nodemodules/duplicate-driver.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const {expect} = require('chai')
+const {Target} = require('../../..')
+const {
+  TestSetup: {getEyes, Browsers},
+} = require('@applitools/sdk-coverage-tests/coverage-tests')
+const ncp = require('ncp')
+const {promisify} = require('util')
+const pncp = promisify(ncp)
+const SpecWrappedElement = require('../../../src/SpecWrappedElement')
+
+describe('JS Coverage tests', () => {
+  it('works in a project with duplicate protractor', async () => {
+    // create node_modules folder inside this folder
+    const otherNodeModules = path.resolve(__dirname, 'node_modules')
+    fs.rmdirSync(otherNodeModules, {recursive: true})
+    fs.mkdirSync(otherNodeModules)
+
+    const targetSeleniumFolder = path.resolve(otherNodeModules, 'selenium-webdriver')
+
+    // copy selenium-webdriver into the new node_modules
+    await pncp(
+      path.resolve(require.resolve('selenium-webdriver'), '..'), // eslint-disable-line node/no-extraneous-require
+      targetSeleniumFolder,
+    )
+
+    // make Node take protractor from new node_modules location (I don't really know what I'm doing here, I found what to do through debugging)
+    module.constructor._pathCache = {}
+
+    // we can't use TestSetup because the driver needs to be require'd from this module
+    const driver = await buildDriver({capabilities: Browsers.chrome()})
+
+    try {
+      await driver.get('https://example.org')
+
+      // verify that the specific API that this test was written to fix is working
+      const {By: By2} = require(targetSeleniumFolder)
+      const el = await driver.findElement(By2.css('html'))
+      expect(SpecWrappedElement.isCompatible(el)).to.be.true
+
+      // verify that overall everything is working
+      const eyes = getEyes()
+      await eyes.open(driver, 'Coverage tests', 'duplicate driver', {width: 800, height: 600})
+      await eyes.check('', Target.window())
+      await eyes.close(false)
+    } finally {
+      driver.quit()
+      // fs.rmdirSync(otherNodeModules, {recursive: true})
+    }
+  })
+})
+
+async function buildDriver({capabilities, serverUrl = process.env.CVG_TESTS_REMOTE}) {
+  const {Builder} = require('selenium-webdriver')
+  return new Builder()
+    .withCapabilities(capabilities)
+    .usingServer(serverUrl)
+    .build()
+}

--- a/packages/eyes-webdriverio-4/src/LegacyWrappedElement.js
+++ b/packages/eyes-webdriverio-4/src/LegacyWrappedElement.js
@@ -5,6 +5,9 @@
  */
 function LegacyAPIElement(EyesWrappedElement) {
   return class EyesWebElement extends EyesWrappedElement {
+    get __EyesWebElement() {
+      return true
+    }
     get element() {
       return this.unwrapped
     }

--- a/packages/sdk-coverage-tests/coverage-tests/custom/DuplicateSdk.spec.js
+++ b/packages/sdk-coverage-tests/coverage-tests/custom/DuplicateSdk.spec.js
@@ -1,0 +1,80 @@
+'use strict'
+const cwd = process.cwd()
+const path = require('path')
+const {getEyes, Browsers} = require('../util/TestSetup')
+const spec = require(path.resolve(cwd, 'src/SpecWrappedDriver'))
+const fs = require('fs')
+const {promisify} = require('util')
+const ncp = require('ncp')
+const pncp = promisify(ncp)
+
+describe('Coverage tests', () => {
+  let driver, eyes
+
+  afterEach(async () => {
+    await spec.cleanup(driver)
+  })
+
+  beforeEach(async () => {
+    driver = await spec.build({capabilities: Browsers.chrome()})
+    eyes = await getEyes({isCssStitching: true})
+  })
+
+  it('resilient to duplicate copies of the SDK', async () => {
+    const {sdkPath, cleanup} = await createCopyOfSdk(cwd)
+
+    await spec.visit(driver, 'https://applitools.github.io/demo/TestPages/FramesTestPage/')
+
+    module.constructor._pathCache = {}
+
+    try {
+      const sdk = require(sdkPath)
+
+      await eyes.open(driver, 'Eyes JS SDK', 'duplicate copies of SDK', {width: 700, height: 460})
+      await eyes.check(sdk.Target.region('#overflowing-div'))
+      await eyes.close()
+    } finally {
+      cleanup()
+    }
+  })
+})
+
+async function createCopyOfSdk(pathToExistingSdk) {
+  const targetCorePath = path.resolve(pathToExistingSdk, 'eyes-sdk-core')
+  fs.rmdirSync(targetCorePath, {recursive: true})
+  // copy core into here
+  await pncp(path.resolve(pathToExistingSdk, '../eyes-sdk-core'), targetCorePath)
+
+  // create copy of src folder
+  const targetSrcPath = path.resolve(pathToExistingSdk, 'src2')
+  fs.rmdirSync(targetSrcPath, {recursive: true})
+  await pncp(path.resolve(pathToExistingSdk, 'src'), targetSrcPath)
+
+  // fix references in src folder
+  const filesInSrc = fs.readdirSync(path.resolve(pathToExistingSdk, 'src2'))
+  for (const file of filesInSrc) {
+    const filepath = path.resolve(pathToExistingSdk, 'src2', file)
+    const content = fs.readFileSync(filepath).toString()
+    const newContent = content.replace('@applitools/eyes-sdk-core', `../eyes-sdk-core`)
+    fs.writeFileSync(filepath, newContent)
+  }
+
+  // create copy of index file
+  const targetIndexPath = path.resolve(pathToExistingSdk, 'index2.js')
+  fs.copyFileSync(path.resolve(pathToExistingSdk, 'index.js'), targetIndexPath)
+
+  // fix references in index file
+  const content = fs.readFileSync(targetIndexPath).toString()
+  const newContent = content
+    .replace('@applitools/eyes-sdk-core', `./eyes-sdk-core`)
+    .replace('./src/', './src2/')
+  fs.writeFileSync(targetIndexPath, newContent)
+
+  return {sdkPath: targetIndexPath, cleanup}
+
+  function cleanup() {
+    fs.rmdirSync(targetSrcPath, {recursive: true})
+    fs.rmdirSync(targetCorePath, {recursive: true})
+    fs.unlinkSync(targetIndexPath)
+  }
+}

--- a/packages/sdk-coverage-tests/coverage-tests/custom/DuplicateSdk.spec.js
+++ b/packages/sdk-coverage-tests/coverage-tests/custom/DuplicateSdk.spec.js
@@ -31,7 +31,7 @@ describe('Coverage tests', () => {
       const sdk = require(sdkPath)
 
       await eyes.open(driver, 'Eyes JS SDK', 'duplicate copies of SDK', {width: 700, height: 460})
-      await eyes.check(sdk.Target.region('#overflowing-div'))
+      await eyes.check(sdk.Target.region('#overflowing-div').fully())
       await eyes.close()
     } finally {
       cleanup()

--- a/packages/sdk-coverage-tests/package.json
+++ b/packages/sdk-coverage-tests/package.json
@@ -40,6 +40,7 @@
     "@applitools/sdk-shared": "0.1.0",
     "@typescript-eslint/parser": "^2.14.0",
     "mocha": "^6.2.2",
+    "ncp": "^2.0.0",
     "typescript": "^3.7.4"
   },
   "bin": {


### PR DESCRIPTION
It seems like the Cucumber testing framework is creating a copy of the SDK's code, and also invalidates require cache. It's not 100% certain, it could be either that or something else - what we do know is that checks for `instanceof` are failing, and when we added console logs for customers that experienced this, the path to the file was the same. Meaning, it's not a duplicate node_module somewhere. It's just loaded again into memory.

This PR serves to fix the particular issue of the customer. After this, we should change all occurences of `instanceof` to `TypeUtils.instanceOf`

In order to do that, we need to add `static get __ConstructorName() { return true; }` to all classes.
We could do this in a utility function, so something like:

```
class Region() {
}

module.exports = markType(Region)
```

where `markType` is something like:

```
function markType(ctor) {
  Object.defineProperty(ctor, `__${ctor.name}`, {value: true})
}
```