### PR TITLE
Add "See details at ..." section at the beginning

### DIFF
--- a/packages/eyes-storybook/src/processResults.js
+++ b/packages/eyes-storybook/src/processResults.js
@@ -21,6 +21,8 @@ function processResults({results = [], totalTime, concurrency}) {
   );
   errors = flatten(errors).filter(({err}) => err.constructor.name === 'Error');
 
+  outputStr += `See details at ${(passedOrNew[0] || unresolved[0]).getAppUrls().getBatch()}\n\n`;
+
   outputStr += '[EYES: TEST RESULTS]:\n\n';
   if (passedOrNew.length > 0) {
     outputStr += testResultsOutput(passedOrNew);


### PR DESCRIPTION
We have over 1000 tests and output gets cut so we don't see the link to applitools.
I added the link to the beginning of the output as well so at least we can click it even the end is cut.

resolves #256 

This is an example for the output:
![image](https://user-images.githubusercontent.com/35173937/94012014-deaa5e00-fdb0-11ea-8693-16a92c61ae49.png)
