### PR TITLE
fix: remove cyclic dependencies from index

### DIFF
--- a/packages/eyes-sdk-core/lib/AppEnvironment.js
+++ b/packages/eyes-sdk-core/lib/AppEnvironment.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, RectangleSize} = require('..')
+const RectangleSize = require('../lib/geometry/RectangleSize')
+const GeneralUtils = require('../lib/utils/GeneralUtils')
 
 /**
  * The environment in which the application under test is executing.

--- a/packages/eyes-sdk-core/lib/close/closeBatch.js
+++ b/packages/eyes-sdk-core/lib/close/closeBatch.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const {
-  GeneralUtils: {presult},
-  ServerConnector,
-  Configuration,
-  Logger,
-} = require('../../')
+const Logger = require('../logging/Logger')
+const ServerConnector = require('../server/ServerConnector')
+const Configuration = require('../config/Configuration')
+const {presult} = require('../utils/GeneralUtils')
 
 async function closeBatch({batchIds, serverUrl, apiKey, proxy}) {
   if (!batchIds) throw new Error('no batchIds were set')

--- a/packages/eyes-sdk-core/lib/fluent/CheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/CheckSettings.js
@@ -1,12 +1,10 @@
 'use strict'
 
-const {
-  Region,
-  GeneralUtils,
-  MatchLevel,
-  FloatingMatchSettings,
-  AccessibilityMatchSettings,
-} = require('../..')
+const Region = require('../geometry/Region')
+const GeneralUtils = require('../utils/GeneralUtils')
+const MatchLevel = require('../config/MatchLevel')
+const FloatingMatchSettings = require('../config/FloatingMatchSettings')
+const AccessibilityMatchSettings = require('../config/AccessibilityMatchSettings')
 
 const GetRegion = require('./GetRegion')
 const IgnoreRegionByRectangle = require('./IgnoreRegionByRectangle')

--- a/packages/eyes-sdk-core/lib/getScmInfo.js
+++ b/packages/eyes-sdk-core/lib/getScmInfo.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const {
-  GeneralUtils: {pexec, cachify, presult},
-} = require('..')
+const {pexec, cachify, presult} = require('../lib/utils/GeneralUtils')
 
 async function doGetScmInfo(branchName, parentBranchName, _opts) {
   const commitTimeCmd = `HASH=$(git merge-base ${branchName} ${parentBranchName}) && git show -q --format=%cI $HASH`

--- a/packages/eyes-sdk-core/lib/metadata/ActualAppOutput.js
+++ b/packages/eyes-sdk-core/lib/metadata/ActualAppOutput.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, DateTimeUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const DateTimeUtils = require('../utils/DateTimeUtils')
 
 const ImageMatchSettings = require('./ImageMatchSettings')
 const Image = require('./Image')

--- a/packages/eyes-sdk-core/lib/metadata/Annotations.js
+++ b/packages/eyes-sdk-core/lib/metadata/Annotations.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const {GeneralUtils, Region, FloatingMatchSettings} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const Region = require('../geometry/Region')
+const FloatingMatchSettings = require('../config/FloatingMatchSettings')
 
 class Annotations {
   /**

--- a/packages/eyes-sdk-core/lib/metadata/BatchInfo.js
+++ b/packages/eyes-sdk-core/lib/metadata/BatchInfo.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, DateTimeUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const DateTimeUtils = require('../utils/DateTimeUtils')
 
 class BatchInfo {
   /**

--- a/packages/eyes-sdk-core/lib/metadata/Branch.js
+++ b/packages/eyes-sdk-core/lib/metadata/Branch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 class Branch {
   /**

--- a/packages/eyes-sdk-core/lib/metadata/ExpectedAppOutput.js
+++ b/packages/eyes-sdk-core/lib/metadata/ExpectedAppOutput.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, DateTimeUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const DateTimeUtils = require('../utils/DateTimeUtils')
 
 const Annotations = require('./Annotations')
 const Image = require('./Image')

--- a/packages/eyes-sdk-core/lib/metadata/Image.js
+++ b/packages/eyes-sdk-core/lib/metadata/Image.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, RectangleSize} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const RectangleSize = require('../geometry/RectangleSize')
 
 class Image {
   /**

--- a/packages/eyes-sdk-core/lib/metadata/ImageMatchSettings.js
+++ b/packages/eyes-sdk-core/lib/metadata/ImageMatchSettings.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const {GeneralUtils, Region, FloatingMatchSettings} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
+const Region = require('../geometry/Region')
+const FloatingMatchSettings = require('../config/FloatingMatchSettings')
 
 class ImageMatchSettings {
   /**

--- a/packages/eyes-sdk-core/lib/metadata/SessionResults.js
+++ b/packages/eyes-sdk-core/lib/metadata/SessionResults.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
-
+const GeneralUtils = require('../utils/GeneralUtils')
 const ActualAppOutput = require('./ActualAppOutput')
 const ExpectedAppOutput = require('./ExpectedAppOutput')
 const Branch = require('./Branch')

--- a/packages/eyes-sdk-core/lib/metadata/StartInfo.js
+++ b/packages/eyes-sdk-core/lib/metadata/StartInfo.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
-
+const GeneralUtils = require('../utils/GeneralUtils')
 const ImageMatchSettings = require('./ImageMatchSettings')
 const BatchInfo = require('./BatchInfo')
 const AppEnvironment = require('../AppEnvironment')

--- a/packages/eyes-sdk-core/lib/positioning/FirefoxRegionPositionCompensation.js
+++ b/packages/eyes-sdk-core/lib/positioning/FirefoxRegionPositionCompensation.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {Region} = require('../..')
+const Region = require('../geometry/Region')
 const RegionPositionCompensation = require('./RegionPositionCompensation')
 
 class FirefoxRegionPositionCompensation extends RegionPositionCompensation {

--- a/packages/eyes-sdk-core/lib/positioning/NullRegionProvider.js
+++ b/packages/eyes-sdk-core/lib/positioning/NullRegionProvider.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {Region} = require('../..')
-
+const Region = require('../geometry/Region')
 const RegionProvider = require('./RegionProvider')
 
 class NullRegionProvider extends RegionProvider {

--- a/packages/eyes-sdk-core/lib/positioning/RegionPositionCompensationFactory.js
+++ b/packages/eyes-sdk-core/lib/positioning/RegionPositionCompensationFactory.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {BrowserNames} = require('../..')
-
+const BrowserNames = require('../useragent/BrowserNames')
 const FirefoxRegionPositionCompensation = require('./FirefoxRegionPositionCompensation')
 const NullRegionPositionCompensation = require('./NullRegionPositionCompensation')
 const SafariRegionPositionCompensation = require('./SafariRegionPositionCompensation')

--- a/packages/eyes-sdk-core/lib/positioning/SafariRegionPositionCompensation.js
+++ b/packages/eyes-sdk-core/lib/positioning/SafariRegionPositionCompensation.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {Region} = require('../..')
-
+const Region = require('../geometry/Region')
 const RegionPositionCompensation = require('./RegionPositionCompensation')
 
 class SafariRegionPositionCompensation extends RegionPositionCompensation {

--- a/packages/eyes-sdk-core/lib/renderer/EmulationDevice.js
+++ b/packages/eyes-sdk-core/lib/renderer/EmulationDevice.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 class EmulationDevice {
   /**

--- a/packages/eyes-sdk-core/lib/renderer/EmulationInfo.js
+++ b/packages/eyes-sdk-core/lib/renderer/EmulationInfo.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
-
+const GeneralUtils = require('../utils/GeneralUtils')
 const EmulationDevice = require('./EmulationDevice')
 
 class EmulationInfo {

--- a/packages/eyes-sdk-core/lib/renderer/RGridDom.js
+++ b/packages/eyes-sdk-core/lib/renderer/RGridDom.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const crypto = require('crypto')
-
-const {GeneralUtils, ArgumentGuard} = require('../..')
-
+const ArgumentGuard = require('../utils/ArgumentGuard')
+const GeneralUtils = require('../utils/GeneralUtils')
 const RGridResource = require('./RGridResource')
 
 class RGridDom {

--- a/packages/eyes-sdk-core/lib/renderer/RGridResource.js
+++ b/packages/eyes-sdk-core/lib/renderer/RGridResource.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const crypto = require('crypto')
-
-const {GeneralUtils, ArgumentGuard} = require('../..')
+const ArgumentGuard = require('../utils/ArgumentGuard')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 const VISUAL_GRID_MAX_BUFFER_SIZE = 15 * 1000000
 

--- a/packages/eyes-sdk-core/lib/renderer/RenderInfo.js
+++ b/packages/eyes-sdk-core/lib/renderer/RenderInfo.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const {GeneralUtils, Region} = require('../..')
+const Region = require('../geometry/Region')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 const EmulationInfo = require('./EmulationInfo')
 

--- a/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
+++ b/packages/eyes-sdk-core/lib/renderer/RenderRequest.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {ArgumentGuard} = require('../..')
+const ArgumentGuard = require('../utils/ArgumentGuard')
 
 /**
  * Encapsulates data required to start render using the RenderingGrid API.

--- a/packages/eyes-sdk-core/lib/renderer/RenderStatusResults.js
+++ b/packages/eyes-sdk-core/lib/renderer/RenderStatusResults.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const {GeneralUtils, RectangleSize, Region} = require('../..')
+const RectangleSize = require('../geometry/RectangleSize')
+const Region = require('../geometry/Region')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 /**
  * Encapsulates data for the render currently running in the client.

--- a/packages/eyes-sdk-core/lib/renderer/RunningRender.js
+++ b/packages/eyes-sdk-core/lib/renderer/RunningRender.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
-
+const GeneralUtils = require('../utils/GeneralUtils')
 /**
  * Encapsulates data for the render currently running in the client.
  */

--- a/packages/eyes-sdk-core/lib/runner/EyesRunner.js
+++ b/packages/eyes-sdk-core/lib/runner/EyesRunner.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
 const TestResultsSummary = require('./TestResultsSummary')
 
 class EyesRunner {

--- a/packages/eyes-sdk-core/lib/runner/TestResultsSummary.js
+++ b/packages/eyes-sdk-core/lib/runner/TestResultsSummary.js
@@ -1,6 +1,8 @@
 'use strict'
 
-const {ArgumentGuard, TypeUtils, GeneralUtils} = require('../..')
+const ArgumentGuard = require('../utils/ArgumentGuard')
+const TypeUtils = require('../utils/TypeUtils')
+const GeneralUtils = require('../utils/GeneralUtils')
 const TestFailedError = require('../errors/TestFailedError')
 const TestResultsStatus = require('../TestResultsStatus')
 const TestResultContainer = require('./TestResultContainer')

--- a/packages/eyes-sdk-core/lib/runner/VisualGridRunner.js
+++ b/packages/eyes-sdk-core/lib/runner/VisualGridRunner.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
 const EyesRunner = require('./EyesRunner')
 
 class VisualGridRunner extends EyesRunner {

--- a/packages/eyes-sdk-core/lib/scaling/ContextBasedScaleProvider.js
+++ b/packages/eyes-sdk-core/lib/scaling/ContextBasedScaleProvider.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {ArgumentGuard} = require('../..')
-
+const ArgumentGuard = require('../utils/ArgumentGuard')
 const ScaleProvider = require('./ScaleProvider')
 
 // Allowed deviations for viewport size and default content entire size.

--- a/packages/eyes-sdk-core/lib/scaling/FixedScaleProvider.js
+++ b/packages/eyes-sdk-core/lib/scaling/FixedScaleProvider.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {ArgumentGuard} = require('../..')
-
+const ArgumentGuard = require('../utils/ArgumentGuard')
 const ScaleProvider = require('./ScaleProvider')
 
 class FixedScaleProvider extends ScaleProvider {

--- a/packages/eyes-sdk-core/lib/sdk/EyesBase.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesBase.js
@@ -1,23 +1,23 @@
 'use strict'
 
-const {
-  Logger,
-  ArgumentGuard,
-  TypeUtils,
-  EyesError,
-  Region,
-  Location,
-  RectangleSize,
-  CoordinatesType,
-  ImageDeltaCompressor,
-  SimplePropertyHandler,
-  ReadOnlyPropertyHandler,
-  FileDebugScreenshotsProvider,
-  NullDebugScreenshotProvider,
-  SessionType,
-  Configuration,
-  GeneralUtils,
-} = require('../../')
+const Logger = require('../logging/Logger')
+const EyesError = require('../errors/EyesError')
+const Region = require('../geometry/Region')
+const Location = require('../geometry/Location')
+const RectangleSize = require('../geometry/RectangleSize')
+const CoordinatesType = require('../geometry/CoordinatesType')
+
+const GeneralUtils = require('../utils/GeneralUtils')
+const ArgumentGuard = require('../utils/ArgumentGuard')
+const TypeUtils = require('../utils/TypeUtils')
+
+const ImageDeltaCompressor = require('../images/ImageDeltaCompressor')
+const SimplePropertyHandler = require('../handler/SimplePropertyHandler')
+const ReadOnlyPropertyHandler = require('../handler/ReadOnlyPropertyHandler')
+const FileDebugScreenshotsProvider = require('../debug/FileDebugScreenshotsProvider')
+const NullDebugScreenshotProvider = require('../debug/NullDebugScreenshotProvider')
+const SessionType = require('../config/SessionType')
+const Configuration = require('../config/Configuration')
 
 const AppOutputProvider = require('../capture/AppOutputProvider')
 const AppOutputWithScreenshot = require('../capture/AppOutputWithScreenshot')

--- a/packages/eyes-sdk-core/lib/server/RenderingInfo.js
+++ b/packages/eyes-sdk-core/lib/server/RenderingInfo.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {GeneralUtils} = require('../..')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 class RenderingInfo {
   /**

--- a/packages/eyes-sdk-core/lib/server/RunningSession.js
+++ b/packages/eyes-sdk-core/lib/server/RunningSession.js
@@ -1,5 +1,6 @@
 'use strict'
-const {GeneralUtils} = require('../..')
+
+const GeneralUtils = require('../utils/GeneralUtils')
 const RenderingInfo = require('./RenderingInfo')
 
 /**

--- a/packages/eyes-sdk-core/lib/server/requestHelpers.js
+++ b/packages/eyes-sdk-core/lib/server/requestHelpers.js
@@ -1,6 +1,8 @@
 const getTunnelAgentFromProxy = require('./getTunnelAgentFromProxy')
 
-const {GeneralUtils, DateTimeUtils, TypeUtils} = require('../..')
+const DateTimeUtils = require('../utils/DateTimeUtils')
+const TypeUtils = require('../utils/TypeUtils')
+const GeneralUtils = require('../utils/GeneralUtils')
 
 const HTTP_STATUS_CODES = {
   CREATED: 201,

--- a/packages/eyes-sdk-core/lib/triggers/MouseTrigger.js
+++ b/packages/eyes-sdk-core/lib/triggers/MouseTrigger.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {ArgumentGuard} = require('../..')
-
+const ArgumentGuard = require('../utils/ArgumentGuard')
 const Trigger = require('./Trigger')
 
 /**

--- a/packages/eyes-sdk-core/lib/triggers/TextTrigger.js
+++ b/packages/eyes-sdk-core/lib/triggers/TextTrigger.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const {ArgumentGuard} = require('../..')
-
+const ArgumentGuard = require('../utils/ArgumentGuard')
 const Trigger = require('./Trigger')
 
 /**


### PR DESCRIPTION
# cyclic dependencies
throughout the codebase we had requires like this one: 
`const {SeverConnector, GeneralUtils , ...} = require('../..')`

this is convenient (because otherwise you would have to use 2 different requires from 2 different locations in the example above) but results in many cyclic dependencies:
![image](https://user-images.githubusercontent.com/16037265/97110870-30157800-16e4-11eb-964b-ff715c2e073d.png)

after this PR - **0** cyclic dependencies are created from `index.js` 😃 

going forward - I think it's better to have an `index.js` per folder which will allow for greater grouping when requiring from the same folder, and also give us the opportunity to wrap exported modules (so we wouldn't have to do that in the main `index.js`)
