### PR TITLE
feat: batch close

### DIFF
--- a/packages/eyes-images/index.js
+++ b/packages/eyes-images/index.js
@@ -77,3 +77,4 @@ exports.FailureReports = core.FailureReports
 exports.TestResults = core.TestResults
 exports.TestResultsFormatter = core.TestResultsFormatter
 exports.TestResultsStatus = core.TestResultsStatus
+exports.BatchClose = core.BatchClose

--- a/packages/eyes-sdk-core/index.js
+++ b/packages/eyes-sdk-core/index.js
@@ -114,6 +114,7 @@ exports.ImageProvider = require('./lib/capture/ImageProvider')
 exports.ImageProviderFactory = require('./lib/capture/ImageProviderFactory')
 exports.CorsIframeHandle = require('./lib/capture/CorsIframeHandles')
 exports.CorsIframeHandler = require('./lib/capture/CorsIframeHandler')
+exports.BatchClose = require('./lib/close/BatchClose')
 
 exports.CutProvider = require('./lib/cropping/CutProvider')
 exports.FixedCutProvider = require('./lib/cropping/FixedCutProvider')

--- a/packages/eyes-sdk-core/index.js
+++ b/packages/eyes-sdk-core/index.js
@@ -114,7 +114,10 @@ exports.ImageProvider = require('./lib/capture/ImageProvider')
 exports.ImageProviderFactory = require('./lib/capture/ImageProviderFactory')
 exports.CorsIframeHandle = require('./lib/capture/CorsIframeHandles')
 exports.CorsIframeHandler = require('./lib/capture/CorsIframeHandler')
-exports.BatchClose = require('./lib/close/BatchClose')
+
+const closeBatch = require('./lib/close/closeBatch')
+const BatchClose = require('./lib/close/BatchClose')
+exports.BatchClose = () => BatchClose(closeBatch)
 
 exports.CutProvider = require('./lib/cropping/CutProvider')
 exports.FixedCutProvider = require('./lib/cropping/FixedCutProvider')

--- a/packages/eyes-sdk-core/index.js
+++ b/packages/eyes-sdk-core/index.js
@@ -116,8 +116,8 @@ exports.CorsIframeHandle = require('./lib/capture/CorsIframeHandles')
 exports.CorsIframeHandler = require('./lib/capture/CorsIframeHandler')
 
 const closeBatch = require('./lib/close/closeBatch')
-const BatchClose = require('./lib/close/BatchClose')
-exports.BatchClose = () => BatchClose(closeBatch)
+const makeBatchClose = require('./lib/close/BatchClose')
+exports.BatchClose = makeBatchClose(closeBatch)
 
 exports.CutProvider = require('./lib/cropping/CutProvider')
 exports.FixedCutProvider = require('./lib/cropping/FixedCutProvider')

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -1,39 +1,38 @@
 function makeBatchClose(closeBatch) {
   return function BatchClose() {
-    this._batchIds = null
-    this._serverUrl = null
-    this._apiKey = null
-    this._proxy = null
-
-    this.setBatchIds = function(batchIds) {
-      this._batchIds = batchIds
-      return this
+    const that = {
+      batchIds: null,
+      serverUrl: null,
+      apiKey: null,
+      proxy: null,
     }
 
-    this.setUrl = function(serverUrl) {
-      this._serverUrl = serverUrl
-      return this
+    that.setBatchIds = function(batchIds) {
+      that.batchIds = batchIds
+      return that
     }
 
-    this.setApiKey = function(apiKey) {
-      this._apiKey = apiKey
-      return this
+    that.setUrl = function(serverUrl) {
+      that.serverUrl = serverUrl
+      return that
     }
 
-    this.setProxy = function(proxy) {
-      this._proxy = proxy
-      return this
+    that.setApiKey = function(apiKey) {
+      that.apiKey = apiKey
+      return that
     }
 
-    this.close = async function() {
-      const serverUrl = this._serverUrl
-      const batchIds = this._batchIds
-      const apiKey = this._apiKey
-      const proxy = this._proxy
+    that.setProxy = function(proxy) {
+      that.proxy = proxy
+      return that
+    }
+
+    that.close = async function() {
+      const {batchIds, serverUrl, apiKey, proxy} = that
       await closeBatch({batchIds, serverUrl, apiKey, proxy})
     }
 
-    return this
+    return that
   }
 }
 

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -1,29 +1,22 @@
-'use strict'
+function BatchClose(closeBatch) {
+  this._batchIds = null
+  this._serverUrl = null
 
-const closeBatch = require('./closeBatch')
-
-class BatchClose {
-  constructor() {
-    this._batchIds = null
-    this._serverUrl = null
-    this._apiKey = null
-  }
-
-  setBatchIds(batchIds) {
+  this.setBatchIds = function(batchIds) {
     if (batchIds && batchIds.length > 0) {
       this._batchIds = batchIds
-      return this
     }
+    return this
   }
 
-  setUrl(serverUrl) {
+  this.setUrl = function(serverUrl) {
     if (serverUrl) {
       this._serverUrl = serverUrl
-      return this
     }
+    return this
   }
 
-  async close() {
+  this.close = async function() {
     try {
       const serverUrl = this._serverUrl
       const batchIds = this._batchIds
@@ -32,6 +25,8 @@ class BatchClose {
       throw new Error(error.message)
     }
   }
+
+  return this
 }
 
 module.exports = BatchClose

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -2,6 +2,8 @@ function makeBatchClose(closeBatch) {
   return function BatchClose() {
     this._batchIds = null
     this._serverUrl = null
+    this._apiKey = null
+    this._proxy = null
 
     this.setBatchIds = function(batchIds) {
       if (batchIds && batchIds.length > 0) {
@@ -17,11 +19,27 @@ function makeBatchClose(closeBatch) {
       return this
     }
 
+    this.setApiKey = function(apiKey) {
+      if (apiKey) {
+        this._apiKey = apiKey
+      }
+      return this
+    }
+
+    this.setProxy = function(proxy) {
+      if (proxy) {
+        this._proxy = proxy
+      }
+      return this
+    }
+
     this.close = async function() {
       try {
         const serverUrl = this._serverUrl
         const batchIds = this._batchIds
-        await closeBatch({batchIds, serverUrl})
+        const apiKey = this._apiKey
+        const proxy = this._apiKey
+        await closeBatch({batchIds, serverUrl, apiKey, proxy})
       } catch (error) {
         throw new Error(error.message)
       }

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -1,23 +1,18 @@
 'use strict'
 
-const ServerConnector = require('../server/ServerConnector')
-const RunningSession = require('../server/RunningSession')
-const Configuration = require('../config/Configuration')
-const Logger = require('../logging/Logger')
+const closeBatch = require('./closeBatch')
 
 class BatchClose {
-  constructor({batchIds = [], serverUrl, apiKey}) {
-    this._batchIds = batchIds
-    this._serverUrl = serverUrl
-    this._apiKey = apiKey
+  constructor() {
+    this._batchIds = null
+    this._serverUrl = null
+    this._apiKey = null
   }
 
   setBatchIds(batchIds) {
     if (batchIds && batchIds.length > 0) {
       this._batchIds = batchIds
       return this
-    } else {
-      // err handling ?
     }
   }
 
@@ -25,49 +20,16 @@ class BatchClose {
     if (serverUrl) {
       this._serverUrl = serverUrl
       return this
-    } else {
-      // err handling ?
     }
-  }
-
-  _setupServerConfig({serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
-    const configuration = new Configuration({serverUrl, apiKey})
-    const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
-
-    configuration.setServerUrl(serverUrl)
-    configuration.setApiKey(apiKey)
-
-    return {configuration, logger}
   }
 
   async close() {
     try {
       const serverUrl = this._serverUrl
       const batchIds = this._batchIds
-      return await this.closeBatch({batchIds, serverUrl})
+      await closeBatch({batchIds, serverUrl})
     } catch (error) {
-      // err handling ?
-    }
-  }
-
-  async closeBatch({batchIds, serverUrl}) {
-    try {
-      const {logger, configuration} = this._setupServerConfig(serverUrl)
-      // getAgentId ?
-      const getAgentId = () => 'core/close'
-      const server = new ServerConnector({logger, configuration, getAgentId})
-
-      for (const batchId of batchIds) {
-        // isAborted and save?
-        const isAborted = false
-        const save = false
-        // should I use RunningSession?
-        const runningSession = new RunningSession({batchId})
-        return await server.stopSession(runningSession, isAborted, save)
-      }
-    } catch (error) {
-      // err handling ?
-      console.error(error)
+      throw new Error(error.message)
     }
   }
 }

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -6,30 +6,22 @@ function makeBatchClose(closeBatch) {
     this._proxy = null
 
     this.setBatchIds = function(batchIds) {
-      if (batchIds && batchIds.length > 0) {
-        this._batchIds = batchIds
-      }
+      this._batchIds = batchIds
       return this
     }
 
     this.setUrl = function(serverUrl) {
-      if (serverUrl) {
-        this._serverUrl = serverUrl
-      }
+      this._serverUrl = serverUrl
       return this
     }
 
     this.setApiKey = function(apiKey) {
-      if (apiKey) {
-        this._apiKey = apiKey
-      }
+      this._apiKey = apiKey
       return this
     }
 
     this.setProxy = function(proxy) {
-      if (proxy) {
-        this._proxy = proxy
-      }
+      this._proxy = proxy
       return this
     }
 
@@ -38,7 +30,7 @@ function makeBatchClose(closeBatch) {
         const serverUrl = this._serverUrl
         const batchIds = this._batchIds
         const apiKey = this._apiKey
-        const proxy = this._apiKey
+        const proxy = this._proxy
         await closeBatch({batchIds, serverUrl, apiKey, proxy})
       } catch (error) {
         throw new Error(error.message)

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -26,15 +26,11 @@ function makeBatchClose(closeBatch) {
     }
 
     this.close = async function() {
-      try {
-        const serverUrl = this._serverUrl
-        const batchIds = this._batchIds
-        const apiKey = this._apiKey
-        const proxy = this._proxy
-        await closeBatch({batchIds, serverUrl, apiKey, proxy})
-      } catch (error) {
-        throw new Error(error.message)
-      }
+      const serverUrl = this._serverUrl
+      const batchIds = this._batchIds
+      const apiKey = this._apiKey
+      const proxy = this._proxy
+      await closeBatch({batchIds, serverUrl, apiKey, proxy})
     }
 
     return this

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -1,32 +1,34 @@
-function BatchClose(closeBatch) {
-  this._batchIds = null
-  this._serverUrl = null
+function makeBatchClose(closeBatch) {
+  return function BatchClose() {
+    this._batchIds = null
+    this._serverUrl = null
 
-  this.setBatchIds = function(batchIds) {
-    if (batchIds && batchIds.length > 0) {
-      this._batchIds = batchIds
+    this.setBatchIds = function(batchIds) {
+      if (batchIds && batchIds.length > 0) {
+        this._batchIds = batchIds
+      }
+      return this
     }
+
+    this.setUrl = function(serverUrl) {
+      if (serverUrl) {
+        this._serverUrl = serverUrl
+      }
+      return this
+    }
+
+    this.close = async function() {
+      try {
+        const serverUrl = this._serverUrl
+        const batchIds = this._batchIds
+        await closeBatch({batchIds, serverUrl})
+      } catch (error) {
+        throw new Error(error.message)
+      }
+    }
+
     return this
   }
-
-  this.setUrl = function(serverUrl) {
-    if (serverUrl) {
-      this._serverUrl = serverUrl
-    }
-    return this
-  }
-
-  this.close = async function() {
-    try {
-      const serverUrl = this._serverUrl
-      const batchIds = this._batchIds
-      await closeBatch({batchIds, serverUrl})
-    } catch (error) {
-      throw new Error(error.message)
-    }
-  }
-
-  return this
 }
 
-module.exports = BatchClose
+module.exports = makeBatchClose

--- a/packages/eyes-sdk-core/lib/close/BatchClose.js
+++ b/packages/eyes-sdk-core/lib/close/BatchClose.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const ServerConnector = require('../server/ServerConnector')
+const RunningSession = require('../server/RunningSession')
+const Configuration = require('../config/Configuration')
+const Logger = require('../logging/Logger')
+
+class BatchClose {
+  constructor({batchIds = [], serverUrl, apiKey}) {
+    this._batchIds = batchIds
+    this._serverUrl = serverUrl
+    this._apiKey = apiKey
+  }
+
+  setBatchIds(batchIds) {
+    if (batchIds && batchIds.length > 0) {
+      this._batchIds = batchIds
+      return this
+    } else {
+      // err handling ?
+    }
+  }
+
+  setUrl(serverUrl) {
+    if (serverUrl) {
+      this._serverUrl = serverUrl
+      return this
+    } else {
+      // err handling ?
+    }
+  }
+
+  _setupServerConfig({serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
+    const configuration = new Configuration({serverUrl, apiKey})
+    const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
+
+    configuration.setServerUrl(serverUrl)
+    configuration.setApiKey(apiKey)
+
+    return {configuration, logger}
+  }
+
+  async close() {
+    try {
+      const serverUrl = this._serverUrl
+      const batchIds = this._batchIds
+      return await this.closeBatch({batchIds, serverUrl})
+    } catch (error) {
+      // err handling ?
+    }
+  }
+
+  async closeBatch({batchIds, serverUrl}) {
+    try {
+      const {logger, configuration} = this._setupServerConfig(serverUrl)
+      // getAgentId ?
+      const getAgentId = () => 'core/close'
+      const server = new ServerConnector({logger, configuration, getAgentId})
+
+      for (const batchId of batchIds) {
+        // isAborted and save?
+        const isAborted = false
+        const save = false
+        // should I use RunningSession?
+        const runningSession = new RunningSession({batchId})
+        return await server.stopSession(runningSession, isAborted, save)
+      }
+    } catch (error) {
+      // err handling ?
+      console.error(error)
+    }
+  }
+}
+
+module.exports = BatchClose

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -7,16 +7,12 @@ const Logger = require('../logging/Logger')
 function setupServerConfig({serverUrl, apiKey}) {
   const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
   const configuration = new Configuration()
-  configuration.setServerUrl(serverUrl)
-  configuration.setApiKey(apiKey)
+  if (serverUrl) configuration.setServerUrl(serverUrl)
+  if (apiKey) configuration.setApiKey(apiKey)
   return {configuration, logger}
 }
 
-async function closeBatch({
-  batchIds = [],
-  serverUrl = '',
-  apiKey = process.env.APPLITOOLS_API_KEY,
-}) {
+async function closeBatch({batchIds = [], serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
   try {
     const getAgentId = () => 'core/close'
     const {logger, configuration} = setupServerConfig({serverUrl, apiKey})

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -5,7 +5,8 @@ const Configuration = require('../config/Configuration')
 const Logger = require('../logging/Logger')
 const {presult} = require('../troubleshoot/utils')
 
-async function closeBatch({batchIds = [], serverUrl, apiKey, proxy}) {
+async function closeBatch({batchIds, serverUrl, apiKey, proxy}) {
+  if (!batchIds) throw new Error('no batchIds were set')
   const serverConnector = new ServerConnector({
     logger: new Logger(!!process.env.APPLITOOLS_SHOW_LOGS),
     configuration: new Configuration({serverUrl, apiKey}),
@@ -15,8 +16,8 @@ async function closeBatch({batchIds = [], serverUrl, apiKey, proxy}) {
 
   const promises = batchIds.map(batchId => serverConnector.deleteBatchSessions(batchId))
   const results = await Promise.all(promises.map(presult))
-  const err = results.find(([err]) => !!err)
-  if (err) throw err[0]
+  const error = results.find(([err]) => !!err)
+  if (error) throw error[0]
 }
 
 module.exports = closeBatch

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -4,18 +4,24 @@ const ServerConnector = require('../server/ServerConnector')
 const Configuration = require('../config/Configuration')
 const Logger = require('../logging/Logger')
 
-function setupServerConfig({serverUrl, apiKey}) {
+function setupServerConfig({serverUrl, apiKey, proxy}) {
   const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
   const configuration = new Configuration()
   if (serverUrl) configuration.setServerUrl(serverUrl)
   if (apiKey) configuration.setApiKey(apiKey)
+  if (proxy) configuration.setProxy(proxy)
   return {configuration, logger}
 }
 
-async function closeBatch({batchIds = [], serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
+async function closeBatch({
+  batchIds = [],
+  serverUrl,
+  apiKey = process.env.APPLITOOLS_API_KEY,
+  proxy,
+}) {
   try {
     const getAgentId = () => 'core/close'
-    const {logger, configuration} = setupServerConfig({serverUrl, apiKey})
+    const {logger, configuration} = setupServerConfig({serverUrl, apiKey, proxy})
     const server = new ServerConnector({logger, configuration, getAgentId})
     for (const batchId of batchIds) {
       await server.deleteBatchSessions(batchId)

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -9,8 +9,7 @@ async function closeBatch({batchIds, serverUrl, apiKey, proxy}) {
   if (!batchIds) throw new Error('no batchIds were set')
   const serverConnector = new ServerConnector({
     logger: new Logger(!!process.env.APPLITOOLS_SHOW_LOGS),
-    configuration: new Configuration({serverUrl, apiKey}),
-    proxy,
+    configuration: new Configuration({serverUrl, apiKey, proxy}),
     getAgentId: () => '',
   })
 

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -1,0 +1,26 @@
+const ServerConnector = require('../server/ServerConnector')
+const Configuration = require('../config/Configuration')
+const Logger = require('../logging/Logger')
+
+function setupServerConfig({serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
+  const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
+  const configuration = new Configuration()
+  configuration.setServerUrl(serverUrl)
+  configuration.setApiKey(apiKey)
+  return {configuration, logger}
+}
+
+async function closeBatch({batchIds = [], serverUrl = ''}) {
+  try {
+    const getAgentId = () => 'core/close'
+    const {logger, configuration} = setupServerConfig({serverUrl})
+    const server = new ServerConnector({logger, configuration, getAgentId})
+    for (const batchId of batchIds) {
+      await server.deleteBatchSessions(batchId)
+    }
+  } catch (error) {
+    throw new Error(error)
+  }
+}
+
+module.exports = closeBatch

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -5,24 +5,13 @@ const Configuration = require('../config/Configuration')
 const Logger = require('../logging/Logger')
 const {presult} = require('../troubleshoot/utils')
 
-function setupServerConfig({serverUrl, apiKey, proxy}) {
-  const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
-  const configuration = new Configuration()
-  if (serverUrl) configuration.setServerUrl(serverUrl)
-  if (apiKey) configuration.setApiKey(apiKey)
-  if (proxy) configuration.setProxy(proxy)
-  return {configuration, logger}
-}
-
-async function closeBatch({
-  batchIds = [],
-  serverUrl,
-  apiKey = process.env.APPLITOOLS_API_KEY,
-  proxy,
-}) {
-  const getAgentId = () => ''
-  const {logger, configuration} = setupServerConfig({serverUrl, apiKey, proxy})
-  const serverConnector = new ServerConnector({logger, configuration, getAgentId})
+async function closeBatch({batchIds = [], serverUrl, apiKey, proxy}) {
+  const serverConnector = new ServerConnector({
+    logger: new Logger(!!process.env.APPLITOOLS_SHOW_LOGS),
+    configuration: new Configuration({serverUrl, apiKey}),
+    proxy,
+    getAgentId: () => '',
+  })
 
   const promises = batchIds.map(batchId => serverConnector.deleteBatchSessions(batchId))
   const results = await Promise.all(promises.map(presult))

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -1,8 +1,10 @@
+'use strict'
+
 const ServerConnector = require('../server/ServerConnector')
 const Configuration = require('../config/Configuration')
 const Logger = require('../logging/Logger')
 
-function setupServerConfig({serverUrl, apiKey = process.env.APPLITOOLS_API_KEY}) {
+function setupServerConfig({serverUrl, apiKey}) {
   const logger = new Logger(!!process.env.APPLITOOLS_SHOW_LOGS)
   const configuration = new Configuration()
   configuration.setServerUrl(serverUrl)
@@ -10,10 +12,14 @@ function setupServerConfig({serverUrl, apiKey = process.env.APPLITOOLS_API_KEY})
   return {configuration, logger}
 }
 
-async function closeBatch({batchIds = [], serverUrl = ''}) {
+async function closeBatch({
+  batchIds = [],
+  serverUrl = '',
+  apiKey = process.env.APPLITOOLS_API_KEY,
+}) {
   try {
     const getAgentId = () => 'core/close'
-    const {logger, configuration} = setupServerConfig({serverUrl})
+    const {logger, configuration} = setupServerConfig({serverUrl, apiKey})
     const server = new ServerConnector({logger, configuration, getAgentId})
     for (const batchId of batchIds) {
       await server.deleteBatchSessions(batchId)

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -62,6 +62,7 @@
     "mocha": "^8.0.1",
     "ncp": "^2.0.0",
     "prettier": "1.19.0",
+    "sinon": "^9.2.0",
     "typescript": "^3.9.5"
   },
   "browser": {

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -61,8 +61,8 @@
     "jsdoc": "3.6.4",
     "mocha": "^8.0.1",
     "ncp": "^2.0.0",
+    "nock": "^13.0.4",
     "prettier": "1.19.0",
-    "sinon": "^9.2.0",
     "typescript": "^3.9.5"
   },
   "browser": {

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -1,0 +1,33 @@
+const BatchClose = require('../../../lib/close/BatchClose')
+const {expect} = require('chai')
+
+describe('BatchClose', () => {
+  it('should provide a fluent API', () => {
+    const batchClose = BatchClose()
+    expect(batchClose).to.haveOwnProperty('setUrl')
+    expect(batchClose).to.haveOwnProperty('setBatchIds')
+    expect(batchClose).to.haveOwnProperty('close')
+  })
+
+  it('should set batchIds', () => {
+    const batchIds = ['123', '456']
+    const batchClose = BatchClose().setBatchIds(batchIds)
+    expect(batchClose._batchIds).to.eql(batchIds)
+  })
+
+  it('should set server url', () => {
+    const url = 'http://localhost:1234'
+    const batchClose = BatchClose().setUrl(url)
+    expect(batchClose._serverUrl).to.equal(url)
+  })
+
+  it('should call closeBatch', async () => {
+    const result = []
+    BatchClose(() => result.push('works'))
+      .setUrl('http://localhost:1234')
+      .setBatchIds(['123', '456'])
+      .close()
+
+    expect(result).to.eql(['works'])
+  })
+})

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -51,7 +51,7 @@ describe('BatchClose', () => {
       url: 'http://localhost:1234',
     }
     let expectedProxy = {}
-    const BatchClose = makeBatchClose(({proxy}) => Object.assign(expectedProxy, proxy))
+    const BatchClose = makeBatchClose(({proxy}) => (expectedProxy = proxy))
     await BatchClose()
       .setProxy(proxy)
       .close()
@@ -88,7 +88,7 @@ describe('BatchClose', () => {
     expect(response).to.eql({serverUrl, batchIds, apiKey, proxy})
   })
 
-  it('should throw if no batchIds were provided', async () => {
+  it('should set empty batchIds', async () => {
     let expectedBatchIds
     const BatchClose = makeBatchClose(({batchIds}) => (expectedBatchIds = batchIds))
     await BatchClose()

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -1,7 +1,8 @@
-const BatchClose = require('../../../lib/close/BatchClose')
+const makeBatchClose = require('../../../lib/close/BatchClose')
 const {expect} = require('chai')
 
 describe('BatchClose', () => {
+  const BatchClose = makeBatchClose(() => 'hi')
   it('should provide a fluent API', () => {
     const batchClose = BatchClose()
     expect(batchClose).to.haveOwnProperty('setUrl')
@@ -23,7 +24,8 @@ describe('BatchClose', () => {
 
   it('should call closeBatch', async () => {
     const result = []
-    BatchClose(() => result.push('works'))
+    const BatchClose = makeBatchClose(() => result.push('works'))
+    BatchClose()
       .setUrl('http://localhost:1234')
       .setBatchIds(['123', '456'])
       .close()

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -24,24 +24,66 @@ describe('BatchClose', () => {
 
   it('should set batchIds', () => {
     const batchIds = ['123', '456']
-    const batchClose = BatchClose().setBatchIds(batchIds)
-    expect(batchClose._batchIds).to.eql(batchIds)
+    const expectedBatchIds = []
+    const BatchClose = makeBatchClose(({batchIds}) => expectedBatchIds.push(...batchIds))
+    BatchClose()
+      .setBatchIds(batchIds)
+      .close()
+    expect(expectedBatchIds).to.eql(batchIds)
   })
 
   it('should set server url', () => {
+    let expectedServerUrl
     const url = 'http://localhost:1234'
-    const batchClose = BatchClose().setUrl(url)
-    expect(batchClose._serverUrl).to.equal(url)
+    const BatchClose = makeBatchClose(({serverUrl}) => (expectedServerUrl = serverUrl))
+    BatchClose()
+      .setUrl(url)
+      .close()
+    expect(expectedServerUrl).to.equal(url)
   })
 
-  it('should call closeBatch', async () => {
-    const result = []
-    const BatchClose = makeBatchClose(() => result.push('works'))
+  it('should set proxy', () => {
+    let proxy = {
+      protocol: 'https',
+      host: 'localhost',
+      port: 1234,
+      isHttpOnly: false,
+      url: 'http://localhost:1234',
+    }
+    let expectedProxy = {}
+    const BatchClose = makeBatchClose(({proxy}) => Object.assign(expectedProxy, proxy))
     BatchClose()
-      .setUrl('http://localhost:1234')
-      .setBatchIds(['123', '456'])
+      .setProxy(proxy)
+      .close()
+    expect(expectedProxy).to.eql(proxy)
+  })
+
+  it('should set apiKey', () => {
+    let expectedApiKey
+    const apiKey = '1234'
+    const BatchClose = makeBatchClose(({apiKey}) => (expectedApiKey = apiKey))
+    BatchClose()
+      .setApiKey(apiKey)
+      .close()
+    expect(expectedApiKey).to.eql(apiKey)
+  })
+
+  it('should call closeBatch with correct paramters', async () => {
+    const response = {}
+    const serverUrl = 'http://localhost:1234'
+    const batchIds = ['123', '456']
+    const apiKey = '1234'
+    const proxy = {host: 'localhost'}
+    const BatchClose = makeBatchClose(({serverUrl, batchIds, proxy, apiKey}) =>
+      Object.assign(response, {serverUrl, batchIds, proxy, apiKey}),
+    )
+    BatchClose()
+      .setUrl(serverUrl)
+      .setBatchIds(batchIds)
+      .setApiKey(apiKey)
+      .setProxy(proxy)
       .close()
 
-    expect(result).to.eql(['works'])
+    expect(response).to.eql({serverUrl, batchIds, apiKey, proxy})
   })
 })

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -5,9 +5,15 @@ describe('BatchClose', () => {
   const BatchClose = makeBatchClose(() => 'hi')
   it('should provide a fluent API', () => {
     const batchClose = BatchClose()
-    expect(batchClose).to.haveOwnProperty('setUrl')
-    expect(batchClose).to.haveOwnProperty('setBatchIds')
-    expect(batchClose).to.haveOwnProperty('close')
+    expect(batchClose)
+      .to.haveOwnProperty('setUrl')
+      .and.be.a('function')
+    expect(batchClose)
+      .to.haveOwnProperty('setBatchIds')
+      .and.be.a('function')
+    expect(batchClose)
+      .to.haveOwnProperty('close')
+      .and.be.a('function')
   })
 
   it('should set batchIds', () => {

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -1,6 +1,5 @@
 const makeBatchClose = require('../../../lib/close/BatchClose')
 const {expect} = require('chai')
-const {presult} = require('../../../lib/troubleshoot/utils')
 
 describe('BatchClose', () => {
   it('should provide a fluent API', () => {

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -14,6 +14,12 @@ describe('BatchClose', () => {
     expect(batchClose)
       .to.haveOwnProperty('close')
       .and.be.a('function')
+    expect(batchClose)
+      .to.haveOwnProperty('setApiKey')
+      .and.be.a('function')
+    expect(batchClose)
+      .to.haveOwnProperty('setProxy')
+      .and.be.a('function')
   })
 
   it('should set batchIds', () => {

--- a/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/BatchClose.spec.js
@@ -1,9 +1,10 @@
 const makeBatchClose = require('../../../lib/close/BatchClose')
 const {expect} = require('chai')
+const {presult} = require('../../../lib/troubleshoot/utils')
 
 describe('BatchClose', () => {
-  const BatchClose = makeBatchClose(() => 'hi')
   it('should provide a fluent API', () => {
+    const BatchClose = makeBatchClose(() => {})
     const batchClose = BatchClose()
     expect(batchClose)
       .to.haveOwnProperty('setUrl')
@@ -22,27 +23,27 @@ describe('BatchClose', () => {
       .and.be.a('function')
   })
 
-  it('should set batchIds', () => {
+  it('should set batchIds', async () => {
     const batchIds = ['123', '456']
     const expectedBatchIds = []
     const BatchClose = makeBatchClose(({batchIds}) => expectedBatchIds.push(...batchIds))
-    BatchClose()
+    await BatchClose()
       .setBatchIds(batchIds)
       .close()
     expect(expectedBatchIds).to.eql(batchIds)
   })
 
-  it('should set server url', () => {
+  it('should set server url', async () => {
     let expectedServerUrl
     const url = 'http://localhost:1234'
     const BatchClose = makeBatchClose(({serverUrl}) => (expectedServerUrl = serverUrl))
-    BatchClose()
+    await BatchClose()
       .setUrl(url)
       .close()
     expect(expectedServerUrl).to.equal(url)
   })
 
-  it('should set proxy', () => {
+  it('should set proxy', async () => {
     let proxy = {
       protocol: 'https',
       host: 'localhost',
@@ -52,17 +53,17 @@ describe('BatchClose', () => {
     }
     let expectedProxy = {}
     const BatchClose = makeBatchClose(({proxy}) => Object.assign(expectedProxy, proxy))
-    BatchClose()
+    await BatchClose()
       .setProxy(proxy)
       .close()
     expect(expectedProxy).to.eql(proxy)
   })
 
-  it('should set apiKey', () => {
+  it('should set apiKey', async () => {
     let expectedApiKey
     const apiKey = '1234'
     const BatchClose = makeBatchClose(({apiKey}) => (expectedApiKey = apiKey))
-    BatchClose()
+    await BatchClose()
       .setApiKey(apiKey)
       .close()
     expect(expectedApiKey).to.eql(apiKey)
@@ -77,7 +78,8 @@ describe('BatchClose', () => {
     const BatchClose = makeBatchClose(({serverUrl, batchIds, proxy, apiKey}) =>
       Object.assign(response, {serverUrl, batchIds, proxy, apiKey}),
     )
-    BatchClose()
+
+    await BatchClose()
       .setUrl(serverUrl)
       .setBatchIds(batchIds)
       .setApiKey(apiKey)
@@ -85,5 +87,14 @@ describe('BatchClose', () => {
       .close()
 
     expect(response).to.eql({serverUrl, batchIds, apiKey, proxy})
+  })
+
+  it('should throw if no batchIds were provided', async () => {
+    let expectedBatchIds
+    const BatchClose = makeBatchClose(({batchIds}) => (expectedBatchIds = batchIds))
+    await BatchClose()
+      .setBatchIds()
+      .close()
+    expect(expectedBatchIds).to.be.undefined
   })
 })

--- a/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
@@ -42,13 +42,4 @@ describe('closeBatch', () => {
       expect(scopes[index].interceptors[0].queries).to.eql({apiKey})
     })
   })
-
-  it('should call deleteBatchSession per batchId', async () => {
-    await closeBatch({batchIds, serverUrl, apiKey})
-    batchIds.forEach((batchId, index) => {
-      expect(scopes[index].interceptors[0].path).to.equal(
-        `/api/sessions/batches/${batchId}/close/bypointerid`,
-      )
-    })
-  })
 })

--- a/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
@@ -1,35 +1,50 @@
+const nock = require('nock')
 const closeBatch = require('../../../lib/close/closeBatch')
-const sinon = require('sinon')
 const {expect} = require('chai')
 const {presult} = require('../../../lib/troubleshoot/utils')
-const ServerConnector = require('../../../lib/server/ServerConnector')
 
 describe('closeBatch', () => {
-  let sandbox, deleteBatchSessionsStub
-  beforeEach(() => {
-    sandbox = sinon.createSandbox()
-    deleteBatchSessionsStub = sandbox.stub(ServerConnector.prototype, 'deleteBatchSessions')
-  })
+  let serverUrl, apiKey, batchIds, scopes
 
-  afterEach(() => {
-    sandbox.restore()
+  beforeEach(() => {
+    serverUrl = 'http://localhost:1234'
+    apiKey = '12345'
+
+    batchIds = ['123', '456']
+    scopes = []
+
+    batchIds.forEach(batchId => {
+      const scope = nock(serverUrl)
+        .delete(`/api/sessions/batches/${batchId}/close/bypointerid`)
+        .query({apiKey})
+        .reply(200)
+      scopes.push(scope)
+    })
   })
 
   it('should throw', async () => {
-    const batchIds = ['123', '456']
-    deleteBatchSessionsStub.callsFake(() => {
-      throw new Error('something happened')
+    nock(serverUrl)
+      .delete(`/api/sessions/batches/678/close/bypointerid`)
+      .query({apiKey})
+      .replyWithError({message: 'something went wrong', code: 500})
+    const [err] = await presult(closeBatch({batchIds: ['678'], serverUrl, apiKey}))
+    expect(err.message).to.equal('Error: something went wrong')
+  })
+
+  it('should setup configuration', async () => {
+    const [err] = await presult(closeBatch({batchIds, serverUrl, apiKey}))
+    expect(err).to.be.undefined
+    batchIds.forEach((batchId, index) => {
+      expect(scopes[index].basePath).to.equal(serverUrl)
+      expect(scopes[index].interceptors[0].path).to.include(batchId)
+      expect(scopes[index].interceptors[0].queries).to.eql({apiKey})
     })
-    const [err] = await presult(closeBatch({batchIds}))
-    expect(err.message).to.equal('Error: something happened')
   })
 
   it('should call deleteBatchSession per batchId', async () => {
-    const batchIds = ['123', '456']
-    await closeBatch({batchIds})
-    expect(deleteBatchSessionsStub.callCount).to.equal(2)
-    batchIds.forEach((batchId, index) =>
-      expect(deleteBatchSessionsStub.getCall(index).args).to.eql([batchId]),
-    )
+    await closeBatch({batchIds, serverUrl, apiKey})
+    batchIds.forEach((batchId, index) => {
+      expect(scopes[index].interceptors[0].path).to.include(batchId[index])
+    })
   })
 })

--- a/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
@@ -31,12 +31,14 @@ describe('closeBatch', () => {
     expect(err.message).to.equal('Error: something went wrong')
   })
 
-  it('should setup configuration', async () => {
+  it('should send the correct close batch requests to the server', async () => {
     const [err] = await presult(closeBatch({batchIds, serverUrl, apiKey}))
     expect(err).to.be.undefined
     batchIds.forEach((batchId, index) => {
       expect(scopes[index].basePath).to.equal(serverUrl)
-      expect(scopes[index].interceptors[0].path).to.include(batchId)
+      expect(scopes[index].interceptors[0].path).to.equal(
+        `/api/sessions/batches/${batchId}/close/bypointerid`,
+      )
       expect(scopes[index].interceptors[0].queries).to.eql({apiKey})
     })
   })
@@ -44,7 +46,9 @@ describe('closeBatch', () => {
   it('should call deleteBatchSession per batchId', async () => {
     await closeBatch({batchIds, serverUrl, apiKey})
     batchIds.forEach((batchId, index) => {
-      expect(scopes[index].interceptors[0].path).to.include(batchId[index])
+      expect(scopes[index].interceptors[0].path).to.equal(
+        `/api/sessions/batches/${batchId}/close/bypointerid`,
+      )
     })
   })
 })

--- a/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
@@ -1,0 +1,35 @@
+const closeBatch = require('../../../lib/close/closeBatch')
+const sinon = require('sinon')
+const {expect} = require('chai')
+const {presult} = require('../../../lib/troubleshoot/utils')
+const ServerConnector = require('../../../lib/server/ServerConnector')
+
+describe('closeBatch', () => {
+  let sandbox, deleteBatchSessionsStub
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    deleteBatchSessionsStub = sandbox.stub(ServerConnector.prototype, 'deleteBatchSessions')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should throw', async () => {
+    const batchIds = ['123', '456']
+    deleteBatchSessionsStub.callsFake(() => {
+      throw new Error('something happened')
+    })
+    const [err] = await presult(closeBatch({batchIds}))
+    expect(err.message).to.equal('Error: something happened')
+  })
+
+  it('should call deleteBatchSession per batchId', async () => {
+    const batchIds = ['123', '456']
+    await closeBatch({batchIds})
+    expect(deleteBatchSessionsStub.callCount).to.equal(2)
+    batchIds.forEach((batchId, index) =>
+      expect(deleteBatchSessionsStub.getCall(index).args).to.eql([batchId]),
+    )
+  })
+})

--- a/packages/eyes-sdk-core/yarn.lock
+++ b/packages/eyes-sdk-core/yarn.lock
@@ -263,6 +263,42 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.2.0.tgz#fcff83ab86f83b5498f4a967869c079408d9b5eb"
+  integrity sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@testim/chrome-version@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
@@ -965,7 +1001,7 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-diff@4.0.2:
+diff@4.0.2, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -1789,6 +1825,11 @@ is2@2.0.1:
     ip-regex "^2.1.0"
     is-url "^1.2.2"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1879,6 +1920,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
+
 klaw@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
@@ -1935,6 +1981,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.mapvalues@4.6.0:
   version "4.6.0"
@@ -2150,6 +2201,17 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-fetch@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
@@ -2331,6 +2393,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -2664,6 +2733,19 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+sinon@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.0.tgz#1d333967e30023609f7347351ebc0dc964c0f3c9"
+  integrity sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.2.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2903,7 +2985,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==

--- a/packages/eyes-sdk-core/yarn.lock
+++ b/packages/eyes-sdk-core/yarn.lock
@@ -15,16 +15,6 @@
   resolved "https://registry.yarnpkg.com/@applitools/dom-shared/-/dom-shared-1.0.4.tgz#1a59116f3f29fb140ac031949547531348c9d972"
   integrity sha512-WRGko/7pJLwcDbQ5r0q2KD58VemIHm+JyKeXSflQhJvQqA5ONYyBX6cZo0h3o1SqdlzQnWM5REzoxoOpOGflzQ==
 
-"@applitools/dom-snapshot@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.2.1.tgz#26495372535109dd8d2ad35f1f9f171b21262b74"
-  integrity sha512-a64sYVxKhPRwxneinAVN28JeRe+9C/touEyXIL1s0a7FSlJ7bsVQid7ZwqTrQu+8W//VWiYxgGI1SK11Y/a6Eg==
-  dependencies:
-    "@applitools/dom-shared" "1.0.4"
-    "@applitools/functional-commons" "1.6.0"
-    css-tree "1.0.0-alpha.39"
-    pako "1.0.11"
-
 "@applitools/dom-snapshot@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@applitools/dom-snapshot/-/dom-snapshot-4.2.2.tgz#6c52a65ea3ed732b27921a313a6598f9fa7a1877"

--- a/packages/eyes-sdk-core/yarn.lock
+++ b/packages/eyes-sdk-core/yarn.lock
@@ -263,42 +263,6 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
-  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
-  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
-"@sinonjs/formatio@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
-  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^5.0.2"
-
-"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.2.0.tgz#fcff83ab86f83b5498f4a967869c079408d9b5eb"
-  integrity sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
-  dependencies:
-    "@sinonjs/commons" "^1.6.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
-
-"@sinonjs/text-encoding@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
-  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
-
 "@testim/chrome-version@^1.0.7":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
@@ -1001,7 +965,7 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-diff@4.0.2, diff@^4.0.2:
+diff@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -1825,11 +1789,6 @@ is2@2.0.1:
     ip-regex "^2.1.0"
     is-url "^1.2.2"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1905,7 +1864,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -1919,11 +1878,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
-
-just-extend@^4.0.2:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
-  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
 klaw@^3.0.0:
   version "3.0.0"
@@ -1982,11 +1936,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.mapvalues@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
@@ -2001,6 +1950,11 @@ lodash.pickby@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
   integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -2201,16 +2155,15 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nise@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
-  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+nock@^13.0.4:
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.0.4.tgz#9fb74db35d0aa056322e3c45be14b99105cd7510"
+  integrity sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash.set "^4.3.2"
+    propagate "^2.0.0"
 
 node-fetch@2.6.0:
   version "2.6.0"
@@ -2394,13 +2347,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -2467,6 +2413,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -2733,19 +2684,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-sinon@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.0.tgz#1d333967e30023609f7347351ebc0dc964c0f3c9"
-  integrity sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==
-  dependencies:
-    "@sinonjs/commons" "^1.8.1"
-    "@sinonjs/fake-timers" "^6.0.1"
-    "@sinonjs/formatio" "^5.0.1"
-    "@sinonjs/samsam" "^5.2.0"
-    diff "^4.0.2"
-    nise "^4.0.4"
-    supports-color "^7.1.0"
-
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2985,7 +2923,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
+type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
# Batch Close
provide the ability to manually close batches using an array of `batchIds`

### API
```
const {BatchClose} = require('@applitools/eyes-sdk-core')
async function someFunction() {
...
await BatchClose().setBatchIds(['123', '456']).close()
...
}
```

you can also provide a custom URL:
```
const {BatchClose} = require('@applitools/eyes-sdk-core')
async function someFunction() {
...
await BatchClose().setUrl('example.com').setBatchIds(['123', '456']).close()
...
}
```