### PR TITLE
Add disableBrowserFetching configuration

### DIFF
--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -245,6 +245,9 @@ class Configuration {
     /** @type {number[]|boolean} */
     this._layoutBreakpoints = undefined
 
+    /** @type {boolean} */
+    this._disableBrowserFetching = undefined
+
     if (configuration) {
       this.mergeConfig(configuration)
     }
@@ -1316,6 +1319,15 @@ class Configuration {
     } else {
       this._layoutBreakpoints = Array.from(new Set(breakpoints)).sort((a, b) => (a < b ? 1 : -1))
     }
+    return this
+  }
+
+  getDisableBrowserFetching() {
+    return this._disableBrowserFetching
+  }
+
+  setDisableBrowserFetching(value) {
+    this._disableBrowserFetching = value
     return this
   }
 

--- a/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
@@ -295,6 +295,9 @@ class CheckSettings {
     if (object.layoutBreakpoints) {
       settings.layoutBreakpoints(object.layoutBreakpoints)
     }
+    if (object.disableBrowserFetching) {
+      settings.disableBrowserFetching()
+    }
     return settings
   }
   /**
@@ -972,6 +975,13 @@ class CheckSettings {
   }
   getLayoutBreakpoints() {
     return this._layoutBreakpoints
+  }
+  disableBrowserFetching(value = true) {
+    this._disableBrowserFetching = value
+    return this
+  }
+  getDisableBrowserFetching() {
+    return this._disableBrowserFetching
   }
 
   /**

--- a/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
+++ b/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
@@ -52,6 +52,7 @@ const BOOLEAN_CONFIGS = [
   '_isThrowExceptionOn',
   '_dontCloseBatches',
   '_layoutBreakpoints',
+  '_disableBrowserFetching',
 ]
 
 const NUMBER_CONFIGS = [
@@ -177,6 +178,7 @@ describe('Configuration', () => {
       configuration.setIgnoreDisplacements(true)
       configuration.setMatchLevel(MatchLevel.Layout)
       configuration.setLayoutBreakpoints(true)
+      configuration.setDisableBrowserFetching(true)
 
       const configurationCopy = new Configuration(configuration)
 
@@ -186,6 +188,10 @@ describe('Configuration', () => {
       assert.strictEqual(
         configuration.getLayoutBreakpoints(),
         configurationCopy.getLayoutBreakpoints(),
+      )
+      assert.strictEqual(
+        configuration.getDisableBrowserFetching(),
+        configurationCopy.getDisableBrowserFetching(),
       )
       assert.strictEqual(
         configuration.getIgnoreDisplacements(),

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
@@ -30,6 +30,8 @@ describe('CheckSettings', () => {
       accessibilityRegions: ['accessibility-region-selector'],
       isFully: true,
       visualGridOptions: {polyfillAdoptedStyleSheets: true},
+      layoutBreakpoints: true,
+      disableBrowserFetching: true,
     }
     const checkSettings = CheckSettings.from(object)
 
@@ -53,6 +55,8 @@ describe('CheckSettings', () => {
       )
       .fully(object.isFully)
       .visualGridOption('polyfillAdoptedStyleSheets', true)
+      .layoutBreakpoints()
+      .disableBrowserFetching()
 
     assert.deepStrictEqual(checkSettings, checkSettings2)
   })

--- a/packages/sdk-shared/coverage-tests/custom/TestDisableBrowserFetching.spec.js
+++ b/packages/sdk-shared/coverage-tests/custom/TestDisableBrowserFetching.spec.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const path = require('path')
+const cwd = process.cwd()
+const startTestServer = require('../../src/test-server')
+const {Target} = require(cwd)
+const spec = require(path.resolve(cwd, 'src/SpecDriver'))
+const {getEyes} = require('../../src/test-setup')
+
+describe('TestDisableBrowserFetching', () => {
+  let testServer
+  let driver
+
+  before(async () => {
+    const staticPath = path.join(__dirname, '../fixtures')
+    testServer = await startTestServer({
+      port: 5555,
+      staticPath,
+      middlewareFile: path.resolve(__dirname, '../util/ua-middleware'),
+    })
+  })
+
+  after(async () => {
+    await testServer.close()
+  })
+
+  beforeEach(async () => {
+    driver = await spec.build({browser: 'chrome'})
+  })
+
+  afterEach(async () => {
+    await spec.cleanup(driver)
+  })
+
+  it('sends dontFetchResources to dom snapshot', async () => {
+    const url = 'http://localhost:5555/ua.html'
+    await spec.visit(driver, url)
+    const eyes = getEyes({isVisualGrid: true, configuration: {disableBrowserFetching: true}})
+    await eyes.open(driver, 'VgFetch', 'TestDisableBrowserFetching', {width: 800, height: 600})
+    await eyes.check(Target.window())
+    await eyes.close()
+  })
+})

--- a/packages/sdk-shared/coverage-tests/custom/TestVisualGridRefererHeader.spec.js
+++ b/packages/sdk-shared/coverage-tests/custom/TestVisualGridRefererHeader.spec.js
@@ -38,7 +38,7 @@ describe('TestVisualGridRefererHeader', () => {
   it('send referer header', async () => {
     const url = 'http://localhost:5555/cors.html'
     await spec.visit(driver, url)
-    const eyes = getEyes('VG')
+    const eyes = getEyes({isVisualGrid: true})
     await eyes.open(driver, 'VgFetch', ' VgFetch referer', {width: 800, height: 600})
     await eyes.check('referer', Target.window())
     await eyes.close()

--- a/packages/sdk-shared/coverage-tests/fixtures/ua.html
+++ b/packages/sdk-shared/coverage-tests/fixtures/ua.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>UA test page</title>
+</head>
+<body style="margin:20px;">
+  <div>UA test page</div>
+  <div class="hasImg" style="width: 200px; height: 200px;">Should have an image here (If SDK can fetch it).</div>
+  <style>
+    .hasImg {
+      background-image: url('smurfs.jpg');
+    }
+  </style>
+</body>
+</html>

--- a/packages/sdk-shared/coverage-tests/util/ua-middleware.js
+++ b/packages/sdk-shared/coverage-tests/util/ua-middleware.js
@@ -1,0 +1,12 @@
+// this middleware causes smurfs.jpg to be served only outside of the browser
+module.exports = (req, res, next) => {
+  if (req.url === '/smurfs.jpg') {
+    if (/Mozilla/.test(req.headers['user-agent'])) {
+      res.status(404).send('Not found')
+    } else {
+      next()
+    }
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
This PR adds `disableBrowserFetching` as a configuration parameter to both `Configuration` and `CheckSettings`.
It can serve as a guide to how to add configuration properties.
I was thinking how to test this, and thought it would be best to do an e2e test. Mainly because I wanted to verify that dom-snapshot receives `dontFetchResources`, but it's hard to validate without changing something fundamental: dom-snapshot is run today with no args, so it's hard to test its arguments if they are encoded in the script string. And I didn't want to change it and find myself in a rabbit hole.

So the test I did uses a local test server with a middleware that would serve an image only if it's fetched from Node.js. So I know that DS cannot fetch it and therefore the visual test is an indicator for passing the right configuration.