### PR TITLE
fix: user config override

### DIFF
--- a/packages/eyes-sdk-core/lib/utils/ConfigUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/ConfigUtils.js
@@ -29,7 +29,11 @@ function getConfig({
 
   const envConfig = {}
   for (const p of configParams) {
-    envConfig[p] = GeneralUtils.getEnvValue(toEnvVarName(p))
+    if (defaultConfig[p]) {
+      envConfig[p] = defaultConfig[p]
+    } else {
+      envConfig[p] = GeneralUtils.getEnvValue(toEnvVarName(p))
+    }
     if (envConfig[p] === 'true') {
       envConfig[p] = true
     } else if (envConfig[p] === 'false') {

--- a/packages/eyes-sdk-core/test/fixtures/applitools.config.js
+++ b/packages/eyes-sdk-core/test/fixtures/applitools.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   bla: 'kuku',
-  it: 'works',
+  it: 'works'
 };

--- a/packages/eyes-sdk-core/test/unit/utils/ConfigUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/ConfigUtils.spec.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 
 const {ConfigUtils, Logger} = require('../../../index')
 
-describe('ConfigUtils', () => {
+describe.only('ConfigUtils', () => {
   describe('getConfig()', () => {
     let prevEnv
     const logger = new Logger()
@@ -34,10 +34,10 @@ describe('ConfigUtils', () => {
       assert.deepStrictEqual(config, expectedConfig)
     })
 
-    it('loads config with env variables', () => {
-      process.env.APPLITOOLS_BLA = 'env kuku'
-      const config = getConfigAtConfigPath({configParams: ['bla']})
-      const expectedConfig = {bla: 'env kuku', it: 'works'}
+    it('loads config with env variables if no config property provided', () => {
+      process.env.APPLITOOLS_OVERRIDE = 'HELLO'
+      const config = getConfigAtConfigPath({configParams: ['override']})
+      const expectedConfig = {bla: 'kuku', it: 'works', override: 'HELLO'}
       assert.deepStrictEqual(config, expectedConfig)
     })
 
@@ -76,10 +76,10 @@ describe('ConfigUtils', () => {
       }
     })
 
-    it('loads config with bamboo prefix variable', () => {
-      process.env.bamboo_APPLITOOLS_BLA = 'env kuku bamboo'
-      const config = getConfigAtConfigPath({configParams: ['bla']})
-      const expectedConfig = {bla: 'env kuku bamboo', it: 'works'}
+    it('loads config with bamboo prefix variable if no config property provided', () => {
+      process.env.bamboo_APPLITOOLS_BRO = 'env kuku bamboo'
+      const config = getConfigAtConfigPath({configParams: ['bro']})
+      const expectedConfig = {bro: 'env kuku bamboo', it: 'works', bla: 'kuku'}
       assert.deepStrictEqual(config, expectedConfig)
     })
 


### PR DESCRIPTION
fix for user config override.

if a user provides us with `applitools.config.js` we do not take properties which exist on the env.

there is this test:
```js
 it('loads config with env variables', () => {
      process.env.APPLITOOLS_BLA = 'env kuku'
      const config = getConfigAtConfigPath({configParams: ['bla']})
      const expectedConfig = {bla: 'env kuku', it: 'works'}
      assert.deepStrictEqual(config, expectedConfig)
    })
```

I am not sure if this was the author's intent - but this test basically explains the bug. 
if the user provides config property `bla` with value: `kuku` than we take `process.env.APPLITOOLS_BLA` instead of what the user provided.

this issue manifested when someone tried to provide a different `apiKey` than what existed on his env.

