### PR TITLE
takeDomSnapshot.spec.js suggestion

### DIFF
--- a/packages/eyes-sdk-core/lib/utils/createFramesPaths.js
+++ b/packages/eyes-sdk-core/lib/utils/createFramesPaths.js
@@ -1,0 +1,21 @@
+function createFramesPaths(snapshot, path = []) {
+  const paths = snapshot.crossFramesXPaths
+    ? snapshot.crossFramesXPaths.map(selector => ({
+        path: path.concat(selector),
+        parentSnapshot: snapshot,
+      }))
+    : []
+
+  for (const frame of snapshot.frames) {
+    if (frame.selector) {
+      paths.push(...createFramesPaths(frame, path.concat(frame.selector)))
+    }
+  }
+
+  delete snapshot.selector
+  delete snapshot.crossFramesXPaths
+
+  return paths
+}
+
+module.exports = createFramesPaths

--- a/packages/eyes-sdk-core/test/it/takeDomSnapshot.spec.js
+++ b/packages/eyes-sdk-core/test/it/takeDomSnapshot.spec.js
@@ -35,14 +35,12 @@ describe('takeDomSnapshot', () => {
 
   it('should take a dom snapshot', async () => {
     driver.mockScript('dom-snapshot', function() {
-      return JSON.stringify(
-        generateSnapshotResponse({
-          cdt: 'cdt',
-          resourceUrls: 'resourceUrls',
-          blobs: [],
-          frames: [],
-        }),
-      )
+      return generateSnapshotResponse({
+        cdt: 'cdt',
+        resourceUrls: 'resourceUrls',
+        blobs: [],
+        frames: [],
+      })
     })
     const actualSnapshot = await takeDomSnapshot({driver: eyesDriver})
     expect(actualSnapshot).to.eql({
@@ -58,11 +56,9 @@ describe('takeDomSnapshot', () => {
 
   it('should take a dom snapshot with cross origin frames', async () => {
     driver.mockScript('dom-snapshot', function() {
-      const snapshot =
-        this.name === 'HTML[1]/BODY[1]/IFRAME[1]'
-          ? generateSnapshotResponse({cdt: 'frame-cdt'})
-          : generateSnapshotResponse({crossFramesXPaths: ['HTML[1]/BODY[1]/IFRAME[1]']})
-      return JSON.stringify(snapshot)
+      return this.name === 'HTML[1]/BODY[1]/IFRAME[1]'
+        ? generateSnapshotResponse({cdt: 'frame-cdt'})
+        : generateSnapshotResponse({crossFramesXPaths: ['HTML[1]/BODY[1]/IFRAME[1]']})
     })
     driver.mockElements([
       {
@@ -116,21 +112,17 @@ describe('takeDomSnapshot', () => {
       driver.mockScript('dom-snapshot', function() {
         switch (this.name) {
           case 'HTML[1]/BODY[1]/IFRAME[1]':
-            return JSON.stringify(
-              generateSnapshotResponse({
-                cdt: 'frame',
-                crossFramesXPaths: ['BODY[1]/IFRAME[1]'],
-              }),
-            )
+            return generateSnapshotResponse({
+              cdt: 'frame',
+              crossFramesXPaths: ['BODY[1]/IFRAME[1]'],
+            })
           case 'BODY[1]/IFRAME[1]':
-            return JSON.stringify(generateSnapshotResponse({cdt: 'nested frame'}))
+            return generateSnapshotResponse({cdt: 'nested frame'})
           default:
-            return JSON.stringify(
-              generateSnapshotResponse({
-                cdt: 'top page',
-                crossFramesXPaths: ['HTML[1]/BODY[1]/IFRAME[1]'],
-              }),
-            )
+            return generateSnapshotResponse({
+              cdt: 'top page',
+              crossFramesXPaths: ['HTML[1]/BODY[1]/IFRAME[1]'],
+            })
         }
       })
 
@@ -187,25 +179,21 @@ describe('takeDomSnapshot', () => {
     driver.mockScript('dom-snapshot', function() {
       switch (this.name) {
         case 'DIV[1]/SPAN[1]/DIV[1]/IFRAME[1]':
-          return JSON.stringify(
-            generateSnapshotResponse({
-              cdt: 'nested frame',
-              selector: 'DIV[1]/SPAN[1]/DIV[1]/IFRAME[1]',
-            }),
-          )
+          return generateSnapshotResponse({
+            cdt: 'nested frame',
+            selector: 'DIV[1]/SPAN[1]/DIV[1]/IFRAME[1]',
+          })
         default:
-          return JSON.stringify(
-            generateSnapshotResponse({
-              cdt: 'top page',
-              frames: [
-                generateSnapshotObject({
-                  cdt: 'frame',
-                  selector: 'DIV[1]/IFRAME[1]',
-                  crossFramesXPaths: ['DIV[1]/SPAN[1]/DIV[1]/IFRAME[1]'],
-                }),
-              ],
-            }),
-          )
+          return generateSnapshotResponse({
+            cdt: 'top page',
+            frames: [
+              generateSnapshotObject({
+                cdt: 'frame',
+                selector: 'DIV[1]/IFRAME[1]',
+                crossFramesXPaths: ['DIV[1]/SPAN[1]/DIV[1]/IFRAME[1]'],
+              }),
+            ],
+          })
       }
     })
 
@@ -240,7 +228,7 @@ describe('takeDomSnapshot', () => {
 })
 
 function generateSnapshotResponse(overrides) {
-  return {status: 'SUCCESS', value: generateSnapshotObject(overrides)}
+  return JSON.stringify({status: 'SUCCESS', value: generateSnapshotObject(overrides)})
 }
 
 function generateSnapshotObject(overrides) {

--- a/packages/eyes-sdk-core/test/unit/utils/createFramesPaths.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/createFramesPaths.spec.js
@@ -1,0 +1,38 @@
+const createFramesPaths = require('../../../lib/utils/createFramesPaths')
+const assert = require('assert')
+
+describe('createFramesPaths', () => {
+  it('should return an empty array when no cross frames exist', () => {
+    const snapshot = generateSnapshot()
+    const result = createFramesPaths(snapshot)
+    assert.strictEqual(result.length, 0)
+  })
+
+  it('should create a frame path map', () => {
+    const snapshot = generateSnapshot(['HTML[1]/BODY[1]'])
+    const result = createFramesPaths(snapshot)
+    assert.deepStrictEqual(result[0], {
+      parentSnapshot: {
+        cdt: [],
+        srcAttr: null,
+        resourceUrls: [],
+        blobs: [],
+        frames: [],
+        scriptVersion: 'mock script',
+      },
+      path: ['HTML[1]/BODY[1]'],
+    })
+  })
+
+  function generateSnapshot(crossFramesXPaths = []) {
+    return {
+      cdt: [],
+      srcAttr: null,
+      resourceUrls: [],
+      blobs: [],
+      frames: [],
+      crossFramesXPaths,
+      scriptVersion: 'mock script',
+    }
+  }
+})

--- a/packages/sdk-shared/coverage-tests/custom/TestCheckDomSnapshotCrossOriginFrames_VG.spec.js
+++ b/packages/sdk-shared/coverage-tests/custom/TestCheckDomSnapshotCrossOriginFrames_VG.spec.js
@@ -7,7 +7,7 @@ const {getEyes} = require('../../src/test-setup')
 const adjustUrlToDocker = require('../util/adjust-url-to-docker')
 
 describe('Coverage Tests', () => {
-  let driver, eyes, serverA, serverB, url
+  let driver, destroy, eyes, serverA, serverB, url
 
   beforeEach(async () => {
     url = adjustUrlToDocker('http://localhost:7373/handles/cors_frames/cors.hbs')
@@ -23,8 +23,7 @@ describe('Coverage Tests', () => {
       },
     })
     serverB = await testServer({port: 7374, staticPath})
-
-    driver = await spec.build({browser: 'chrome'})
+    ;[driver, destroy] = await spec.build({browser: 'chrome'})
     eyes = getEyes({
       isVisualGrid: true,
       branchName: 'master',
@@ -32,7 +31,7 @@ describe('Coverage Tests', () => {
   })
 
   afterEach(async () => {
-    await spec.cleanup(driver)
+    await destroy()
     await serverA.close()
     await serverB.close()
   })


### PR DESCRIPTION
There are several points here:

1. Be more explicit in tests. Don't try to DRY. Specifying what dom-snapshot returns should be specific to each test, so it should be mocked in each test, rather than in `beforeEach`.

2. Expecting a function to throw: `presult` is a helpful utility when you have an async function that might throw and you want to handle the error.

3. No need for try/catch if catching only throws the error

4. `generateSnapshotObject` is more general and you can specify any overriden property. This leaves room to test also blobs and resourceContents in the future.

5. `should throw an error if timeout is reached` didn't really do anything because it wasn't failing on timeout.

6. `generateSnapshotResponse` has less functionality than the previous `generateSnapshotObject`. If I want to generate an error or WIP response, I don't need that function. Clearer API.