### PR TITLE
dom-snapshot: expose function to fetch and process resourceUrls

### DIFF
--- a/packages/dom-snapshot/index.js
+++ b/packages/dom-snapshot/index.js
@@ -9,6 +9,7 @@ const getProcessPageAndSerialize = makeGetScript('processPageAndSerialize');
 const getProcessPageAndSerializePoll = makeGetScript('processPageAndSerializePoll');
 const getProcessPageAndSerializeForIE = makeGetScript('processPageAndSerializeForIE');
 const getProcessPageAndSerializePollForIE = makeGetScript('processPageAndSerializePollForIE');
+const processResourceUrlsAndBlobs = require('./src/browser/processResourceUrlsAndBlobs');
 
 module.exports = {
   getProcessPage,
@@ -16,6 +17,7 @@ module.exports = {
   getProcessPageAndSerializeForIE,
   getProcessPageAndSerializePoll,
   getProcessPageAndSerializePollForIE,
+  processResourceUrlsAndBlobs,
   makeExtractResourcesFromSvg,
   toUriEncoding,
   toUnAnchoredUri,

--- a/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
+++ b/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
@@ -12,14 +12,13 @@ const absolutizeUrl = require('./absolutizeUrl');
 const makeLog = require('./log');
 const noop = require('./noop');
 
-function processResourceUrlsAndBlobs(
-  {fetchUrl, resourceUrls, showLogs} = {
-    fetchUrl: () => {
-      throw new Error('fetchUrl not implemented');
-    },
-    resourceUrls: [],
+function processResourceUrlsAndBlobs({
+  fetchUrl = () => {
+    throw new Error('fetchUrl not implemented');
   },
-) {
+  resourceUrls = [],
+  showLogs,
+} = {}) {
   const styleSheetCache = {};
   const findStyleSheetByUrl = makeFindStyleSheetByUrl({styleSheetCache});
   const extractResourcesFromStyleSheet = makeExtractResourcesFromStyleSheet({

--- a/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
+++ b/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
@@ -5,6 +5,7 @@ const makeGetResourceUrlsAndBlobs = require('./getResourceUrlsAndBlobs');
 const makeFindStyleSheetByUrl = require('./findStyleSheetByUrl');
 const getCorsFreeStyleSheet = require('./getCorsFreeStyleSheet');
 const makeExtractResourcesFromStyleSheet = require('./extractResourcesFromStyleSheet');
+const {CSSRule} = require('cssom');
 const makeExtractResourceUrlsFromStyleTags = require('./extractResourceUrlsFromStyleTags');
 const makeExtractResourcesFromSvg = require('./makeExtractResourcesFromSvg');
 const absolutizeUrl = require('./absolutizeUrl');
@@ -21,7 +22,10 @@ function processResourceUrlsAndBlobs(
 ) {
   const styleSheetCache = {};
   const findStyleSheetByUrl = makeFindStyleSheetByUrl({styleSheetCache});
-  const extractResourcesFromStyleSheet = makeExtractResourcesFromStyleSheet({styleSheetCache});
+  const extractResourcesFromStyleSheet = makeExtractResourcesFromStyleSheet({
+    styleSheetCache,
+    CSSRule,
+  });
   const extractResourceUrlsFromStyleTags = makeExtractResourceUrlsFromStyleTags(
     extractResourcesFromStyleSheet,
   );
@@ -40,9 +44,11 @@ function processResourceUrlsAndBlobs(
     processResource,
     aggregateResourceUrlsAndBlobs,
   });
-  return getResourceUrlsAndBlobs({urls: resourceUrls}).then((resourceUrls, blobsObj) => {
+  return getResourceUrlsAndBlobs({urls: resourceUrls}).then(result => {
+    const urls = Object.keys(result.blobsObj);
+    const blobsObj = result.blobsObj;
     return {
-      resourceUrls: resourceUrls.map(url => url.replace(/^blob:/, '')),
+      resourceUrls: urls.map(url => url.replace(/^blob:/, '')),
       blobs: blobsObjToArray(blobsObj),
     };
   });

--- a/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
+++ b/packages/dom-snapshot/src/browser/processResourceUrlsAndBlobs.js
@@ -1,0 +1,62 @@
+'use strict';
+const aggregateResourceUrlsAndBlobs = require('./aggregateResourceUrlsAndBlobs');
+const makeProcessResource = require('./processResource');
+const makeGetResourceUrlsAndBlobs = require('./getResourceUrlsAndBlobs');
+const makeFindStyleSheetByUrl = require('./findStyleSheetByUrl');
+const getCorsFreeStyleSheet = require('./getCorsFreeStyleSheet');
+const makeExtractResourcesFromStyleSheet = require('./extractResourcesFromStyleSheet');
+const makeExtractResourceUrlsFromStyleTags = require('./extractResourceUrlsFromStyleTags');
+const makeExtractResourcesFromSvg = require('./makeExtractResourcesFromSvg');
+const absolutizeUrl = require('./absolutizeUrl');
+const makeLog = require('./log');
+const noop = require('./noop');
+
+function processResourceUrlsAndBlobs(
+  {fetchUrl, resourceUrls, showLogs} = {
+    fetchUrl: () => {
+      throw new Error('fetchUrl not implemented');
+    },
+    resourceUrls: [],
+  },
+) {
+  const styleSheetCache = {};
+  const findStyleSheetByUrl = makeFindStyleSheetByUrl({styleSheetCache});
+  const extractResourcesFromStyleSheet = makeExtractResourcesFromStyleSheet({styleSheetCache});
+  const extractResourceUrlsFromStyleTags = makeExtractResourceUrlsFromStyleTags(
+    extractResourcesFromStyleSheet,
+  );
+  const extractResourcesFromSvg = makeExtractResourcesFromSvg({extractResourceUrlsFromStyleTags});
+  const log = showLogs ? makeLog(Date.now()) : noop;
+  const processResource = makeProcessResource({
+    fetchUrl,
+    findStyleSheetByUrl,
+    getCorsFreeStyleSheet,
+    extractResourcesFromStyleSheet,
+    extractResourcesFromSvg,
+    absolutizeUrl,
+    log,
+  });
+  const getResourceUrlsAndBlobs = makeGetResourceUrlsAndBlobs({
+    processResource,
+    aggregateResourceUrlsAndBlobs,
+  });
+  return getResourceUrlsAndBlobs({urls: resourceUrls}).then((resourceUrls, blobsObj) => {
+    return {
+      resourceUrls: resourceUrls.map(url => url.replace(/^blob:/, '')),
+      blobs: blobsObjToArray(blobsObj),
+    };
+  });
+}
+
+function blobsObjToArray(blobsObj) {
+  return Object.keys(blobsObj).map(blobUrl =>
+    Object.assign(
+      {
+        url: blobUrl.replace(/^blob:/, ''),
+      },
+      blobsObj[blobUrl],
+    ),
+  );
+}
+
+module.exports = processResourceUrlsAndBlobs;

--- a/packages/dom-snapshot/test/processResourceUrlsAndBlobs.test.js
+++ b/packages/dom-snapshot/test/processResourceUrlsAndBlobs.test.js
@@ -1,0 +1,23 @@
+'use strict';
+const {describe, it, _before, _after, _beforeEach, _afterEach} = require('mocha');
+const {expect} = require('chai');
+const {processResourceUrlsAndBlobs} = require('../index');
+
+describe('processPage', () => {
+  const fetchUrl = async url => {
+    switch (url) {
+      case 'http://blah':
+        return {url, value: 'blah'};
+      case 'http://blahblah':
+        return {url, value: 'blahblah'};
+      case 'http://blahblahblah':
+        return {url, value: 'blahblahblah'};
+    }
+  };
+  it('works', async () => {
+    const resourceUrls = ['http://blah', 'http://blahblah', 'http://blahblahblah'];
+    const result = await processResourceUrlsAndBlobs({resourceUrls, fetchUrl});
+    expect(result.resourceUrls).not.to.be.empty;
+    expect(result.blobs).not.to.be.empty;
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,26 @@
     postcss-value-parser "^4.0.2"
     throat "^5.0.0"
 
+"@applitools/visual-grid-client@14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@applitools/visual-grid-client/-/visual-grid-client-14.6.1.tgz#9bd1d4cc8d98180471a22467cc2165fae5ad420a"
+  integrity sha512-rpUAoyeBZ3af7CP7Vbxvpk3H6BxCEp4AeIvF+DeiV3xQ2w0WHfNQ6JuKiO1fXiyBJPxFSlvvdmuIkpj+mX+/Tg==
+  dependencies:
+    "@applitools/dom-snapshot" "4.0.0"
+    "@applitools/eyes-sdk-core" "11.5.1"
+    "@applitools/feature-flags" "2.1.1"
+    "@applitools/functional-commons" "1.5.4"
+    "@applitools/http-commons" "2.3.12"
+    "@applitools/isomorphic-fetch" "3.0.0"
+    "@applitools/jsdom" "1.0.2"
+    chalk "3.0.0"
+    he "1.2.0"
+    lodash.mapvalues "^4.6.0"
+    mime-types "^2.1.24"
+    mkdirp "^0.5.1"
+    postcss-value-parser "^4.0.2"
+    throat "^5.0.0"
+
 "@babel/code-frame@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"


### PR DESCRIPTION
In some SDKs we want to improve the performance of `dom-snapshot` (like `eyes-testcafe`).

One way to do that is to instruct dom-snapshot to not fetch the resources.

This delegates the responsibility down the SDK to fetch and process the resources. This PR is an attempt to make the implementation for the SDK relatively straight-forward.

Still a WIP. Feedback welcome!