### PR TITLE
Override cors frame's src after dom snapshot is taken

### DIFF
--- a/packages/eyes-sdk-core/lib/utils/createFramesPaths.js
+++ b/packages/eyes-sdk-core/lib/utils/createFramesPaths.js
@@ -1,8 +1,9 @@
 function createFramesPaths({snapshot, path = [], logger}) {
-  const paths = snapshot.crossFramesSelectors
-    ? snapshot.crossFramesSelectors.map(selector => ({
+  const paths = snapshot.crossFrames
+    ? snapshot.crossFrames.map(({selector, index}) => ({
         path: path.concat(selector),
         parentSnapshot: snapshot,
+        cdtNode: snapshot.cdt[index],
       }))
     : []
 
@@ -13,7 +14,7 @@ function createFramesPaths({snapshot, path = [], logger}) {
   }
 
   logger.verbose(
-    `frames paths for ${snapshot.crossFramesSelectors}`,
+    `frames paths for ${snapshot.crossFrames}`,
     paths.map(({path}) => path.join('-->')).join(' , '),
   )
 

--- a/packages/eyes-sdk-core/lib/utils/deserializeDomSnapshotResult.js
+++ b/packages/eyes-sdk-core/lib/utils/deserializeDomSnapshotResult.js
@@ -8,7 +8,7 @@ function deserializeDomSnapshotResult(domSnapshotResult) {
   }
   delete ret.blobs
   delete ret.selector
-  delete ret.crossFramesSelectors
+  delete ret.crossFrames
   return ret
 }
 

--- a/packages/eyes-sdk-core/test/unit/utils/createFramesPaths.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/createFramesPaths.spec.js
@@ -8,7 +8,7 @@ describe('createFramesPaths', () => {
   it('should return an empty array when no cross frames exist', () => {
     const snapshot = {
       frames: [],
-      crossFramesSelectors: [],
+      crossFrames: [],
     }
     const result = createFramesPaths({snapshot, logger})
     assert.deepStrictEqual(result, [])
@@ -16,40 +16,47 @@ describe('createFramesPaths', () => {
 
   it('should create frame paths for cross origin frames', () => {
     const snapshot = {
+      cdt: [{nodeName: 'IFRAME'}],
       frames: [],
-      crossFramesSelectors: ['selector1'],
+      crossFrames: [{selector: 'selector1', index: 0}],
     }
     const result = createFramesPaths({snapshot, logger})
     assert.deepStrictEqual(result, [
       {
-        parentSnapshot: snapshot,
         path: ['selector1'],
+        parentSnapshot: snapshot,
+        cdtNode: snapshot.cdt[0],
       },
     ])
   })
 
   it('should create frame paths for frames that have cross origin frames', () => {
     const frameSnapshot = {
-      cdt: 'frame',
+      cdt: [{nodeName: 'IFRAME-1'}, {nodeName: 'NOT-IFRAME'}, {nodeName: 'IFRAME-2'}],
       frames: [],
-      crossFramesSelectors: ['selector1', 'selector2'],
+      crossFrames: [
+        {selector: 'selector1', index: 0},
+        {selector: 'selector2', index: 2},
+      ],
       selector: 'selector0',
     }
     const snapshot = {
       cdt: 'top',
       frames: [frameSnapshot],
-      crossFramesSelectors: [],
+      crossFrames: [],
     }
 
     const result = createFramesPaths({snapshot, logger})
     assert.deepStrictEqual(result, [
       {
-        parentSnapshot: frameSnapshot,
         path: ['selector0', 'selector1'],
+        parentSnapshot: frameSnapshot,
+        cdtNode: frameSnapshot.cdt[0],
       },
       {
-        parentSnapshot: frameSnapshot,
         path: ['selector0', 'selector2'],
+        parentSnapshot: frameSnapshot,
+        cdtNode: frameSnapshot.cdt[2],
       },
     ])
   })

--- a/packages/eyes-sdk-core/test/utils/MockDriver.js
+++ b/packages/eyes-sdk-core/test/utils/MockDriver.js
@@ -177,16 +177,16 @@ class MockDriver {
     }
     elements.push(element)
     if (element.frame) {
-      const contextId = Symbol('contextId' + Math.floor(Math.random() * 100))
+      const contextId = Symbol('contextId' + (element.name || Math.floor(Math.random() * 100)))
       this._contexts.set(contextId, {
         id: contextId,
         parentId: state.parentContextId,
         isCORS: state.isCORS,
         element,
-        document: {id: Symbol('documentId' + Math.floor(Math.random() * 100))},
+        document: {id: Symbol('documentId' + (element.name || Math.floor(Math.random() * 100)))},
         state: {
           get name() {
-            return element.selector
+            return element.name || element.selector
           },
         },
       })

--- a/packages/sdk-shared/coverage-tests/fixtures/cors_frames/cors.hbs
+++ b/packages/sdk-shared/coverage-tests/fixtures/cors_frames/cors.hbs
@@ -2,7 +2,8 @@
 <html>
 <body>
     <h1>Hello, I have a designer cross origin frame</h1>
-    <iframe src="{{ src }}"
-        style="display: flex; width: 100%; height: 100%; flex-direction: column;"></iframe>
+    <iframe src="{{ src }}" style="display: flex; width: 100%; height: 100%; flex-direction: column;"></iframe>
+    <iframe srcdoc="<script>location.replace('{{ src }}')</script>"></iframe>
+    <iframe src="./redirect.hbs"></iframe>
 </body>
 </html>

--- a/packages/sdk-shared/coverage-tests/fixtures/cors_frames/redirect.hbs
+++ b/packages/sdk-shared/coverage-tests/fixtures/cors_frames/redirect.hbs
@@ -1,0 +1,1 @@
+<script>location.replace('{{ src }}')</script>


### PR DESCRIPTION
[Trello](https://trello.com/c/iBY0LLki)
Related to https://github.com/applitools/dom-scripts/pull/10

- Fix the try-catch block around the context switching, since it catches and ignores all other errors as well. 
- Insert `data-applitools-src` attribute to each cors frame with a value of `frameSnapshot.url`