### PR TITLE
Add support for layout breakpoints

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- add support for `layoutBreakpoints`
 - avoid javascript execution on native devices during viewport size extraction
 
 ## 12.1.4 - 2020/8/13

--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -36,7 +36,7 @@ const GeneralUtils = require('../utils/GeneralUtils')
  * @typedef {{chromeEmulationInfo: EmulationInfo}} ChromeEmulationInfo
  */
 /**
- * @typedef {{iosDeviceInfo: {deviceName: IosDevieName, screenOrientation: (ScreenOrientation|undefined)}}} IosDeviceInfo
+ * @typedef {{iosDeviceInfo: {deviceName: IosDeviceName, screenOrientation: (ScreenOrientation|undefined)}}} IosDeviceInfo
  */
 /**
  * @typedef {(DesktopBrowserInfo|EmulationInfo|ChromeEmulationInfo|IosDeviceInfo)} RenderInfo
@@ -1297,6 +1297,22 @@ class Configuration {
       this._visualGridOptions = {}
     }
     this._visualGridOptions[key] = value
+    return this
+  }
+
+  getLayoutBreakpoints() {
+    return this._layoutBreakpoints
+  }
+
+  setLayoutBreakpoints(breakpoints) {
+    ArgumentGuard.notNull(breakpoints, 'breakpoints')
+    if (!TypeUtils.isArray(breakpoints)) {
+      this._layoutBreakpoints = breakpoints
+    } else if (breakpoints.length === 0) {
+      this._layoutBreakpoints = false
+    } else {
+      this._layoutBreakpoints = Array.from(new Set(breakpoints)).sort((a, b) => (a > b ? 1 : -1))
+    }
     return this
   }
 

--- a/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
@@ -66,6 +66,8 @@ const TypeUtils = require('../utils/TypeUtils')
  * @prop {boolean} [enablePatterns=true]
  * @prop {boolean} [ignoreDisplacements=true]
  * @prop {boolean} [ignoreCaret=true]
+ * @prop {Object<string, any>} [visualGridOptions]
+ * @prop {number[]|boolean} [layoutBreakpoints]
  * @prop {boolean} [isFully=false]
  * @prop {string} [renderId]
  * @prop {{[key: string]: string}} [hooks]
@@ -188,6 +190,8 @@ class CheckSettings {
     this._scriptHooks = {}
     /** @private @type {Object} */
     this._visualGridOptions = undefined
+    /** @private @type {number[]|boolean} */
+    this._layoutBreakpoints = null
   }
   /**
    * Create check settings from an object
@@ -287,6 +291,9 @@ class CheckSettings {
       Object.entries(object.visualGridOptions).forEach(([key, value]) => {
         settings.visualGridOption(key, value)
       })
+    }
+    if (object.layoutBreakpoints) {
+      settings.layoutBreakpoints(object.layoutBreakpoints)
     }
     return settings
   }
@@ -945,6 +952,19 @@ class CheckSettings {
     }
     this._visualGridOptions[key] = value
     return this
+  }
+  layoutBreakpoints(breakpoints = true) {
+    if (!TypeUtils.isArray(breakpoints)) {
+      this._layoutBreakpoints = breakpoints
+    } else if (breakpoints.length === 0) {
+      this._layoutBreakpoints = false
+    } else {
+      this._layoutBreakpoints = Array.from(new Set(breakpoints)).sort((a, b) => (a > b ? 1 : -1))
+    }
+    return this
+  }
+  getLayoutBreakpoints() {
+    return this._layoutBreakpoints
   }
 
   /**

--- a/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
@@ -257,7 +257,7 @@ class EyesVisualGrid extends EyesCore {
         fully: this.getForceFullPageScreenshot() || config.fully,
         sendDom: this.getSendDom() || config.sendDom,
         matchLevel: TypeUtils.getOrDefault(config.matchLevel, this.getMatchLevel()),
-        snapshots,
+        snapshot: snapshots,
         url,
       })
     })

--- a/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
@@ -301,8 +301,8 @@ class EyesVisualGrid extends EyesCore {
         } else if (TypeUtils.has(browser, 'chromeEmulationInfo')) {
           const {width} = await this._getEmulatedDeviceSize(browser.chromeEmulationInfo)
           return width
-        } else if (TypeUtils.has(browser, 'iosEmulationInfo')) {
-          const {width} = await this._getIosDeviceSize(browser.iosEmulationInfo)
+        } else if (TypeUtils.has(browser, 'iosDeviceInfo')) {
+          const {width} = await this._getIosDeviceSize(browser.iosDeviceInfo)
           return width
         }
       }),

--- a/packages/eyes-sdk-core/lib/server/ServerConnector.js
+++ b/packages/eyes-sdk-core/lib/server/ServerConnector.js
@@ -785,6 +785,45 @@ class ServerConnector {
 
     throw new Error(`ServerConnector.postLocators - unexpected status (${response.statusText})`)
   }
+
+  async getEmulatedDevicesSizes() {
+    this._logger.verbose(`ServerConnector.getEmulatedDevicesSizes`)
+
+    const config = {
+      name: 'getEmulatedDevicesSizes',
+      method: 'GET',
+      withApiKey: false,
+      url: GeneralUtils.urlConcat(this._renderingInfo.getServiceUrl(), '/emulated-devices-sizes'),
+    }
+
+    const response = await this._axios.request(config)
+    if (response.status === HTTP_STATUS_CODES.OK) {
+      return response.data
+    } else {
+      throw new Error(
+        `ServerConnector.getEmulatedDevicesSizes - unexpected status (${response.statusText})`,
+      )
+    }
+  }
+
+  async getIosDevicesSizes() {
+    this._logger.verbose(`ServerConnector.getIosDevicesSizes`)
+
+    const config = {
+      name: 'getIosDevicesSizes',
+      method: 'GET',
+      url: GeneralUtils.urlConcat(this._renderingInfo.getServiceUrl(), '/ios-devices-sizes'),
+    }
+
+    const response = await this._axios.request(config)
+    if (response.status === HTTP_STATUS_CODES.OK) {
+      return response.data
+    } else {
+      throw new Error(
+        `ServerConnector.getIosDevicesSizes - unexpected status (${response.statusText})`,
+      )
+    }
+  }
 }
 
 module.exports = ServerConnector

--- a/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
@@ -459,6 +459,14 @@ function cachify(getterFunction, cacheRegardlessOfArgs = false) {
   return cachedGetter
 }
 
+function getBreakpointWidth(breakpoints, width) {
+  if (!TypeUtils.isArray(breakpoints) || breakpoints.length === 0) {
+    return width
+  }
+  const breakpoint = breakpoints.find(breakpoint => breakpoint > width)
+  return breakpoint ? breakpoint - 1 : breakpoints[breakpoints.length - 1]
+}
+
 module.exports = {
   urlConcat,
   stripTrailingSlash,
@@ -486,4 +494,5 @@ module.exports = {
   presult,
   pexec,
   cachify,
+  getBreakpointWidth,
 }

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -4,7 +4,8 @@ const {
   getProcessPageAndSerializePoll,
   getProcessPageAndSerializePollForIE,
 } = require('@applitools/dom-snapshot')
-const {GeneralUtils, deserializeDomSnapshotResult} = require('@applitools/eyes-sdk-core')
+const GeneralUtils = require('./GeneralUtils')
+const deserializeDomSnapshotResult = require('./deserializeDomSnapshotResult')
 
 const PULL_TIMEOUT = 200 // ms
 const CAPTURE_DOM_TIMEOUT_MS = 5 * 60 * 1000 // 5 min
@@ -29,9 +30,9 @@ async function getScriptForIE() {
   return captureScriptIE
 }
 
-async function takeDomSnapshot({executeScript, startTime = Date.now(), browser}) {
+async function takeDomSnapshot({driver, startTime = Date.now(), browser}) {
   const processPageAndPollScript = browser === 'IE' ? await getScriptForIE() : await getScript()
-  const resultAsString = await executeScript(processPageAndPollScript)
+  const resultAsString = await driver.execute(processPageAndPollScript)
 
   const scriptResponse = JSON.parse(resultAsString)
 
@@ -44,7 +45,7 @@ async function takeDomSnapshot({executeScript, startTime = Date.now(), browser})
   }
 
   await GeneralUtils.sleep(PULL_TIMEOUT)
-  return takeDomSnapshot({executeScript, startTime})
+  return takeDomSnapshot({driver, startTime})
 }
 
 module.exports = takeDomSnapshot

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@applitools/sdk-fake-eyes-server": "^2.0.0",
     "@applitools/sdk-release-kit": "0.2.2",
-    "@applitools/visual-grid-client": "14.7.3",
+    "@applitools/visual-grid-client": "14.7.5",
     "assert-rejects": "1.0.0",
     "chai": "4.2.0",
     "chai-uuid": "1.0.6",

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -33,6 +33,7 @@
   "typings": "./typings/index.d.ts",
   "dependencies": {
     "@applitools/dom-capture": "7.2.6",
+    "@applitools/dom-snapshot": "4.0.5",
     "@applitools/isomorphic-fetch": "3.0.0",
     "@applitools/snippets": "1.0.3",
     "axios": "0.19.2",

--- a/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
+++ b/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
@@ -625,4 +625,16 @@ describe('Configuration', () => {
     const config = new Configuration({defaultMatchSettings: {matchLevel: 'Layout'}})
     assert.strictEqual(config.getMatchLevel(), MatchLevel.Layout)
   })
+
+  it('setLayoutBreakpoints()', async () => {
+    const config = new Configuration()
+    config.setLayoutBreakpoints(true)
+    assert.deepStrictEqual(config.getLayoutBreakpoints(), true)
+    config.setLayoutBreakpoints([25, 50, 100, 200])
+    assert.deepStrictEqual(config.getLayoutBreakpoints(), [25, 50, 100, 200])
+    config.setLayoutBreakpoints([100, 200, 200, 100, 50, 25])
+    assert.deepStrictEqual(config.getLayoutBreakpoints(), [25, 50, 100, 200])
+    config.setLayoutBreakpoints([])
+    assert.deepStrictEqual(config.getLayoutBreakpoints(), false)
+  })
 })

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
@@ -83,6 +83,20 @@ describe('CheckSettings', () => {
     })
   })
 
+  it('layoutBreakpoints', async () => {
+    const checkSettings = new CheckSettings()
+    checkSettings.layoutBreakpoints()
+    assert.deepStrictEqual(checkSettings.getLayoutBreakpoints(), true)
+    checkSettings.layoutBreakpoints(false)
+    assert.deepStrictEqual(checkSettings.getLayoutBreakpoints(), false)
+    checkSettings.layoutBreakpoints([25, 50, 100, 200])
+    assert.deepStrictEqual(checkSettings.getLayoutBreakpoints(), [25, 50, 100, 200])
+    checkSettings.layoutBreakpoints([100, 200, 200, 100, 50, 25])
+    assert.deepStrictEqual(checkSettings.getLayoutBreakpoints(), [25, 50, 100, 200])
+    checkSettings.layoutBreakpoints([])
+    assert.deepStrictEqual(checkSettings.getLayoutBreakpoints(), false)
+  })
+
   // TODO this test makes more sense to run inside docker
   it('resilient to duplicate copies of the SDK', async () => {
     const context = {

--- a/packages/eyes-sdk-core/test/unit/sdk/EyesVisualGrid.spec.js
+++ b/packages/eyes-sdk-core/test/unit/sdk/EyesVisualGrid.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const assert = require('assert')
+const {EyesVisualGrid} = require('../../utils/FakeSDK')
+
+describe('EyesVisualGrid', () => {
+  describe('getBrowserSize(browser)', () => {
+    let eyes
+
+    before(async () => {
+      eyes = new EyesVisualGrid()
+      eyes._serverConnector.getEmulatedDevicesSizes = async () => {
+        return {
+          emulated1: {portrait: {width: 1, height: 11}, landscape: {width: 11, height: 1}},
+          emulated2: {portrait: {width: 2, height: 22}, landscape: {width: 22, height: 2}},
+        }
+      }
+      eyes._serverConnector.getIosDevicesSizes = async () => {
+        return {
+          ios1: {portrait: {width: 10, height: 110}, landscape: {width: 110, height: 10}},
+        }
+      }
+    })
+
+    it('works with desktop browser', async () => {
+      const browser = {name: 'browser1', width: 3, height: 33}
+      assert.deepStrictEqual(await eyes.getBrowserSize(browser), {width: 3, height: 33})
+    })
+
+    it('works with emulated device syntax', async () => {
+      const device1 = {deviceName: 'emulated1'}
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1), {width: 1, height: 11})
+      const device1Portrait = {deviceName: 'emulated1', screenOrientation: 'portrait'}
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1Portrait), {width: 1, height: 11})
+      const device1Landscape = {deviceName: 'emulated1', screenOrientation: 'landscape'}
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1Landscape), {width: 11, height: 1})
+      const device2 = {chromeEmulationInfo: {deviceName: 'emulated2'}}
+      assert.deepStrictEqual(await eyes.getBrowserSize(device2), {width: 2, height: 22})
+      const device2Portrait = {
+        chromeEmulationInfo: {deviceName: 'emulated2', screenOrientation: 'portrait'},
+      }
+      assert.deepStrictEqual(await eyes.getBrowserSize(device2Portrait), {width: 2, height: 22})
+      const device2Landscape = {
+        chromeEmulationInfo: {deviceName: 'emulated2', screenOrientation: 'landscape'},
+      }
+      assert.deepStrictEqual(await eyes.getBrowserSize(device2Landscape), {width: 22, height: 2})
+    })
+
+    it('works with ios device syntax', async () => {
+      const device1 = {iosDeviceInfo: {deviceName: 'ios1'}}
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1), {width: 10, height: 110})
+      const device1Portrait = {
+        iosDeviceInfo: {deviceName: 'ios1', screenOrientation: 'portrait'},
+      }
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1Portrait), {width: 10, height: 110})
+      const device1Landscape = {
+        iosDeviceInfo: {deviceName: 'ios1', screenOrientation: 'landscape'},
+      }
+      assert.deepStrictEqual(await eyes.getBrowserSize(device1Landscape), {width: 110, height: 10})
+    })
+  })
+})

--- a/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
@@ -391,4 +391,15 @@ describe('GeneralUtils', () => {
       process.env.APPLITOOLS_MY_FLAG = undefined
     })
   })
+
+  describe('getBreakpointWidth()', () => {
+    it('works', () => {
+      assert.strictEqual(GeneralUtils.getBreakpointWidth([100], 50), 99)
+      assert.strictEqual(GeneralUtils.getBreakpointWidth([100], 150), 100)
+      assert.strictEqual(GeneralUtils.getBreakpointWidth([100, 300], 150), 299)
+      assert.strictEqual(GeneralUtils.getBreakpointWidth([100, 300], 500), 300)
+      assert.strictEqual(GeneralUtils.getBreakpointWidth([], 33), 33)
+      assert.strictEqual(GeneralUtils.getBreakpointWidth(null, 33), 33)
+    })
+  })
 })

--- a/packages/sdk-shared/coverage-tests/generic/spec-emitter.js
+++ b/packages/sdk-shared/coverage-tests/generic/spec-emitter.js
@@ -44,6 +44,7 @@ function makeSpecEmitter(options) {
   addHook('deps', `const path = require('path')`)
   addHook('deps', `const assert = require('assert')`)
   addHook('deps', `const spec = require(path.resolve(cwd, 'src/SpecDriver'))`)
+  addHook('deps', `const {Configuration} = require(cwd)`)
   addHook('deps', `const {testSetup} = require('@applitools/sdk-shared')`)
 
   addHook('vars', `let driver`)
@@ -113,6 +114,9 @@ function makeSpecEmitter(options) {
       setViewportSize(viewportSize) {
         addCommand(js`await eyes.constructor.setViewportSize(driver, ${viewportSize})`)
       },
+    },
+    setConfiguration(config) {
+      addCommand(js`await eyes.setConfiguration(new Configuration(${config}))`)
     },
     runner: {
       getAllTestResults(throwEx) {

--- a/packages/sdk-shared/coverage-tests/generic/supported-tests.js
+++ b/packages/sdk-shared/coverage-tests/generic/supported-tests.js
@@ -328,4 +328,5 @@ module.exports = [
   {name: 'TestHorizonalScroll', executionMode: {isCssStitching: true}},
   {name: 'TestHorizonalScroll', executionMode: {isScrollStitching: true}},
   {name: 'TestGetAllTestResults', executionMode: {isCssStitching: true}},
+  {name: 'CheckWindowOnJsLayoutPage', executionMode: {isVisualGrid: true}},
 ]

--- a/packages/sdk-shared/src/render.js
+++ b/packages/sdk-shared/src/render.js
@@ -101,6 +101,10 @@ const args = yargs
     describe: 'comma-separated list of selectors for layout regions',
     type: 'string',
   })
+  .option('layout-breakpoints', {
+    describe: 'comma-separated list of breakpoints (widths) for js layouts',
+    type: 'string',
+  })
   .option('viewport-size', {
     describe: 'the viewport size to open the browser (widthxheight)',
     type: 'string',
@@ -345,6 +349,14 @@ if (!url && !args.attach) {
         target,
         args.layoutRegions.split(',').map(s => s.trim()),
       )
+    }
+
+    if (args.hasOwnProperty('layoutBreakpoints')) {
+      let layoutBreakpoints
+      if (['', 'true', '1'].includes(args.layoutBreakpoints)) layoutBreakpoints = true
+      else if (['false', '0'].includes(args.layoutBreakpoints)) layoutBreakpoints = false
+      else layoutBreakpoints = args.layoutBreakpoints.split(',').map(s => Number.parseInt(s.trim()))
+      target.layoutBreakpoints(layoutBreakpoints)
     }
 
     if (args.scrollRootElement) {

--- a/packages/sdk-shared/src/render.js
+++ b/packages/sdk-shared/src/render.js
@@ -104,6 +104,7 @@ const args = yargs
   .option('layout-breakpoints', {
     describe: 'comma-separated list of breakpoints (widths) for js layouts',
     type: 'string',
+    coerce: parseLayoutBreakpoints,
   })
   .option('viewport-size', {
     describe: 'the viewport size to open the browser (widthxheight)',
@@ -352,11 +353,7 @@ if (!url && !args.attach) {
     }
 
     if (args.hasOwnProperty('layoutBreakpoints')) {
-      let layoutBreakpoints
-      if (['', 'true', '1'].includes(args.layoutBreakpoints)) layoutBreakpoints = true
-      else if (['false', '0'].includes(args.layoutBreakpoints)) layoutBreakpoints = false
-      else layoutBreakpoints = args.layoutBreakpoints.split(',').map(s => Number.parseInt(s.trim()))
-      target.layoutBreakpoints(layoutBreakpoints)
+      target.layoutBreakpoints(args.layoutBreakpoints)
     }
 
     if (args.scrollRootElement) {
@@ -504,6 +501,12 @@ function parseBrowser(arg) {
     )
 
   return {name: match[1], width: parseInt(match[3], 10), height: parseInt(match[5], 10)}
+}
+
+function parseLayoutBreakpoints(arg) {
+  if (['', 'true'].includes(arg)) return true
+  else if (['false'].includes(arg)) return false
+  else return arg.split(',').map(s => Number.parseInt(s.trim()))
 }
 
 /**

--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- move `takeDomSnapshot` to `eyes-sdk-core`
 
 ## 14.7.5 - 2020/8/13
 

--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added support for multiple dom snapshots for `checkWindow`, `testWindow` and `takeScreenshot`
+- removed @applitools/dom-snapshot from dependencies
 - move `takeDomSnapshot` to `eyes-sdk-core`
 
 ## 14.7.5 - 2020/8/13

--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- added support for multiple dom snapshots for `checkWindow`, `testWindow` and `takeScreenshot`
+- Breaking change: added support for multiple dom snapshots for `checkWindow`, `testWindow` and `takeScreenshot`
 - removed @applitools/dom-snapshot from dependencies
 - move `takeDomSnapshot` to `eyes-sdk-core`
 

--- a/packages/visual-grid-client/package.json
+++ b/packages/visual-grid-client/package.json
@@ -31,7 +31,6 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@applitools/dom-snapshot": "4.0.3",
     "@applitools/eyes-sdk-core": "12.1.4",
     "@applitools/functional-commons": "1.5.4",
     "@applitools/http-commons": "2.3.12",
@@ -49,6 +48,7 @@
     "@applitools/jsdom": false
   },
   "devDependencies": {
+    "applitools/dom-snapshot": "4.0.3",
     "@applitools/sdk-release-kit": "0.2.2",
     "@applitools/sdk-shared": "0.1.0",
     "chai": "^4.2.0",

--- a/packages/visual-grid-client/package.json
+++ b/packages/visual-grid-client/package.json
@@ -48,7 +48,7 @@
     "@applitools/jsdom": false
   },
   "devDependencies": {
-    "applitools/dom-snapshot": "4.0.3",
+    "@applitools/dom-snapshot": "4.0.5",
     "@applitools/sdk-release-kit": "0.2.2",
     "@applitools/sdk-shared": "0.1.0",
     "chai": "^4.2.0",

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -32,10 +32,6 @@ function makeCheckWindow({
   visualGridOptions: _visualGridOptions,
 }) {
   return function checkWindow({
-    // resourceUrls = [],
-    // resourceContents = {},
-    // frames = [],
-    // cdt,
     snapshot,
     url,
     tag,
@@ -283,15 +279,7 @@ function makeCheckWindow({
         return
       }
 
-      const results = await getResourcesPromise
-      const {dom, resources} = results.reduce(
-        (results, {rGridDom, allResources}) => {
-          results.dom.push(rGridDom)
-          results.resources.push(Object.values(allResources))
-          return results
-        },
-        {dom: [], resources: []},
-      )
+      const pages = await getResourcesPromise
 
       if (testController.shouldStopAllTests()) {
         logger.log(`aborting startRender because there was an error in getAllResources`)
@@ -300,8 +288,7 @@ function makeCheckWindow({
 
       const renderRequests = createRenderRequests({
         url,
-        dom,
-        resources,
+        pages,
         browsers,
         renderInfo,
         sizeMode,

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -36,7 +36,7 @@ function makeCheckWindow({
     // resourceContents = {},
     // frames = [],
     // cdt,
-    snapshots,
+    snapshot,
     url,
     tag,
     target = 'window',
@@ -58,6 +58,8 @@ function makeCheckWindow({
     ignoreDisplacements,
     visualGridOptions = _visualGridOptions,
   }) {
+    const snapshots = Array.isArray(snapshot) ? snapshot : Array(browsers.length).fill(snapshot)
+
     if (target === 'window' && !fully) {
       sizeMode = 'viewport'
     } else if (target === 'region' && selector) {

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -32,11 +32,12 @@ function makeCheckWindow({
   visualGridOptions: _visualGridOptions,
 }) {
   return function checkWindow({
-    resourceUrls = [],
-    resourceContents = {},
-    frames = [],
+    // resourceUrls = [],
+    // resourceContents = {},
+    // frames = [],
+    // cdt,
+    snapshots,
     url,
-    cdt,
     tag,
     target = 'window',
     fully = true,
@@ -80,22 +81,28 @@ function makeCheckWindow({
 
     if (typeof window === 'undefined') {
       const handleBrowserDebugData = require('../troubleshoot/handleBrowserDebugData')
-      handleBrowserDebugData({
-        frame: {resourceUrls, resourceContents, frames, cdt, url},
-        metaData: {agentId: wrappers[0].getBaseAgentId()},
-        logger,
+      snapshots.forEach(snapshot => {
+        handleBrowserDebugData({
+          frame: snapshot,
+          metaData: {agentId: wrappers[0].getBaseAgentId()},
+          logger,
+        })
       })
     }
 
-    const getResourcesPromise = createRGridDOMAndGetResourceMapping({
-      resourceUrls,
-      resourceContents,
-      cdt,
-      frames,
-      userAgent,
-      referer: url,
-      proxySettings: wrappers[0].getProxy(),
-    })
+    const getResourcesPromise = Promise.all(
+      snapshots.map(snapshot =>
+        createRGridDOMAndGetResourceMapping({
+          resourceUrls: snapshot.resourceUrls,
+          resourceContents: snapshot.resourceContents,
+          cdt: snapshot.cdt,
+          frames: snapshot.frames,
+          userAgent,
+          referer: url,
+          proxySettings: wrappers[0].getProxy(),
+        }),
+      ),
+    )
 
     const noOffsetSelectors = {
       all: [ignore, layout, strict, content, accessibility],
@@ -274,7 +281,15 @@ function makeCheckWindow({
         return
       }
 
-      const {rGridDom: dom, allResources: resources} = await getResourcesPromise
+      const results = await getResourcesPromise
+      const {dom, resources} = results.reduce(
+        (results, {rGridDom, allResources}) => {
+          results.dom.push(rGridDom)
+          results.resources.push(Object.values(allResources))
+          return results
+        },
+        {dom: [], resources: []},
+      )
 
       if (testController.shouldStopAllTests()) {
         logger.log(`aborting startRender because there was an error in getAllResources`)
@@ -284,7 +299,7 @@ function makeCheckWindow({
       const renderRequests = createRenderRequests({
         url,
         dom,
-        resources: Object.values(resources),
+        resources,
         browsers,
         renderInfo,
         sizeMode,
@@ -307,8 +322,8 @@ function makeCheckWindow({
       globalState.setQueuedRendersCount(globalState.getQueuedRendersCount() - 1)
 
       if (saveDebugData) {
-        for (const renderId of renderIds) {
-          await saveData({renderId, cdt, resources, url, logger})
+        for (const [index, renderId] of renderIds.entries()) {
+          await saveData({renderId, cdt: snapshots[index].cdt, resources, url, logger})
         }
       }
 

--- a/packages/visual-grid-client/src/sdk/createRenderRequests.js
+++ b/packages/visual-grid-client/src/sdk/createRenderRequests.js
@@ -26,8 +26,8 @@ function createRenderRequests({
     offsetSelectors,
   })
 
-  return browsers.map(
-    ({
+  return browsers.map((browser, index) => {
+    const {
       width,
       height,
       name,
@@ -37,42 +37,41 @@ function createRenderRequests({
       mobile,
       platform,
       iosDeviceInfo,
-    }) => {
-      const emulationInfo = createEmulationInfo({
-        deviceName,
-        screenOrientation,
-        deviceScaleFactor,
-        mobile,
+    } = browser
+    const emulationInfo = createEmulationInfo({
+      deviceName,
+      screenOrientation,
+      deviceScaleFactor,
+      mobile,
+      width,
+      height,
+    })
+    const filledBrowserName = iosDeviceInfo && !name ? 'safari' : name
+    const filledPlatform = iosDeviceInfo && !platform ? 'ios' : platform
+
+    return new RenderRequest({
+      webhook: renderInfo.getResultsUrl(),
+      stitchingService: renderInfo.getStitchingServiceUrl(),
+      url,
+      resources: resources[index],
+      dom: dom[index],
+      renderInfo: new RenderInfo({
         width,
         height,
-      })
-      const filledBrowserName = iosDeviceInfo && !name ? 'safari' : name
-      const filledPlatform = iosDeviceInfo && !platform ? 'ios' : platform
-
-      return new RenderRequest({
-        webhook: renderInfo.getResultsUrl(),
-        stitchingService: renderInfo.getStitchingServiceUrl(),
-        url,
-        resources,
-        dom,
-        renderInfo: new RenderInfo({
-          width,
-          height,
-          sizeMode,
-          selector,
-          region,
-          emulationInfo,
-          iosDeviceInfo,
-        }),
-        browserName: filledBrowserName,
-        scriptHooks,
-        selectorsToFindRegionsFor,
-        sendDom,
-        platform: filledPlatform,
-        visualGridOptions,
-      })
-    },
-  )
+        sizeMode,
+        selector,
+        region,
+        emulationInfo,
+        iosDeviceInfo,
+      }),
+      browserName: filledBrowserName,
+      scriptHooks,
+      selectorsToFindRegionsFor,
+      sendDom,
+      platform: filledPlatform,
+      visualGridOptions,
+    })
+  })
 }
 
 module.exports = createRenderRequests

--- a/packages/visual-grid-client/src/sdk/createRenderRequests.js
+++ b/packages/visual-grid-client/src/sdk/createRenderRequests.js
@@ -6,8 +6,7 @@ const calculateSelectorsToFindRegionsFor = require('./calculateSelectorsToFindRe
 
 function createRenderRequests({
   url,
-  resources,
-  dom,
+  pages,
   browsers,
   renderInfo,
   sizeMode,
@@ -53,8 +52,8 @@ function createRenderRequests({
       webhook: renderInfo.getResultsUrl(),
       stitchingService: renderInfo.getStitchingServiceUrl(),
       url,
-      resources: resources[index],
-      dom: dom[index],
+      resources: Object.values(pages[index].allResources),
+      dom: pages[index].rGridDom,
       renderInfo: new RenderInfo({
         width,
         height,

--- a/packages/visual-grid-client/src/sdk/takeScreenshot.js
+++ b/packages/visual-grid-client/src/sdk/takeScreenshot.js
@@ -36,26 +36,16 @@ async function takeScreenshot({
     renderingInfo,
   })
 
-  const results = await Promise.all(
+  const pages = await Promise.all(
     snapshots.map(snapshot => {
       const {resourceUrls, resourceContents, frames, cdt} = deserializeDomSnapshotResult(snapshot)
       return createRGridDOMAndGetResourceMapping({resourceUrls, resourceContents, frames, cdt})
     }),
   )
 
-  const {dom, resources} = results.reduce(
-    (results, {rGridDom, allResources}) => {
-      results.dom.push(rGridDom)
-      results.resources.push(Object.values(allResources))
-      return results
-    },
-    {dom: [], resources: []},
-  )
-
   const renderRequests = createRenderRequests({
     url,
-    dom,
-    resources,
+    pages,
     browsers,
     renderInfo: renderingInfo,
     sizeMode,

--- a/packages/visual-grid-client/src/visual-grid-client.js
+++ b/packages/visual-grid-client/src/visual-grid-client.js
@@ -10,14 +10,11 @@ const {
 const makeVisualGridClient = require('./sdk/renderingGridClient')
 const configParams = require('./sdk/configParams')
 const takeScreenshot = require('./sdk/takeScreenshot')
-const takeDomSnapshot = require('./utils/takeDomSnapshot')
 
 module.exports = {
   configParams,
   makeVisualGridClient,
   takeScreenshot,
-  capturePageDom: takeDomSnapshot, // TODO: should be removed later (used from WDIO SDKs)
-  takeDomSnapshot,
   DiffsFoundError,
   TestResults,
   TestFailedError,

--- a/packages/visual-grid-client/test/browser/browser.e2e.test.js
+++ b/packages/visual-grid-client/test/browser/browser.e2e.test.js
@@ -64,7 +64,7 @@ describe('browser visual grid', () => {
         );
 
         checkWindow({
-          snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
+          snapshot: {resourceUrls, resourceContents, cdt},
           tag: 'first',
           url,
         });

--- a/packages/visual-grid-client/test/browser/browser.e2e.test.js
+++ b/packages/visual-grid-client/test/browser/browser.e2e.test.js
@@ -64,9 +64,7 @@ describe('browser visual grid', () => {
         );
 
         checkWindow({
-          resourceUrls,
-          resourceContents,
-          cdt,
+          snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
           tag: 'first',
           url,
         });

--- a/packages/visual-grid-client/test/e2e/openEyes.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/openEyes.e2e.test.js
@@ -95,7 +95,7 @@ describe('openEyes', () => {
     }
 
     checkWindow({
-      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
+      snapshot: {resourceUrls, resourceContents, cdt},
       tag: 'first',
       url,
       scriptHooks,
@@ -133,7 +133,7 @@ describe('openEyes', () => {
     cdt.find(node => node.nodeValue === "hi, I'm red").nodeValue = 'WRONG TEXT'
 
     checkWindow({
-      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
+      snapshot: {resourceUrls, resourceContents, cdt},
       tag: 'first',
       url,
       scriptHooks,

--- a/packages/visual-grid-client/test/e2e/openEyes.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/openEyes.e2e.test.js
@@ -95,9 +95,7 @@ describe('openEyes', () => {
     }
 
     checkWindow({
-      resourceUrls,
-      resourceContents,
-      cdt,
+      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
       tag: 'first',
       url,
       scriptHooks,
@@ -135,9 +133,7 @@ describe('openEyes', () => {
     cdt.find(node => node.nodeValue === "hi, I'm red").nodeValue = 'WRONG TEXT'
 
     checkWindow({
-      resourceUrls,
-      resourceContents,
-      cdt,
+      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
       tag: 'first',
       url,
       scriptHooks,

--- a/packages/visual-grid-client/test/e2e/render.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/render.e2e.test.js
@@ -41,7 +41,7 @@ describe('render e2e', () => {
       renderingInfo,
     })
 
-    const {rGridDom: dom, allResources: resources} = await createRGridDOMAndGetResourceMapping({
+    const page = await createRGridDOMAndGetResourceMapping({
       resourceUrls: [],
       resourceContents: [],
       cdt: [{nodeType: 3, nodeValue: 'renders older browser versions - works!'}],
@@ -50,8 +50,7 @@ describe('render e2e', () => {
 
     const renderRequests = createRenderRequests({
       url: 'http://something',
-      dom: Array(browsers.length).fill(dom),
-      resources: Array(browsers.length).fill(Object.values(resources)),
+      pages: Array(browsers.length).fill(page),
       browsers,
       renderInfo: renderingInfo,
       sizeMode: 'full-page',

--- a/packages/visual-grid-client/test/e2e/render.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/render.e2e.test.js
@@ -41,7 +41,7 @@ describe('render e2e', () => {
       renderingInfo,
     })
 
-    const {rGridDom: dom, allResources: _} = await createRGridDOMAndGetResourceMapping({
+    const {rGridDom: dom, allResources: resources} = await createRGridDOMAndGetResourceMapping({
       resourceUrls: [],
       resourceContents: [],
       cdt: [{nodeType: 3, nodeValue: 'renders older browser versions - works!'}],
@@ -50,8 +50,8 @@ describe('render e2e', () => {
 
     const renderRequests = createRenderRequests({
       url: 'http://something',
-      dom,
-      resources: [],
+      dom: Array(browsers.length).fill(dom),
+      resources: Array(browsers.length).fill(Object.values(resources)),
       browsers,
       renderInfo: renderingInfo,
       sizeMode: 'full-page',

--- a/packages/visual-grid-client/test/e2e/takeScreenshot.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/takeScreenshot.e2e.test.js
@@ -39,11 +39,8 @@ describe('takeScreenshot e2e', () => {
         apiKey,
         showLogs: process.env.APPLITOOLS_SHOW_LOGS,
         renderInfo,
-        cdt,
+        snapshot: {cdt, resourceUrls, blobs, frames},
         url,
-        resourceUrls,
-        blobs,
-        frames,
         browsers: [{width: 1920, height: 1440}],
       }),
     )

--- a/packages/visual-grid-client/test/e2e/testWindow.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/testWindow.e2e.test.js
@@ -66,9 +66,7 @@ describe('testWindow', () => {
     }
 
     const checkParams = {
-      resourceUrls,
-      resourceContents,
-      cdt,
+      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
       tag: 'first',
       url,
       scriptHooks: {
@@ -100,9 +98,7 @@ describe('testWindow', () => {
 
     cdt.find(node => node.nodeValue === "hi, I'm red").nodeValue = 'WRONG TEXT'
     const checkParams = {
-      resourceUrls,
-      resourceContents,
-      cdt,
+      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
       tag: 'first',
       url,
       scriptHooks: {

--- a/packages/visual-grid-client/test/e2e/testWindow.e2e.test.js
+++ b/packages/visual-grid-client/test/e2e/testWindow.e2e.test.js
@@ -66,7 +66,7 @@ describe('testWindow', () => {
     }
 
     const checkParams = {
-      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
+      snapshot: {resourceUrls, resourceContents, cdt},
       tag: 'first',
       url,
       scriptHooks: {
@@ -98,7 +98,7 @@ describe('testWindow', () => {
 
     cdt.find(node => node.nodeValue === "hi, I'm red").nodeValue = 'WRONG TEXT'
     const checkParams = {
-      snapshot: Array(3).fill({resourceUrls, resourceContents, cdt}),
+      snapshot: {resourceUrls, resourceContents, cdt},
       tag: 'first',
       url,
       scriptHooks: {

--- a/packages/visual-grid-client/test/it/closeEyes.it.test.js
+++ b/packages/visual-grid-client/test/it/closeEyes.it.test.js
@@ -50,7 +50,11 @@ describe('closeEyes', () => {
       wrappers: [wrapper],
       appName,
     })
-    checkWindow({cdt: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: {cdt: [], resourceUrls: []},
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     const [err, result] = await presult(close())
     console.log('err', err)
     expect(err).to.be.undefined
@@ -62,7 +66,11 @@ describe('closeEyes', () => {
       wrappers: [wrapper],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'bad!', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: {cdt: [], resourceUrls: []},
+      tag: 'bad!',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close()))[0]
     expect(result[0].message).to.equal('Tag bad! should be one of the good tags good1,good2')
@@ -78,7 +86,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'ok-in-1-test', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'ok-in-1-test',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close()))[0]
     expect(result[0].message).to.equal(
@@ -97,7 +109,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close()))[0]
     expect(result[0].getStepsInfo().map(r => r.result.getAsExpected())).to.eql([true])
@@ -115,7 +131,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const resultWithErr = (await presult(close()))[0]
     expect(resultWithErr[0].message).to.equal('mismatch')
@@ -133,7 +153,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const [, resultWithErr] = await presult(close(false))
     expect(resultWithErr[0].message).to.equal('mismatch')
@@ -157,7 +181,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const resultWithErr = (await presult(close()))[0]
     expect(resultWithErr[0].message).to.equal('render error')
@@ -181,7 +209,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const resultWithErr = (await presult(close(false)))[1]
     expect(resultWithErr[0].message).to.equal('render error')
@@ -197,7 +229,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await abort()
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const resultWithErr = (await presult(close()))[0]
@@ -222,7 +258,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await close()
 
     // this simulates setting batchId: 'secondBatchId' in openEyes
@@ -251,7 +291,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'good1', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'good1',
+      url: `${baseUrl}/basic.html`,
+    })
     await abort()
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const resultWithErr = (await presult(close(false)))[1]
@@ -271,7 +315,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'ok-in-1-test', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(3).fill({cdt: [], resourceUrls: []}),
+      tag: 'ok-in-1-test',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close()))[0]
     expect(result[0].message).to.equal('mismatch')
@@ -294,7 +342,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'ok', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'ok',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close()))[0]
     expect(result[0].message).to.equal('mismatch')
@@ -314,7 +366,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'ok', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      tag: 'ok',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close(false)))[1]
     expect(result[0].message).to.equal('mismatch')
@@ -334,7 +390,11 @@ describe('closeEyes', () => {
       ],
       appName,
     })
-    checkWindow({cdt: [], resourceUrls: [], tag: 'ok-in-1-test', url: `${baseUrl}/basic.html`})
+    checkWindow({
+      snapshot: Array(3).fill({cdt: [], resourceUrls: []}),
+      tag: 'ok-in-1-test',
+      url: `${baseUrl}/basic.html`,
+    })
     await psetTimeout(0) // because FakeEyesWrapper throws, and then the error is set async and will be read in the next call to close()
     const result = (await presult(close(false)))[1]
     expect(result[0].message).to.equal('mismatch')

--- a/packages/visual-grid-client/test/it/closeEyes.it.test.js
+++ b/packages/visual-grid-client/test/it/closeEyes.it.test.js
@@ -87,7 +87,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'ok-in-1-test',
       url: `${baseUrl}/basic.html`,
     })
@@ -110,7 +110,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -132,7 +132,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -154,7 +154,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -182,7 +182,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -210,7 +210,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -230,7 +230,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -259,7 +259,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -292,7 +292,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'good1',
       url: `${baseUrl}/basic.html`,
     })
@@ -316,7 +316,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(3).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'ok-in-1-test',
       url: `${baseUrl}/basic.html`,
     })
@@ -343,7 +343,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'ok',
       url: `${baseUrl}/basic.html`,
     })
@@ -367,7 +367,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(2).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'ok',
       url: `${baseUrl}/basic.html`,
     })
@@ -391,7 +391,7 @@ describe('closeEyes', () => {
       appName,
     })
     checkWindow({
-      snapshot: Array(3).fill({cdt: [], resourceUrls: []}),
+      snapshot: {cdt: [], resourceUrls: []},
       tag: 'ok-in-1-test',
       url: `${baseUrl}/basic.html`,
     })

--- a/packages/visual-grid-client/test/it/openEyes.it.test.js
+++ b/packages/visual-grid-client/test/it/openEyes.it.test.js
@@ -78,7 +78,7 @@ describe('openEyes', () => {
 
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
-    checkWindow({resourceUrls, cdt, tag: 'good1', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'good1', url: `${baseUrl}/test.html`})
     expect((await close())[0].getStepsInfo().map(r => r.result.getAsExpected())).to.eql([true])
   })
 
@@ -91,7 +91,7 @@ describe('openEyes', () => {
     const cdt = loadJsonFixture('test.cdt.json')
     cdt.find(node => node.nodeValue === "hi, I'm red").nodeValue = "hi, I'm green"
 
-    checkWindow({resourceUrls, cdt, tag: 'good1', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'good1', url: `${baseUrl}/test.html`})
     const result = (await presult(close()))[0]
     expect(result[0].message).to.equal('mismatch')
   })
@@ -113,7 +113,7 @@ describe('openEyes', () => {
 
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
-    checkWindow({resourceUrls, cdt, tag: 'good1', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'good1', url: `${baseUrl}/test.html`})
     expect(
       (await close()).map(wrapperResult =>
         wrapperResult.getStepsInfo().map(r2 => r2.result.getAsExpected()),
@@ -200,8 +200,7 @@ describe('openEyes', () => {
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
     checkWindow({
-      resourceUrls,
-      cdt,
+      snapshot: {resourceUrls, cdt},
       tag: 'good1',
       target: 'some target',
       url: `${baseUrl}/test.html`,
@@ -246,9 +245,9 @@ describe('openEyes', () => {
 
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
-    checkWindow({resourceUrls, cdt, tag: 'one', url: `${baseUrl}/test.html`})
-    checkWindow({resourceUrls, cdt, tag: 'two', url: `${baseUrl}/test.html`})
-    checkWindow({resourceUrls, cdt, tag: 'three', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'one', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'two', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {resourceUrls, cdt}, tag: 'three', url: `${baseUrl}/test.html`})
     expect((await close()).map(r => r.getStepsInfo().map(s => s.result))).to.eql([
       ['one1', 'two1', 'three1'],
       ['one2', 'two2', 'three2'],
@@ -278,7 +277,7 @@ describe('openEyes', () => {
 
     wrapper.goodResourceUrls = [blobUrl, imageUrl]
 
-    checkWindow({cdt: [], resourceContents, tag: 'good1', url: `${baseUrl}/test.html`})
+    checkWindow({snapshot: {cdt: [], resourceContents}, tag: 'good1', url: `${baseUrl}/test.html`})
     expect((await close())[0].getStepsInfo().map(r => r.result.getAsExpected())).to.eql([true])
   })
 
@@ -288,7 +287,7 @@ describe('openEyes', () => {
       appName,
     })
 
-    checkWindow({cdt: [], url: 'some url', selector: '.some selector'})
+    checkWindow({snapshot: {cdt: []}, url: 'some url', selector: '.some selector'})
     expect((await close())[0].getStepsInfo().map(r => r.result.getAsExpected())).to.eql([true])
   })
 
@@ -299,7 +298,7 @@ describe('openEyes', () => {
     })
 
     checkWindow({
-      cdt: [],
+      snapshot: {cdt: []},
       url: 'some url',
       region: {width: 1, height: 2, left: 3, top: 4},
       target: 'region',
@@ -318,8 +317,7 @@ describe('openEyes', () => {
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
     checkWindow({
-      resourceUrls,
-      cdt,
+      snapshot: {resourceUrls, cdt},
       tag: 'good1',
       sizeMode: 'some size mode',
       url: `${baseUrl}/test.html`,
@@ -587,9 +585,9 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: `bla`})
     await psetTimeout(0)
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: `bla`})
     error = await close().then(
       x => x,
       err => err,
@@ -607,9 +605,9 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: `bla`})
     await psetTimeout(0)
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: `bla`})
     error = await close().then(
       x => x,
       err => err,
@@ -730,7 +728,7 @@ Received: 'firefox-1'.`,
         wrappers: [wrapper],
         appName,
       })
-      checkWindow({cdt: [], url: 'url'})
+      checkWindow({snapshot: {cdt: []}, url: 'url'})
       const err1 = await close().then(
         x => x,
         err => err,
@@ -744,7 +742,7 @@ Received: 'firefox-1'.`,
         psetTimeout(100).then(() => ({close: 'not resolved'})),
       ])
       expect(close2).not.to.equal('not resolved')
-      checkWindow2({cdt: [], url: 'url'})
+      checkWindow2({snapshot: {cdt: []}, url: 'url'})
       const result2 = await close2().then(
         x => x,
         err => err,
@@ -856,14 +854,14 @@ Received: 'firefox-1'.`,
 
       // t1
       expect(wrapper1Counters.open).to.equal(1)
-      checkWindow1({cdt: [], url: 'url'})
+      checkWindow1({snapshot: {cdt: []}, url: 'url'})
       await psetTimeout(0)
       expect(wrapper1Counters.render).to.equal(0)
       await psetTimeout(50)
 
       // t2
       expect(wrapper1Counters.render).to.equal(0)
-      checkWindow1({cdt: [], url: 'url'})
+      checkWindow1({snapshot: {cdt: []}, url: 'url'})
       await psetTimeout(0)
       expect(wrapper1Counters.render).to.equal(0)
       expect(wrapper1Counters.renderStatus).to.equal(0)
@@ -889,14 +887,14 @@ Received: 'firefox-1'.`,
 
       // t5
       expect(wrapper1Counters.render).to.equal(2)
-      checkWindow2({cdt: [], url: 'url'})
+      checkWindow2({snapshot: {cdt: []}, url: 'url'})
       await psetTimeout(50)
 
       // t6
       expect(wrapper1Counters.render).to.equal(2)
       expect(wrapper1Counters.renderStatus).to.equal(2)
       expect(wrapper2Counters.open).to.equal(0)
-      checkWindow2({cdt: [], url: 'url'})
+      checkWindow2({snapshot: {cdt: []}, url: 'url'})
       await psetTimeout(50)
 
       // t7
@@ -996,17 +994,17 @@ Received: 'firefox-1'.`,
         wrappers: [wrapper],
         appName,
       })
-      checkWindow({url: '', cdt: [], target: null, sizeMode: null})
+      checkWindow({url: '', snapshot: {cdt: []}, target: null, sizeMode: null})
       await psetTimeout(0)
       expect(renderCount).to.equal(1)
       expect(renderStatusCount).to.equal(0) // still batching initial renderIds for /render-status request
 
-      checkWindow({url: '', cdt: [], target: null, sizeMode: null})
+      checkWindow({url: '', snapshot: {cdt: []}, target: null, sizeMode: null})
       await psetTimeout(0)
       expect(renderCount).to.equal(2)
       expect(renderStatusCount).to.equal(0) // still batching initial renderIds for /render-status request
 
-      checkWindow({url: '', cdt: [], target: null, sizeMode: null})
+      checkWindow({url: '', snapshot: {cdt: []}, target: null, sizeMode: null})
       await psetTimeout(0)
       expect(renderCount).to.equal(2) // concurrency is blocking this render
       expect(renderStatusCount).to.equal(0) // still batching initial renderIds for /render-status request
@@ -1040,9 +1038,9 @@ Received: 'firefox-1'.`,
         appName,
       })
 
-      checkWindow({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
-      checkWindow({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
       const expected1 = renderCount
       runningStatuses[0] = RenderStatus.RENDERED
@@ -1071,16 +1069,16 @@ Received: 'firefox-1'.`,
         appName,
       })
 
-      checkWindow({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
 
-      checkWindow2({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow2({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
 
-      checkWindow({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
 
-      checkWindow2({url: '', cdt: [], sizeMode: null, target: null})
+      checkWindow2({url: '', snapshot: {cdt: []}, sizeMode: null, target: null})
       await psetTimeout(0)
 
       const expected1 = renderCount
@@ -1113,7 +1111,7 @@ Received: 'firefox-1'.`,
         appName,
       })
 
-      checkWindow({url: '', cdt: [], selector: '111'})
+      checkWindow({url: '', snapshot: {cdt: []}, selector: '111'})
       await psetTimeout(0)
       expect(renderCount).to.equal(1)
       expect(renderStatusCount).to.equal(0)
@@ -1121,7 +1119,7 @@ Received: 'firefox-1'.`,
       await psetTimeout(150)
       expect(renderStatusCount).to.equal(1)
 
-      checkWindow({url: '', cdt: [], selector: '222'})
+      checkWindow({url: '', snapshot: {cdt: []}, selector: '222'})
       await psetTimeout(0)
       expect(renderCount).to.equal(1)
       expect(renderStatusCount).to.equal(1)
@@ -1160,9 +1158,9 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: 'bla', tag: 'good1'})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: 'bla', tag: 'good1'})
     await psetTimeout(150)
-    checkWindow({resourceUrls: [], cdt: [], url: 'bla', tag: 'good1'})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: 'bla', tag: 'good1'})
 
     const [err3] = await presult(close())
     expect(err3[0].message).to.have.string(failMsg())
@@ -1187,9 +1185,9 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: 'bla', tag: 'good1'})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: 'bla', tag: 'good1'})
     await psetTimeout(0)
-    checkWindow({resourceUrls: [], cdt: [], url: 'bla', tag: 'good1'})
+    checkWindow({snapshot: {resourceUrls: [], cdt: []}, url: 'bla', tag: 'good1'})
     await psetTimeout(200)
     const [err3] = await presult(close())
     expect(err3[0].message).have.string(failMsg())
@@ -1388,8 +1386,7 @@ Received: 'firefox-1'.`,
     const region2 = {left: 11, top: 22, width: 33, height: 44, accessibilityType: 'LargeText'}
     checkWindow({
       url: '',
-      // resourceUrls: [],
-      cdt: [],
+      snapshot: {cdt: []},
       ignore: [region],
       accessibility: [region2],
     })
@@ -1415,8 +1412,7 @@ Received: 'firefox-1'.`,
     const regionContent = {left: 11, top: 21, width: 31, height: 41}
     checkWindow({
       url: '',
-      // resourceUrls: [],
-      cdt: [],
+      snapshot: {cdt: []},
       layout: [regionLayout],
       strict: [regionStrict],
       content: [regionContent],
@@ -1533,8 +1529,7 @@ Received: 'firefox-1'.`,
 
     checkWindow({
       url: '',
-      // resourceUrls: [],
-      cdt: [],
+      snapshot: {cdt: []},
       ignore: [ignoreSelector1, ignoreSelector2],
       layout: [layoutSelector1, layoutSelector2],
       strict: [strictSelector1, strictSelector2],
@@ -1597,8 +1592,7 @@ Received: 'firefox-1'.`,
 
     checkWindow({
       url: '',
-      // resourceUrls: [],
-      cdt: [],
+      snapshot: {cdt: []},
       target: 'region',
       selector,
       ignore: [ignoreRegion, ignoreSelector],
@@ -1721,8 +1715,7 @@ Received: 'firefox-1'.`,
 
     checkWindow({
       url: '',
-      // resourceUrls: [],
-      cdt: [],
+      snapshot: {cdt: []},
       target: 'region',
       selector,
       ignore: [ignoreRegion, ignoreSelector],
@@ -1823,15 +1816,12 @@ Received: 'firefox-1'.`,
     })
     checkWindow({
       url: '',
-      cdt: [],
+      snapshot: {cdt: []},
       useDom: true,
       enablePatterns: false,
       ignoreDisplacements: false,
     })
-    checkWindow({
-      url: '',
-      cdt: [],
-    })
+    checkWindow({url: '', snapshot: {cdt: []}})
     const [results] = await close()
     const r = results.getStepsInfo()[0].result
     const r2 = results.getStepsInfo()[1].result
@@ -1884,7 +1874,7 @@ Received: 'firefox-1'.`,
       aborted = true
     })
 
-    await checkWindow({url: '', cdt: []})
+    await checkWindow({url: '', snapshot: {cdt: []}})
     await abort()
     await donePromise
     expect(checkEndedAfterAbort).to.be.false
@@ -1917,7 +1907,7 @@ Received: 'firefox-1'.`,
       aborted = true
     })
 
-    await checkWindow({url: '', cdt: []})
+    await checkWindow({url: '', snapshot: {cdt: []}})
     await abort()
     await donePromise
     expect(openEndedAfterAbort).to.be.false
@@ -1931,7 +1921,7 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({url: '', cdt: []})
+    checkWindow({url: '', snapshot: {cdt: []}})
     const [results] = await close()
     expect(wrapper.getViewportSize()).to.eql(FakeEyesWrapper.devices['iPhone 4'])
     expect(wrapper.getDeviceInfo()).to.equal(`${deviceName} (Chrome emulation)`)
@@ -1950,7 +1940,7 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({url: '', cdt: []})
+    checkWindow({url: '', snapshot: {cdt: []}})
     const [results] = await close()
     expect(wrapper.getDeviceInfo()).to.equal(deviceName)
     expect(wrapper.iosDeviceInfo).to.eql(iosDeviceInfo)
@@ -1968,7 +1958,7 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({url: '', cdt: []})
+    checkWindow({url: '', snapshot: {cdt: []}})
     const [results] = await close()
     expect(wrapper.results[0].__browserName).to.equal('safari')
     expect(wrapper.results[0].__platform).to.equal('ios')
@@ -2011,7 +2001,7 @@ Received: 'firefox-1'.`,
       wrappers: [wrapper],
       appName,
     })
-    checkWindow({cdt: [], frames, url})
+    checkWindow({snapshot: {cdt: [], frames}, url})
     const ttt = await close()
     expect(ttt[0].getStepsInfo().map(r => r.result.getAsExpected())).to.eql([true])
   })
@@ -2060,11 +2050,11 @@ Received: 'firefox-1'.`,
       wrappers: [wrapper],
       appName,
     })
-    checkWindow({tag: 1, cdt: [], url: ''})
+    checkWindow({tag: 1, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({matchLevel: 'Layout', tag: 2, cdt: [], url: ''})
+    checkWindow({matchLevel: 'Layout', tag: 2, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({tag: 3, cdt: [], url: ''})
+    checkWindow({tag: 3, snapshot: {cdt: []}, url: ''})
     await close()
   })
 
@@ -2083,11 +2073,11 @@ Received: 'firefox-1'.`,
       appName,
       matchLevel: 'Content',
     })
-    checkWindow({tag: 1, cdt: [], url: ''})
+    checkWindow({tag: 1, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({matchLevel: 'Layout', tag: 2, cdt: [], url: ''})
+    checkWindow({matchLevel: 'Layout', tag: 2, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({tag: 3, cdt: [], url: ''})
+    checkWindow({tag: 3, snapshot: {cdt: []}, url: ''})
     await close()
   })
 
@@ -2113,11 +2103,11 @@ Received: 'firefox-1'.`,
       wrappers: [wrapper],
       appName,
     })
-    checkWindow({tag: 1, cdt: [], url: ''})
+    checkWindow({tag: 1, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({matchLevel: 'Layout', tag: 2, cdt: [], url: ''})
+    checkWindow({matchLevel: 'Layout', tag: 2, snapshot: {cdt: []}, url: ''})
     await psetTimeout(0)
-    checkWindow({tag: 3, cdt: [], url: ''})
+    checkWindow({tag: 3, snapshot: {cdt: []}, url: ''})
     await close()
   })
 
@@ -2220,7 +2210,13 @@ Received: 'firefox-1'.`,
     })
     wrapper.on('checkWindowEnd', done)
 
-    await checkWindow({tag: 'good1', cdt: [], url: '', useDom: true, enablePatterns: true})
+    await checkWindow({
+      snapshot: {cdt: []},
+      url: '',
+      tag: 'good1',
+      useDom: true,
+      enablePatterns: true,
+    })
     await donePromise
     const [results] = await close()
     const r = results.getStepsInfo()[0].result
@@ -2251,7 +2247,13 @@ Received: 'firefox-1'.`,
     })
     wrapper.on('checkWindowEnd', done)
 
-    await checkWindow({tag: 'good1', cdt: [], url: '', useDom: false, enablePatterns: false})
+    await checkWindow({
+      snapshot: {cdt: []},
+      url: '',
+      tag: 'good1',
+      useDom: false,
+      enablePatterns: false,
+    })
     await donePromise
     const [results] = await close()
     const r = results.getStepsInfo()[0].result
@@ -2272,7 +2274,7 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    await checkWindow({cdt: [], url: ''})
+    await checkWindow({snapshot: {cdt: []}, url: ''})
     const [results] = await close()
     const r = results.getStepsInfo()[0].getRenderId()
     expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
@@ -2291,7 +2293,7 @@ Received: 'firefox-1'.`,
       visualGridOptions: {aaa: true},
     })
 
-    await checkWindow({cdt: [], url: ''})
+    await checkWindow({snapshot: {cdt: []}, url: ''})
     const [results] = await close()
     const r = results.getStepsInfo()[0].getRenderId()
     expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
@@ -2309,7 +2311,11 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    await checkWindow({cdt: [], url: '', visualGridOptions: {aaa: true}})
+    await checkWindow({
+      snapshot: {cdt: []},
+      url: '',
+      visualGridOptions: {aaa: true},
+    })
     const [results] = await close()
     const r = results.getStepsInfo()[0].getRenderId()
     expect(JSON.parse(r).visualGridOptions).to.eql({aaa: true})
@@ -2340,7 +2346,10 @@ Received: 'firefox-1'.`,
         {width: 1, height: 2, name: 'edgechromium-one-version-back'},
       ],
     })
-    checkWindow({cdt: [], url: ''})
+    checkWindow({
+      snapshot: {cdt: []},
+      url: '',
+    })
     await close()
     expect(wrapper1.results[0].__browserName).to.equal('chrome-1')
     expect(wrapper2.results[0].__browserName).to.equal('chrome-2')
@@ -2363,7 +2372,10 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({
+      snapshot: {resourceUrls: [], cdt: []},
+      url: `bla`,
+    })
     const [err] = await presult(close())
     expect(err[0].message).to.equal('renderBatch')
     expect(wrapper.inferredEnvironment).to.equal('useragent:firefox-ua')
@@ -2390,7 +2402,10 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({
+      snapshot: {resourceUrls: [], cdt: []},
+      url: `bla`,
+    })
     const [err] = await presult(close())
     expect(err[0].message).to.equal('renderBatch')
     expect(wrapper1.inferredEnvironment).to.equal('useragent:firefox-ua')
@@ -2420,7 +2435,10 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({
+      snapshot: {resourceUrls: [], cdt: []},
+      url: `bla`,
+    })
     const [err] = await presult(close())
     expect(err[0].message).to.contain('renderStatusError')
     expect(wrapper.inferredEnvironment).to.equal('some ua')
@@ -2449,7 +2467,10 @@ Received: 'firefox-1'.`,
       appName,
     })
 
-    checkWindow({resourceUrls: [], cdt: [], url: `bla`})
+    checkWindow({
+      snapshot: {resourceUrls: [], cdt: []},
+      url: `bla`,
+    })
     const [err] = await presult(close())
     expect(err[0].message).to.contain('renderStatusError')
     expect(wrapper.inferredEnvironment).to.equal('useragent:firefox-ua')

--- a/packages/visual-grid-client/test/it/testWindow.it.test.js
+++ b/packages/visual-grid-client/test/it/testWindow.it.test.js
@@ -50,7 +50,7 @@ describe('testWindow', () => {
     }
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
-    const checkParams = {resourceUrls, cdt, tag: 'good1', url: `${baseUrl}/test.html`}
+    const checkParams = {snapshot: {resourceUrls, cdt}, tag: 'good1', url: `${baseUrl}/test.html`}
 
     let done
     const p = new Promise(r => (done = r))
@@ -193,7 +193,7 @@ describe('testWindow', () => {
     }
     const resourceUrls = wrapper.goodResourceUrls
     const cdt = loadJsonFixture('test.cdt.json')
-    const checkParams = {resourceUrls, cdt, tag: 'good1', url: `${baseUrl}/test.html`}
+    const checkParams = {snapshot: {resourceUrls, cdt}, tag: 'good1', url: `${baseUrl}/test.html`}
 
     wrapper.closeTestWindow = () => {
       return Promise.reject(new Error('test diff'))

--- a/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
+++ b/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
@@ -44,8 +44,7 @@ describe('createRenderRequests', () => {
 
     const renderRequests = createRenderRequests({
       url,
-      resources: Array(browsers.length).fill(resources),
-      dom: Array(browsers.length).fill(dom),
+      pages: Array(browsers.length).fill({rGridDom: dom, allResources: resources}),
       browsers,
       renderInfo,
       sizeMode,
@@ -108,8 +107,7 @@ describe('createRenderRequests', () => {
     const browsers = [{deviceName, screenOrientation}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [resources],
-      dom: [dom],
+      pages: [{rGridDom: dom, allResources: resources}],
       browsers,
       renderInfo,
       noOffsetSelectors: [],
@@ -143,8 +141,7 @@ describe('createRenderRequests', () => {
     }
     const renderRequests = createRenderRequests({
       url,
-      resources: [resources],
-      dom: [dom],
+      pages: [{rGridDom: dom, allResources: resources}],
       browsers,
       renderInfo,
       noOffsetSelectors: [],
@@ -190,8 +187,7 @@ describe('createRenderRequests', () => {
     const floating = [{some: 'thing'}, {type: 'css', selector: 'sel'}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [resources],
-      dom: [dom],
+      pages: [{rGridDom: dom, allResources: resources}],
       browsers,
       renderInfo,
       noOffsetSelectors: [ignore, layout, strict, content, accessibility],
@@ -236,8 +232,7 @@ describe('createRenderRequests', () => {
     const browsers = [{iosDeviceInfo}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [resources],
-      dom: [dom],
+      pages: [{rGridDom: dom, allResources: resources}],
       browsers,
       renderInfo,
     })
@@ -273,8 +268,11 @@ describe('createRenderRequests', () => {
     const dom2 = createRGridDom({resources: {}, cdt: 'cdt2'})
     const renderRequests = createRenderRequests({
       url,
-      resources: [resources, resources, resources],
-      dom: [dom1, dom2, dom1],
+      pages: [
+        {rGridDom: dom1, allResources: resources},
+        {rGridDom: dom2, allResources: resources},
+        {rGridDom: dom1, allResources: resources},
+      ],
       browsers,
       renderInfo,
     })

--- a/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
+++ b/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
@@ -6,7 +6,7 @@ const createRenderRequests = require('../../../src/sdk/createRenderRequests')
 const createRGridDom = require('../../../src/sdk/createRGridDom')
 
 describe('createRenderRequests', () => {
-  let url, renderInfo, dom, rGridDom
+  let url, renderInfo, dom, domObj, resources, resourcesObj
 
   beforeEach(() => {
     url = 'url'
@@ -15,12 +15,14 @@ describe('createRenderRequests', () => {
       getStitchingServiceUrl: () => 'stitchingServiceUrl',
     }
     const cdt = 'cdt'
-    dom = {
+    domObj = {
       contentType: 'x-applitools-html/cdt',
       hash: getSha256Hash(JSON.stringify({resources: {}, domNodes: cdt})),
       hashFormat: 'sha256',
     }
-    rGridDom = createRGridDom({resources: {}, cdt})
+    dom = createRGridDom({resources: {}, cdt})
+    resources = []
+    resourcesObj = {}
   })
 
   it('works', () => {
@@ -29,6 +31,7 @@ describe('createRenderRequests', () => {
     const url = 'url'
     const cdt = 'cdt'
     const resources = [r1, r2]
+    const dom = createRGridDom({resources: {['url1']: r1, ['url2']: r2}, cdt})
     const browsers = [
       {width: 1, height: 2, name: 'b1'},
       {width: 3, height: 4, name: 'b2'},
@@ -41,8 +44,8 @@ describe('createRenderRequests', () => {
 
     const renderRequests = createRenderRequests({
       url,
-      resources,
-      dom: createRGridDom({resources: {['url1']: r1, ['url2']: r2}, cdt}),
+      resources: Array(browsers.length).fill(resources),
+      dom: Array(browsers.length).fill(dom),
       browsers,
       renderInfo,
       sizeMode,
@@ -55,7 +58,7 @@ describe('createRenderRequests', () => {
     })
 
     const resourcesObj = {url1: 'hash1', url2: 'hash2'}
-    const dom = {
+    const domObj = {
       contentType: 'x-applitools-html/cdt',
       hash: getSha256Hash(JSON.stringify({resources: resourcesObj, domNodes: 'cdt'})),
       hashFormat: 'sha256',
@@ -66,7 +69,7 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
+        dom: domObj,
         resources: resourcesObj,
         browser: {name: 'b1'},
         scriptHooks,
@@ -83,7 +86,7 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
+        dom: domObj,
         resources: resourcesObj,
         browser: {name: 'b2'},
         scriptHooks,
@@ -105,8 +108,8 @@ describe('createRenderRequests', () => {
     const browsers = [{deviceName, screenOrientation}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [],
-      dom: rGridDom,
+      resources: [resources],
+      dom: [dom],
       browsers,
       renderInfo,
       noOffsetSelectors: [],
@@ -118,8 +121,8 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
-        resources: {},
+        dom: domObj,
+        resources: resourcesObj,
         renderInfo: {
           emulationInfo: {deviceName, screenOrientation},
           height: undefined,
@@ -140,8 +143,8 @@ describe('createRenderRequests', () => {
     }
     const renderRequests = createRenderRequests({
       url,
-      resources: [],
-      dom: rGridDom,
+      resources: [resources],
+      dom: [dom],
       browsers,
       renderInfo,
       noOffsetSelectors: [],
@@ -153,8 +156,8 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
-        resources: {},
+        dom: domObj,
+        resources: resourcesObj,
         renderInfo: {
           emulationInfo: {
             width: 1,
@@ -187,8 +190,8 @@ describe('createRenderRequests', () => {
     const floating = [{some: 'thing'}, {type: 'css', selector: 'sel'}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [],
-      dom: rGridDom,
+      resources: [resources],
+      dom: [dom],
       browsers,
       renderInfo,
       noOffsetSelectors: [ignore, layout, strict, content, accessibility],
@@ -200,8 +203,8 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
-        resources: {},
+        dom: domObj,
+        resources: resourcesObj,
         renderInfo: {
           height: 2,
           width: 1,
@@ -233,8 +236,8 @@ describe('createRenderRequests', () => {
     const browsers = [{iosDeviceInfo}]
     const renderRequests = createRenderRequests({
       url,
-      resources: [],
-      dom: rGridDom,
+      resources: [resources],
+      dom: [dom],
       browsers,
       renderInfo,
     })
@@ -244,8 +247,8 @@ describe('createRenderRequests', () => {
         webhook: 'resultsUrl',
         stitchingService: 'stitchingServiceUrl',
         url,
-        dom,
-        resources: {},
+        dom: domObj,
+        resources: resourcesObj,
         browser: {name: 'safari'},
         platform: {name: 'ios'},
         renderInfo: {

--- a/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
+++ b/packages/visual-grid-client/test/unit/sdk/createRenderRequests.test.js
@@ -262,4 +262,43 @@ describe('createRenderRequests', () => {
       },
     ])
   })
+
+  it('handles multiple dom snapshots', () => {
+    const browsers = [
+      {width: 1, height: 1, name: '1'},
+      {width: 2, height: 2, name: '2'},
+      {width: 3, height: 3, name: '1'},
+    ]
+    const dom1 = createRGridDom({resources: {}, cdt: 'cdt1'})
+    const dom2 = createRGridDom({resources: {}, cdt: 'cdt2'})
+    const renderRequests = createRenderRequests({
+      url,
+      resources: [resources, resources, resources],
+      dom: [dom1, dom2, dom1],
+      browsers,
+      renderInfo,
+    })
+
+    expect(renderRequests.map(r => r.toJSON())).to.eql(
+      browsers.map(browser => ({
+        webhook: 'resultsUrl',
+        stitchingService: 'stitchingServiceUrl',
+        url,
+        dom: {
+          contentType: 'x-applitools-html/cdt',
+          hash: getSha256Hash(JSON.stringify({resources: {}, domNodes: `cdt${browser.name}`})),
+          hashFormat: 'sha256',
+        },
+        resources: resourcesObj,
+        browser: {name: browser.name},
+        renderInfo: {
+          width: browser.width,
+          height: browser.height,
+          region: undefined,
+          selector: undefined,
+          sizeMode: undefined,
+        },
+      })),
+    )
+  })
 })


### PR DESCRIPTION
This PR still needs to be finished. I need to fix tests in `visual-grid-client`. But first I would like to know an opinion about the direction I choose.
The idea is to provide an array of snapshots (same as an array of browsers) where each snapshot has the same index as related browser in its array.