### PR TITLE
fix: correct layout region calculation within a region

### DIFF
--- a/packages/eyes-sdk-core/lib/sdk/EyesClassic.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesClassic.js
@@ -611,12 +611,7 @@ class EyesClassic extends EyesCore {
     )
 
     this._logger.verbose('Building screenshot object...')
-    return EyesScreenshot.fromFrameSize(
-      this._logger,
-      this,
-      fullRegionImage,
-      fullRegionImage.getSize(),
-    )
+    return EyesScreenshot.fromScreenshotType(this._logger, this, fullRegionImage)
   }
   /**
    * Create a full page screenshot


### PR DESCRIPTION
when using eyes classic with a region and specifying a layout region - the calculation didn't consider the offset of the region - and therefore our layout regions would turn out slightly off their respective positions.