### PR TITLE
chore: use branches and grouped stdout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,8 @@ jobs:
           yarn publish "--${{github.event.inputs.version}}" --access public
           echo "::endgroup::"
 
-          echo "::group::update master"
+          echo "::group::update master from $BRANCH"
           git checkout master
-          echo $BRANCH
           git merge $BRANCH
           git push origin master
           echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           echo "::group::publish ${{github.event.inputs.name}}"
           cd "packages/${{github.event.inputs.name}}"
           yarn
-          yarn setup
+          yarn prepublish:setup
           yarn publish "--${{github.event.inputs.version}}" --access public
           echo "::endgroup::"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,16 @@
-name: Publish SDK
+name: Publish
 
 on:
   workflow_dispatch:
     inputs:
       name:
-        description: "SDK name"
+        description: "name"
         required: true
       version:
         description: "version type (specify 'major', 'minor, or 'patch')"
         required: true
-      docker:
-        description: "use docker"
-        default: "true"
-        required: true
 jobs:
-  publish_sdk:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +37,7 @@ jobs:
           echo "::group::publish ${{github.event.inputs.name}}"
           cd "packages/${{github.event.inputs.name}}"
           yarn
-          if [ ${{github.event.inputs.docker}} == true ]; then yarn docker:setup; fi
+          yarn setup
           yarn publish "--${{github.event.inputs.version}}" --access public
           echo "::endgroup::"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,16 +40,15 @@ jobs:
 
           echo "::group::publish ${{github.event.inputs.name}}"
           cd "packages/${{github.event.inputs.name}}"
-          yarn && yarn deps
+          yarn
           if [ ${{github.event.inputs.docker}} == true ]; then yarn docker:setup; fi
           yarn publish "--${{github.event.inputs.version}}" --access public
           echo "::endgroup::"
 
-
           echo "::group::update master"
           git checkout master
           echo $BRANCH
-          git merge -X theirs $BRANCH
+          git merge $BRANCH
           git push origin master
           echo "::endgroup::"
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,57 @@
 name: Publish SDK
+
 on:
   workflow_dispatch:
     inputs:
-      sdkName:
+      name:
         description: "SDK name"
         required: true
       version:
         description: "version type (specify 'major', 'minor, or 'patch')"
+        required: true
+      docker:
+        description: "use docker"
+        default: "true"
         required: true
 jobs:
   publish_sdk:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: 14
       - run: |
+
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
           echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "always-auth=true" >> .npmrc
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          cd "packages/${{github.event.inputs.sdkName}}"
-          yarn
-          yarn docker:setup
+
+          echo "::group::create temp branch"
+          DATE=$(date +%F_%H-%M)
+          BRANCH="${{github.event.inputs.name}}_$DATE"
+          git checkout -b $BRANCH
+          git push -u origin $BRANCH
+          echo "::endgroup::"
+
+          echo "::group::publish ${{github.event.inputs.name}}"
+          cd "packages/${{github.event.inputs.name}}"
+          yarn && yarn deps
+          if [ ${{github.event.inputs.docker}} == true ]; then yarn docker:setup; fi
           yarn publish "--${{github.event.inputs.version}}" --access public
+          echo "::endgroup::"
+
+
+          echo "::group::update master"
+          git checkout master
+          echo $BRANCH
+          git merge -X theirs $BRANCH
+          git push origin master
+          echo "::endgroup::"
     env:
       CVG_TESTS_REMOTE: http://localhost:4444/wd/hub
       APPLITOOLS_API_KEY_SDK: ${{secrets.APPLITOOLS_API_KEY_SDK}}

--- a/packages/eyes-common-legacy/package.json
+++ b/packages/eyes-common-legacy/package.json
@@ -58,7 +58,7 @@
     "preversion": "bongo preversion",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-common-legacy/package.json
+++ b/packages/eyes-common-legacy/package.json
@@ -57,7 +57,8 @@
     "typings": "tsc --declaration",
     "preversion": "bongo preversion",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-cypress/package.json
+++ b/packages/eyes-cypress/package.json
@@ -20,7 +20,8 @@
     "preversion": "bongo preversion --skip-deps && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "files": [
     "src",

--- a/packages/eyes-cypress/package.json
+++ b/packages/eyes-cypress/package.json
@@ -21,7 +21,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "files": [
     "src",

--- a/packages/eyes-images-legacy/package.json
+++ b/packages/eyes-images-legacy/package.json
@@ -63,7 +63,8 @@
     "typings": "tsc --declaration",
     "preversion": "bongo preversion",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "yarn build"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-images-legacy/package.json
+++ b/packages/eyes-images-legacy/package.json
@@ -64,7 +64,7 @@
     "preversion": "bongo preversion",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "yarn build"
+    "prepublish:setup": "yarn build"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-images/package.json
+++ b/packages/eyes-images/package.json
@@ -50,7 +50,8 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-images/package.json
+++ b/packages/eyes-images/package.json
@@ -51,7 +51,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-leanft/package.json
+++ b/packages/eyes-leanft/package.json
@@ -67,7 +67,8 @@
     "prepublishOnly": "npm run build && npm run minify",
     "preversion": "bongo preversion",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-leanft/package.json
+++ b/packages/eyes-leanft/package.json
@@ -68,7 +68,7 @@
     "preversion": "bongo preversion",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-nightwatch/package.json
+++ b/packages/eyes-nightwatch/package.json
@@ -90,7 +90,7 @@
     "preversion": "bongo preversion && yarn test && yarn coverage:prod",
     "postversion": "bongo postversion",
     "deps": "bongo deps",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-nightwatch/package.json
+++ b/packages/eyes-nightwatch/package.json
@@ -89,7 +89,8 @@
     "version": "bongo version",
     "preversion": "bongo preversion && yarn test && yarn coverage:prod",
     "postversion": "bongo postversion",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-playwright/package.json
+++ b/packages/eyes-playwright/package.json
@@ -65,7 +65,8 @@
     "preversion": "bongo preversion && yarn coverage:prod",
     "version": "bongo version",
     "postversion": "bongo postversion",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-playwright/package.json
+++ b/packages/eyes-playwright/package.json
@@ -66,7 +66,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-protractor/package.json
+++ b/packages/eyes-protractor/package.json
@@ -82,7 +82,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion",
     "deps": "bongo deps",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-protractor/package.json
+++ b/packages/eyes-protractor/package.json
@@ -81,7 +81,8 @@
     "preversion": "bongo preversion && yarn test && yarn coverage:prod",
     "version": "bongo version",
     "postversion": "bongo postversion",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-puppeteer/package.json
+++ b/packages/eyes-puppeteer/package.json
@@ -71,7 +71,8 @@
     "build": "docker build -t applitools/puppeteer-chrome .",
     "run:docker": "yarn build && docker run -e NODE_AUTH_TOKEN --env APPLITOOLS_API_KEY=$APPLITOOLS_API_KEY_SDK --env APPLITOOLS_BATCH_NAME='JS Coverage Tests: eyes-puppeteer' --env APPLITOOLS_BATCH_ID=$(uuidgen) --env XUNIT_FILE=coverage-test-report.xml -it --init --rm -v $(pwd):/sandbox applitools/puppeteer-chrome",
     "docker:setup": "echo 'docker:setup is a no-op. Move along, nothing to see here.'",
-    "moca": "yarn run:docker yarn mocha --no-timeouts"
+    "moca": "yarn run:docker yarn mocha --no-timeouts",
+    "setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-puppeteer/package.json
+++ b/packages/eyes-puppeteer/package.json
@@ -72,7 +72,7 @@
     "run:docker": "yarn build && docker run -e NODE_AUTH_TOKEN --env APPLITOOLS_API_KEY=$APPLITOOLS_API_KEY_SDK --env APPLITOOLS_BATCH_NAME='JS Coverage Tests: eyes-puppeteer' --env APPLITOOLS_BATCH_ID=$(uuidgen) --env XUNIT_FILE=coverage-test-report.xml -it --init --rm -v $(pwd):/sandbox applitools/puppeteer-chrome",
     "docker:setup": "echo 'docker:setup is a no-op. Move along, nothing to see here.'",
     "moca": "yarn run:docker yarn mocha --no-timeouts",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-sdk-core-legacy/package.json
+++ b/packages/eyes-sdk-core-legacy/package.json
@@ -55,7 +55,8 @@
     "typings": "tsc --declaration",
     "preversion": "bongo preversion",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "echo 'no setup'"
   },
   "browser": {
     "./src/FileLogHandler": false

--- a/packages/eyes-sdk-core-legacy/package.json
+++ b/packages/eyes-sdk-core-legacy/package.json
@@ -56,7 +56,7 @@
     "preversion": "bongo preversion",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "browser": {
     "./src/FileLogHandler": false

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -74,7 +74,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "bin": {
     "eyes-check-network": "./bin/runCheckNetwork.js"

--- a/packages/eyes-sdk-core/package.json
+++ b/packages/eyes-sdk-core/package.json
@@ -73,7 +73,8 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "bin": {
     "eyes-check-network": "./bin/runCheckNetwork.js"

--- a/packages/eyes-selenium-3/package.json
+++ b/packages/eyes-selenium-3/package.json
@@ -79,7 +79,8 @@
     "typings": "tsc --declaration",
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-selenium-3/package.json
+++ b/packages/eyes-selenium-3/package.json
@@ -80,7 +80,7 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-selenium/package.json
+++ b/packages/eyes-selenium/package.json
@@ -82,7 +82,8 @@
     "preversion": "bongo preversion && yarn test && yarn coverage:prod",
     "version": "bongo version",
     "postversion": "bongo postversion",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-selenium/package.json
+++ b/packages/eyes-selenium/package.json
@@ -83,7 +83,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion",
     "deps": "bongo deps",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-storybook/package.json
+++ b/packages/eyes-storybook/package.json
@@ -35,7 +35,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "docker:setup": "echo 'docker:setup is a no-op. Move along, nothing to see here.'"
+    "setup": "echo 'setup is a no-op. Move along, nothing to see here.'"
   },
   "keywords": [
     "applitools",

--- a/packages/eyes-storybook/package.json
+++ b/packages/eyes-storybook/package.json
@@ -35,7 +35,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'setup is a no-op. Move along, nothing to see here.'"
+    "prepublish:setup": "echo 'setup is a no-op. Move along, nothing to see here.'"
   },
   "keywords": [
     "applitools",

--- a/packages/eyes-webdriverio-4-service/package.json
+++ b/packages/eyes-webdriverio-4-service/package.json
@@ -12,7 +12,7 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "author": "",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/eyes-webdriverio-4-service/package.json
+++ b/packages/eyes-webdriverio-4-service/package.json
@@ -11,7 +11,8 @@
     "test": "wdio test/wdio.conf.js",
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
-    "postversion": "bongo postversion --skip-release-notification"
+    "postversion": "bongo postversion --skip-release-notification",
+    "setup": "echo 'no setup'"
   },
   "author": "",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/eyes-webdriverio-4/package.json
+++ b/packages/eyes-webdriverio-4/package.json
@@ -21,7 +21,7 @@
     "deps": "bongo deps",
     "start-chromedriver": "node scripts/start-chromedriver.js",
     "stop-chromedriver": "ps ax | grep chromedriver | grep port=4444 | awk '{print $1}' | xargs kill -9",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "author": "Applitools Team <team@applitools.com> (http://www.applitools.com/)",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/eyes-webdriverio-4/package.json
+++ b/packages/eyes-webdriverio-4/package.json
@@ -21,7 +21,7 @@
     "deps": "bongo deps",
     "start-chromedriver": "node scripts/start-chromedriver.js",
     "stop-chromedriver": "ps ax | grep chromedriver | grep port=4444 | awk '{print $1}' | xargs kill -9",
-    "blah": "echo $BLAH"
+    "setup": "yarn docker:setup"
   },
   "author": "Applitools Team <team@applitools.com> (http://www.applitools.com/)",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/eyes-webdriverio-5-service/package.json
+++ b/packages/eyes-webdriverio-5-service/package.json
@@ -45,7 +45,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-webdriverio-5-service/package.json
+++ b/packages/eyes-webdriverio-5-service/package.json
@@ -44,7 +44,8 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-webdriverio-5/package.json
+++ b/packages/eyes-webdriverio-5/package.json
@@ -86,7 +86,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion",
     "deps": "bongo deps",
-    "setup": "yarn docker:setup"
+    "prepublish:setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/eyes-webdriverio-5/package.json
+++ b/packages/eyes-webdriverio-5/package.json
@@ -85,7 +85,8 @@
     "preversion": "bongo preversion && yarn test && yarn coverage:prod",
     "version": "bongo version",
     "postversion": "bongo postversion",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "yarn docker:setup"
   },
   "license": "SEE LICENSE IN LICENSE",
   "engines": {

--- a/packages/sdk-coverage-tests/package.json
+++ b/packages/sdk-coverage-tests/package.json
@@ -24,7 +24,8 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/sdk-coverage-tests/package.json
+++ b/packages/sdk-coverage-tests/package.json
@@ -25,7 +25,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/sdk-fake-eyes-server/package.json
+++ b/packages/sdk-fake-eyes-server/package.json
@@ -34,7 +34,8 @@
     "preversion": "bongo preversion",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "engines": {
     "node": ">=8.9.0"

--- a/packages/sdk-fake-eyes-server/package.json
+++ b/packages/sdk-fake-eyes-server/package.json
@@ -35,7 +35,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "engines": {
     "node": ">=8.9.0"

--- a/packages/sdk-release-kit/package.json
+++ b/packages/sdk-release-kit/package.json
@@ -26,7 +26,7 @@
     "test": "mocha test/**/*.spec.js",
     "lint": "eslint . --ext .js",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/sdk-release-kit/package.json
+++ b/packages/sdk-release-kit/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "test": "mocha test/**/*.spec.js",
     "lint": "eslint . --ext .js",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/sdk-release-kit/src/cli/index.js
+++ b/packages/sdk-release-kit/src/cli/index.js
@@ -88,6 +88,9 @@ const command = args._[0]
             installedDirectory: path.join('.bongo', 'dry-run'),
           })
         }
+        if (!args.skipDeps) {
+          await commitFiles(!args.skipCommit)
+        }
         console.log('[bongo preversion] done!')
         return
       case 'send-release-notification':
@@ -122,7 +125,8 @@ const command = args._[0]
         writeReleaseEntryToChangelog(cwd)
         return await gitAdd('CHANGELOG.md')
       case 'deps':
-        return deps({shouldCommit: !args.skipCommit})
+        await deps()
+        return await commitFiles(!args.skipCommit)
       default:
         throw new Error('Invalid option provided')
     }
@@ -137,12 +141,15 @@ const command = args._[0]
   }
 })()
 
-async function deps({shouldCommit} = {}) {
+async function deps() {
   verifyUnfixedDeps(cwd)
   await yarnUpgrade({
     folder: cwd,
     upgradeAll: args.upgradeAll,
   })
+}
+
+async function commitFiles(shouldCommit = true) {
   if (shouldCommit) {
     await gitAdd('package.json')
     await gitAdd('CHANGELOG.md')

--- a/packages/sdk-shared/package.json
+++ b/packages/sdk-shared/package.json
@@ -35,7 +35,7 @@
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
     "deps": "bongo deps",
-    "setup": "echo 'no setup'"
+    "prepublish:setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/sdk-shared/package.json
+++ b/packages/sdk-shared/package.json
@@ -34,7 +34,8 @@
     "preversion": "bongo preversion && yarn test",
     "version": "bongo version",
     "postversion": "bongo postversion --skip-release-notification",
-    "deps": "bongo deps"
+    "deps": "bongo deps",
+    "setup": "echo 'no setup'"
   },
   "bugs": {
     "url": "https://github.com/applitools/eyes.sdk.javascript1/issues"

--- a/packages/side-eyes/package.json
+++ b/packages/side-eyes/package.json
@@ -9,6 +9,7 @@
     "build": "yarn build:page && webpack",
     "build:prod": "rm -rf build && env NODE_ENV=production yarn build",
     "build:page": "webpack --config webpack.config.page.babel.js",
+    "setup": "yarn build:prod",
     "test": "jest",
     "test:code-export:csharp": "node tests/e2e/code-export/run-tests.js csharp-nunit",
     "test:code-export:csharp:vg": "node tests/e2e/code-export/run-tests.js csharp-nunit true",

--- a/packages/side-eyes/package.json
+++ b/packages/side-eyes/package.json
@@ -9,7 +9,7 @@
     "build": "yarn build:page && webpack",
     "build:prod": "rm -rf build && env NODE_ENV=production yarn build",
     "build:page": "webpack --config webpack.config.page.babel.js",
-    "setup": "yarn build:prod",
+    "prepublish:setup": "yarn build:prod",
     "test": "jest",
     "test:code-export:csharp": "node tests/e2e/code-export/run-tests.js csharp-nunit",
     "test:code-export:csharp:vg": "node tests/e2e/code-export/run-tests.js csharp-nunit true",

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -9,7 +9,7 @@
     "test:chrome": "mocha --no-timeouts --require test/util/hook.js --grep chrome ./test/*.spec.js",
     "test:ie": "mocha --no-timeouts --require test/util/hook.js --grep 'internet explorer' ./test/*.spec.js",
     "test:ios": "mocha --no-timeouts --require test/util/hook.js --grep 'ios safari' ./test/*.spec.js",
-    "setup": "yarn build",
+    "prepublish:setup": "yarn build",
     "build": "node ./rollup/cli bundle --format json --format snippet",
     "build:watch": "node ./rollup/cli watch --format json --format snippet",
     "preversion": "yarn build && bongo preversion && yarn test",

--- a/packages/snippets/package.json
+++ b/packages/snippets/package.json
@@ -9,6 +9,7 @@
     "test:chrome": "mocha --no-timeouts --require test/util/hook.js --grep chrome ./test/*.spec.js",
     "test:ie": "mocha --no-timeouts --require test/util/hook.js --grep 'internet explorer' ./test/*.spec.js",
     "test:ios": "mocha --no-timeouts --require test/util/hook.js --grep 'ios safari' ./test/*.spec.js",
+    "setup": "yarn build",
     "build": "node ./rollup/cli bundle --format json --format snippet",
     "build:watch": "node ./rollup/cli watch --format json --format snippet",
     "preversion": "yarn build && bongo preversion && yarn test",

--- a/packages/visual-grid-client/package.json
+++ b/packages/visual-grid-client/package.json
@@ -79,7 +79,7 @@
     "test:e2e": "mocha --no-timeouts \"test/e2e/**/*.test.js\"",
     "build:browser": "cd test/fixtures/test-app && yarn install --focused && yarn build",
     "test:browser": "mocha --no-timeouts 'test/browser/**/*.test.js'",
-    "setup": "echo 'no setup'",
+    "prepublish:setup": "echo 'no setup'",
     "test": "yarn build:browser && yarn test:mocha",
     "render": "node example/render.js",
     "preversion": "bongo preversion && yarn test",

--- a/packages/visual-grid-client/package.json
+++ b/packages/visual-grid-client/package.json
@@ -79,6 +79,7 @@
     "test:e2e": "mocha --no-timeouts \"test/e2e/**/*.test.js\"",
     "build:browser": "cd test/fixtures/test-app && yarn install --focused && yarn build",
     "test:browser": "mocha --no-timeouts 'test/browser/**/*.test.js'",
+    "setup": "echo 'no setup'",
     "test": "yarn build:browser && yarn test:mocha",
     "render": "node example/render.js",
     "preversion": "bongo preversion && yarn test",


### PR DESCRIPTION
## improvements
- temp branch name with timestamp
- grouped stdout
- run `yarn docker:setup` if `use docker` is `true`
- update master with new version

## possible improvements
- change `use docker` to `prepublish` and have it be a string - so if you need to run `tsc` instead of `yarn docker:setup` you can just provide it from the action menu.
- update branch temp name to be the **intended** version - this is a bit tricky because we need to know the version prior to running `yarn publish`
- rename to `Publish` as now we can use the same workflow for dev\internal packages as well.