### PR TITLE
Support visualGridOptions

### DIFF
--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -20,7 +20,8 @@ function makeEyesCheckWindow({sendRequest, processPage}) {
       enablePatterns,
       ignoreDisplacements,
       accessibility,
-      matchLevel;
+      matchLevel,
+      visualGridOptions;
     if (typeof args === 'string') {
       tag = args;
     } else if (typeof args === 'object') {
@@ -42,6 +43,7 @@ function makeEyesCheckWindow({sendRequest, processPage}) {
       ignoreDisplacements = args.ignoreDisplacements;
       accessibility = args.accessibility;
       matchLevel = args.matchLevel;
+      visualGridOptions = args.visualGridOptions;
     }
 
     return processPage(doc).then(mainFrame => {
@@ -76,6 +78,7 @@ function makeEyesCheckWindow({sendRequest, processPage}) {
             ignoreDisplacements,
             accessibility,
             matchLevel,
+            visualGridOptions,
           },
         }),
       );

--- a/packages/eyes-cypress/src/plugin/handlers.js
+++ b/packages/eyes-cypress/src/plugin/handlers.js
@@ -115,6 +115,7 @@ function makeHandlers({
       ignoreDisplacements,
       accessibility,
       matchLevel,
+      visualGridOptions,
     }) => {
       logger.log(`[handlers] checkWindow: checkWindow=${typeof checkWindow}`);
       if (!checkWindow) {
@@ -154,6 +155,7 @@ function makeHandlers({
         ignoreDisplacements,
         accessibility,
         matchLevel,
+        visualGridOptions,
       });
     },
 

--- a/packages/eyes-cypress/test/it/browser/eyesCheckWindow.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/eyesCheckWindow.it.test.js
@@ -53,6 +53,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements: undefined,
         accessibility: undefined,
         matchLevel: undefined,
+        visualGridOptions: undefined,
       },
     });
     expect(resourcesPutted).to.eql([
@@ -120,6 +121,7 @@ describe('eyesCheckWindow', () => {
     const ignoreDisplacements = 'ignoreDisplacements';
     const accessibility = 'accessibility';
     const matchLevel = 'matchLevel';
+    const visualGridOptions = 'visualGridOptions';
 
     await eyesCheckWindow('bla doc', {
       tag,
@@ -140,6 +142,7 @@ describe('eyesCheckWindow', () => {
       ignoreDisplacements,
       accessibility,
       matchLevel,
+      visualGridOptions,
     });
 
     expect(sendRequestInput).to.eql({
@@ -171,6 +174,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements,
         accessibility,
         matchLevel,
+        visualGridOptions,
       },
     });
     expect(resourcesPutted).to.eql([
@@ -280,6 +284,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements: undefined,
         accessibility: undefined,
         matchLevel: undefined,
+        visualGridOptions: undefined,
       },
     });
     expect(resourcesPutted).to.eql([
@@ -363,6 +368,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements: undefined,
         accessibility: undefined,
         matchLevel: undefined,
+        visualGridOptions: undefined,
       },
     });
     expect(resourcesPutted).to.eql([
@@ -435,6 +441,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements: undefined,
         accessibility: undefined,
         matchLevel: undefined,
+        visualGridOptions: undefined,
       },
     });
     expect(resourcesPutted).to.eql([
@@ -507,6 +514,7 @@ describe('eyesCheckWindow', () => {
         ignoreDisplacements: undefined,
         accessibility: undefined,
         matchLevel: undefined,
+        visualGridOptions: undefined,
       },
     });
     expect(resourcesPutted).to.eql([]);

--- a/packages/eyes-cypress/test/unit/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/handlers.test.js
@@ -148,6 +148,7 @@ describe('handlers', () => {
     const ignoreDisplacements = 'ignoreDisplacements';
     const accessibility = 'accessibility';
     const matchLevel = 'matchLevel';
+    const visualGridOptions = 'visualGridOptions';
     const resourceContents = {};
 
     const result = await handlers.checkWindow({
@@ -172,6 +173,7 @@ describe('handlers', () => {
       ignoreDisplacements,
       accessibility,
       matchLevel,
+      visualGridOptions,
     });
 
     expect(result).to.eql({
@@ -199,6 +201,7 @@ describe('handlers', () => {
       frames: [],
       accessibility,
       matchLevel,
+      visualGridOptions,
       __openArgs: {
         __test: 123,
         accessibilitySettings: undefined,
@@ -325,6 +328,7 @@ describe('handlers', () => {
       ignoreDisplacements: undefined,
       accessibility: undefined,
       matchLevel: undefined,
+      visualGridOptions: undefined,
     });
   });
 

--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -239,6 +239,9 @@ class Configuration {
     /** @type {boolean} */
     this._dontCloseBatches = undefined
 
+    /** @type {Object} */
+    this._visualGridOptions = undefined
+
     if (configuration) {
       this.mergeConfig(configuration)
     }
@@ -1280,6 +1283,23 @@ class Configuration {
     return this
   }
 
+  getVisualGridOptions() {
+    return this._visualGridOptions
+  }
+
+  setVisualGridOptions(value) {
+    this._visualGridOptions = value
+    return this
+  }
+
+  setVisualGridOption(key, value) {
+    if (!this._visualGridOptions) {
+      this._visualGridOptions = {}
+    }
+    this._visualGridOptions[key] = value
+    return this
+  }
+
   /**
    * @param {Configuration|object} other
    */
@@ -1334,6 +1354,7 @@ class Configuration {
       ignoreDisplacements: this.getIgnoreDisplacements(),
       saveDebugData: this.getSaveDebugData(),
       accessibilitySettings: this.getAccessibilityValidation(),
+      visualGridOptions: this.getVisualGridOptions(),
     }
   }
 

--- a/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
@@ -186,6 +186,8 @@ class CheckSettings {
     this._renderId = undefined
     /** @private @type {Object<string, string>} */
     this._scriptHooks = {}
+    /** @private @type {Object} */
+    this._visualGridOptions = undefined
   }
   /**
    * Create check settings from an object
@@ -280,6 +282,11 @@ class CheckSettings {
     }
     if (object.isFully) {
       settings.fully(object.isFully)
+    }
+    if (object.visualGridOptions) {
+      Object.entries(object.visualGridOptions).forEach(([key, value]) => {
+        settings.visualGridOption(key, value)
+      })
     }
     return settings
   }
@@ -932,6 +939,14 @@ class CheckSettings {
   getScriptHooks() {
     return this._scriptHooks
   }
+  visualGridOption(key, value) {
+    if (!this._visualGridOptions) {
+      this._visualGridOptions = {}
+    }
+    this._visualGridOptions[key] = value
+    return this
+  }
+
   /**
    * @override
    */
@@ -955,6 +970,7 @@ class CheckSettings {
       scriptHooks: this.getScriptHooks(),
       sendDom: this.getSendDom(),
       matchLevel: this.getMatchLevel(),
+      visualGridOptions: this._visualGridOptions,
     }
     if (config.target === 'region') {
       const type = this._targetRegion ? 'region' : 'selector'

--- a/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
+++ b/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
@@ -19,7 +19,7 @@ class RenderRequest {
    * @param {string[]} request.selectorsToFindRegionsFor
    * @param {boolean} request.sendDom
    * @param {string} request.renderId
-   * @param {string} request.agentId
+   * @param {Object} request.visualGridOptions
    */
   constructor({
     webhook,
@@ -35,6 +35,7 @@ class RenderRequest {
     sendDom,
     renderId,
     agentId,
+    visualGridOptions,
   } = {}) {
     ArgumentGuard.notNullOrEmpty(webhook, 'webhook')
     ArgumentGuard.notNull(url, 'url')
@@ -54,6 +55,7 @@ class RenderRequest {
     this._selectorsToFindRegionsFor = selectorsToFindRegionsFor
     this._sendDom = sendDom
     this._agentId = agentId
+    this._visualGridOptions = visualGridOptions
   }
 
   /**
@@ -182,6 +184,14 @@ class RenderRequest {
     this._sendDom = value
   }
 
+  getVisualGridOptions() {
+    return this._visualGridOptions
+  }
+
+  setVisualGridOptions(options) {
+    this._visualGridOptions = options
+  }
+
   /**
    * @override
    */
@@ -233,6 +243,10 @@ class RenderRequest {
 
     if (this._sendDom !== undefined) {
       object.sendDom = this._sendDom
+    }
+
+    if (this._visualGridOptions) {
+      object.options = this._visualGridOptions
     }
 
     return object

--- a/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
+++ b/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
@@ -139,6 +139,8 @@ describe('Configuration', () => {
           name: 'chrome',
         },
       ]
+    } else if (type === '_visualGridOptions') {
+      modifiedValue = {polyfillAdoptedStyleSheets: true}
     }
     return modifiedValue
   }
@@ -606,6 +608,7 @@ describe('Configuration', () => {
         name: 'myBatchName',
         notifyOnCompletion: true,
       },
+      visualGridOptions: {polyfillAdoptedStyleSheets: true},
     }
     const config = new Configuration(conf)
     const result = config.toOpenEyesConfiguration()
@@ -615,6 +618,7 @@ describe('Configuration', () => {
     assert.strictEqual(result.batch.getId(), conf.batch.id)
     assert.strictEqual(result.batch.getName(), conf.batch.name)
     assert.strictEqual(result.batch.getNotifyOnCompletion(), conf.batch.notifyOnCompletion)
+    assert.deepStrictEqual(result.visualGridOptions, conf.visualGridOptions)
   })
 
   it('setMatchLevel("Layout")', () => {

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
@@ -30,6 +30,7 @@ describe('CheckSettings', () => {
       ],
       accessibilityRegions: ['accessibility-region-selector'],
       isFully: true,
+      visualGridOptions: {polyfillAdoptedStyleSheets: true},
     }
     const checkSettings = CheckSettings.from(object)
 
@@ -52,6 +53,7 @@ describe('CheckSettings', () => {
         object.floatingRegions[0].maxRightOffset,
       )
       .fully(object.isFully)
+      .visualGridOption('polyfillAdoptedStyleSheets', true)
 
     assert.deepStrictEqual(checkSettings, checkSettings2)
   })
@@ -70,11 +72,15 @@ describe('CheckSettings', () => {
     const checkSettings = new CheckSettings()
     checkSettings.accessibility({id: 'id0'}, 'bla')
     checkSettings.accessibility({id: 'id-not-mocked', selector: 'not-mocked'}, 'bla')
+    checkSettings.visualGridOption('polyfillAdoptedStyleSheets', true)
     const checkWindowConfiguration = await checkSettings.toCheckWindowConfiguration(driver)
     assert.deepStrictEqual(checkWindowConfiguration.accessibility, [
       {accessibilityType: 'bla', selector: '/HTML[1]/BODY[1]/DIV[2]', type: 'xpath'},
       {accessibilityType: 'bla', selector: '//[data-fake-selector="not-mocked"]', type: 'xpath'},
     ])
+    assert.deepStrictEqual(checkWindowConfiguration.visualGridOptions, {
+      polyfillAdoptedStyleSheets: true,
+    })
   })
 
   // TODO this test makes more sense to run inside docker

--- a/packages/eyes-sdk-core/test/unit/renderer/RenderRequest.spec.js
+++ b/packages/eyes-sdk-core/test/unit/renderer/RenderRequest.spec.js
@@ -48,6 +48,7 @@ describe('RenderRequest', () => {
         scriptHooks: 'scriptHooks',
         selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
         sendDom: 'sendDom',
+        visualGridOptions: {polyfillAdoptedStyleSheets: true},
       })
       assert.strictEqual(renderRequest.getWebhook(), 'webhook')
       assert.strictEqual(renderRequest.getUrl(), 'url')
@@ -60,6 +61,9 @@ describe('RenderRequest', () => {
       assert.strictEqual(renderRequest.getSelectorsToFindRegionsFor(), 'selectorsToFindRegionsFor')
       assert.strictEqual(renderRequest.getSendDom(), 'sendDom')
       assert.strictEqual(renderRequest.getStitchingService(), 'stitchingService')
+      assert.deepStrictEqual(renderRequest.getVisualGridOptions(), {
+        polyfillAdoptedStyleSheets: true,
+      })
     })
   })
 
@@ -104,6 +108,7 @@ describe('RenderRequest', () => {
         scriptHooks: 'scriptHooks',
         selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
         sendDom: 'sendDom',
+        visualGridOptions: {polyfillAdoptedStyleSheets: true},
       })
       const expected = {
         stitchingService: undefined,
@@ -124,6 +129,7 @@ describe('RenderRequest', () => {
         scriptHooks: 'scriptHooks',
         selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
         sendDom: 'sendDom',
+        options: {polyfillAdoptedStyleSheets: true},
       }
       assert.deepStrictEqual(renderRequest.toJSON(), expected)
     })
@@ -170,10 +176,11 @@ describe('RenderRequest', () => {
         scriptHooks: 'scriptHooks',
         selectorsToFindRegionsFor: 'selectorsToFindRegionsFor',
         sendDom: 'sendDom',
+        visualGridOptions: {polyfillAdoptedStyleSheets: true},
       })
       assert.strictEqual(
         renderRequest.toString(),
-        'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName"},"platform":{"name":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor","sendDom":"sendDom"} }',
+        'RenderRequest { {"webhook":"webhook","url":"url","dom":"dom_hashAsObject","resources":{"url1":"hashAsObject1","url2":"hashAsObject2"},"browser":{"name":"browserName"},"platform":{"name":"platform"},"renderInfo":"renderInfoToJSON","scriptHooks":"scriptHooks","selectorsToFindRegionsFor":"selectorsToFindRegionsFor","sendDom":"sendDom","options":{"polyfillAdoptedStyleSheets":true}} }',
       )
     })
   })

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -29,6 +29,7 @@ function makeCheckWindow({
   matchLevel: _matchLevel,
   isSingleWindow,
   getUserAgents,
+  visualGridOptions: _visualGridOptions,
 }) {
   return function checkWindow({
     resourceUrls = [],
@@ -54,6 +55,7 @@ function makeCheckWindow({
     useDom,
     enablePatterns,
     ignoreDisplacements,
+    visualGridOptions = _visualGridOptions,
   }) {
     if (target === 'window' && !fully) {
       sizeMode = 'viewport'
@@ -292,6 +294,7 @@ function makeCheckWindow({
         noOffsetSelectors: noOffsetSelectors.all,
         offsetSelectors: offsetSelectors.all,
         sendDom,
+        visualGridOptions,
       })
 
       globalState.setQueuedRendersCount(globalState.getQueuedRendersCount() + 1)

--- a/packages/visual-grid-client/src/sdk/createRenderRequests.js
+++ b/packages/visual-grid-client/src/sdk/createRenderRequests.js
@@ -17,6 +17,7 @@ function createRenderRequests({
   noOffsetSelectors = [],
   offsetSelectors = [],
   sendDom,
+  visualGridOptions,
 }) {
   const selectorsToFindRegionsFor = calculateSelectorsToFindRegionsFor({
     sizeMode,
@@ -68,6 +69,7 @@ function createRenderRequests({
         selectorsToFindRegionsFor,
         sendDom,
         platform: filledPlatform,
+        visualGridOptions,
       })
     },
   )

--- a/packages/visual-grid-client/src/sdk/openEyes.js
+++ b/packages/visual-grid-client/src/sdk/openEyes.js
@@ -65,6 +65,7 @@ function makeOpenEyes({
   globalState,
   wrappers: _wrappers,
   isSingleWindow = false,
+  visualGridOptions: _visualGridOptions,
 }) {
   return async function openEyes({
     testName,
@@ -103,6 +104,7 @@ function makeOpenEyes({
     ignoreBaseline = _ignoreBaseline,
     notifyOnCompletion,
     getUserAgents = _getUserAgents,
+    visualGridOptions = _visualGridOptions
   }) {
     logger.verbose(`openEyes: testName=${testName}, browser=`, browser)
 
@@ -264,6 +266,7 @@ function makeOpenEyes({
       userAgent,
       isSingleWindow,
       getUserAgents,
+      visualGridOptions,
     })
 
     const close = makeClose({

--- a/packages/visual-grid-client/src/sdk/renderingGridClient.js
+++ b/packages/visual-grid-client/src/sdk/renderingGridClient.js
@@ -80,6 +80,7 @@ function makeRenderingGridClient({
   batchNotify,
   globalState: _globalState,
   dontCloseBatches,
+  visualGridOptions,
 }) {
   const openEyesConcurrency = Number(concurrency)
 
@@ -200,6 +201,7 @@ function makeRenderingGridClient({
     userAgent,
     globalState,
     getUserAgents,
+    visualGridOptions,
   }
 
   const openEyes = makeOpenEyes(openConfig)

--- a/packages/visual-grid-client/test/it/openEyes.it.test.js
+++ b/packages/visual-grid-client/test/it/openEyes.it.test.js
@@ -2259,6 +2259,62 @@ Received: 'firefox-1'.`,
     expect(r.__checkSettings.getEnablePatterns()).to.be.false
   })
 
+  it('handles visualGridOptions in renderingGridClient', async () => {
+    openEyes = makeRenderingGridClient({
+      apiKey,
+      renderWrapper: wrapper,
+      visualGridOptions: {aaa: true},
+    }).openEyes
+
+    const {checkWindow, close} = await openEyes({
+      apiKey,
+      wrappers: [wrapper],
+      appName,
+    })
+
+    await checkWindow({cdt: [], url: ''})
+    const [results] = await close()
+    const r = results.getStepsInfo()[0].getRenderId()
+    expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
+  })
+
+  it('handles visualGridOptions in openEyes', async () => {
+    openEyes = makeRenderingGridClient({
+      apiKey,
+      renderWrapper: wrapper,
+    }).openEyes
+
+    const {checkWindow, close} = await openEyes({
+      apiKey,
+      wrappers: [wrapper],
+      appName,
+      visualGridOptions: {aaa: true},
+    })
+
+    await checkWindow({cdt: [], url: ''})
+    const [results] = await close()
+    const r = results.getStepsInfo()[0].getRenderId()
+    expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
+  })
+
+  it('handles visualGridOptions in checkWindow', async () => {
+    openEyes = makeRenderingGridClient({
+      apiKey,
+      renderWrapper: wrapper,
+    }).openEyes
+
+    const {checkWindow, close} = await openEyes({
+      apiKey,
+      wrappers: [wrapper],
+      appName,
+    })
+
+    await checkWindow({cdt: [], url: '', visualGridOptions: {aaa: true}})
+    const [results] = await close()
+    const r = results.getStepsInfo()[0].getRenderId()
+    expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
+  })
+
   it('doesnt throw error on chrome canary browser name', async () => {
     const [err] = await presult(
       openEyes({

--- a/packages/visual-grid-client/test/util/FakeEyesWrapper.js
+++ b/packages/visual-grid-client/test/util/FakeEyesWrapper.js
@@ -119,6 +119,7 @@ class FakeEyesWrapper extends EventEmitter {
     const iosDeviceInfo = renderInfo.getIosDeviceInfo()
     const selectorsToFindRegionsFor = renderRequest.getSelectorsToFindRegionsFor()
     const platform = renderRequest.getPlatform()
+    const visualGridOptions = renderRequest.getVisualGridOptions()
 
     const isGood = isGoodCdt && isGoodResources
     const renderId = JSON.stringify({
@@ -131,6 +132,7 @@ class FakeEyesWrapper extends EventEmitter {
       iosDeviceInfo,
       selectorsToFindRegionsFor,
       platform,
+      visualGridOptions,
       salt: salt++,
     })
 


### PR DESCRIPTION
The point here is to allow a backchannel for the user to configure stuff on the visual grid **without the need to update the SDK**.

This should be possible in various ways - all the ways for the user to specify parameters for check:
1. Classic SDK Configuration
2. Classic SDK CheckSettings
3. Cypress cy.eyesCheckWindow and cy.eyesOpen
4. Storybook applitools.config.js file

So there are quite a few places to add this in the code. Hopefully I covered them all.
The first use case for this is adopted stylesheets. We will use this as a means for the user to specify what to do for browsers that don't support adopted stylesheets (see more in [Trello](https://trello.com/c/cX4q0DzH/390-adoptedstylesheets-feature-not-supported#comment-5f1b44f7530156669ebbe228))