### PR TITLE
Fix user agent parsing for Edge Chromium

### DIFF
--- a/packages/eyes-sdk-core/lib/useragent/UserAgent.js
+++ b/packages/eyes-sdk-core/lib/useragent/UserAgent.js
@@ -7,7 +7,7 @@ const MAJOR_MINOR = '(\\d+)(?:[_.](\\d+))?'
 const PRODUCT = `(?:(%s)/${MAJOR_MINOR})`
 
 // Browser Regexes
-const VALUES_FOR_BROWSER_REGEX_EXCEPT_IE = ['Opera', 'Chrome', 'Safari', 'Firefox', 'Edge']
+const VALUES_FOR_BROWSER_REGEX_EXCEPT_IE = ['Opera', 'Edg', 'Chrome', 'Safari', 'Firefox', 'Edge']
 const IE_BROWSER_REGEX = new RegExp(`(?:MS(IE) ${MAJOR_MINOR})`)
 
 const getBrowserRegExes = () => {
@@ -183,6 +183,10 @@ class UserAgent {
         result._browserMinorVersion = ieMatch[2]
         browserOK = true
       }
+    }
+
+    if (result._browser === 'Edg') {
+      result._browser = 'Edge'
     }
 
     if (!browserOK) {

--- a/packages/eyes-sdk-core/test/unit/useragent/UserAgent.spec.js
+++ b/packages/eyes-sdk-core/test/unit/useragent/UserAgent.spec.js
@@ -122,6 +122,7 @@ describe('UserAgent', () => {
       assert.strictEqual(userAgent.getBrowserMajorVersion(), '11')
       assert.strictEqual(userAgent.getBrowserMinorVersion(), '0')
     })
+
     ;[
       {
         uaStr:
@@ -403,6 +404,16 @@ describe('UserAgent', () => {
         expectedOsMinorVersion: '14',
         expectedBrowser: BrowserNames.Safari,
         expectedBrowserMajorVersion: '12',
+        expectedBrowserMinorVersion: '0',
+      },
+      {
+        uaStr:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36 Edg/79.0.309.18',
+        expectedOs: OSNames.MacOSX,
+        expectedOsMajorVersion: '10',
+        expectedOsMinorVersion: '15',
+        expectedBrowser: BrowserNames.Edge,
+        expectedBrowserMajorVersion: '79',
         expectedBrowserMinorVersion: '0',
       },
     ].forEach(


### PR DESCRIPTION
[Trello](https://trello.com/c/bOUk7oj8/182-edge-browserstack-user-agent-is-considered-as-chrome)