### PR TITLE
fix: bongo commit 

### DIFF
--- a/packages/sdk-release-kit/src/cli/index.js
+++ b/packages/sdk-release-kit/src/cli/index.js
@@ -33,7 +33,7 @@ const {lint} = require('../lint')
 const sendReleaseNotification = require('../send-report')
 const {createDotFolder} = require('../setup')
 const {verifyCommits, verifyInstalledVersions, verifyVersions} = require('../versions')
-const {gitAdd, gitCommit, gitPushWithTags, isStagedForCommit} = require('../git')
+const {gitAdd, gitCommit, gitPushWithTags, isChanged} = require('../git')
 const {yarnInstall, yarnUpgrade, verifyUnfixedDeps} = require('../yarn')
 
 const command = args._[0]
@@ -88,6 +88,7 @@ const command = args._[0]
             installedDirectory: path.join('.bongo', 'dry-run'),
           })
         }
+        await commitFiles()
         console.log('[bongo preversion] done!')
         return
       case 'send-release-notification':
@@ -122,7 +123,8 @@ const command = args._[0]
         writeReleaseEntryToChangelog(cwd)
         return await gitAdd('CHANGELOG.md')
       case 'deps':
-        return deps({shouldCommit: !args.skipCommit})
+        await deps()
+        return await commitFiles()
       default:
         throw new Error('Invalid option provided')
     }
@@ -137,17 +139,26 @@ const command = args._[0]
   }
 })()
 
-async function deps({shouldCommit} = {}) {
+async function deps() {
   verifyUnfixedDeps(cwd)
   await yarnUpgrade({
     folder: cwd,
     upgradeAll: args.upgradeAll,
   })
+}
+
+async function commitFiles(shouldCommit = true) {
   if (shouldCommit) {
-    await gitAdd('package.json')
-    await gitAdd('CHANGELOG.md')
-    await gitAdd('yarn.lock')
-    if (await isStagedForCommit('package.json', 'CHANGELOG.md', 'yarn.lock')) {
+    const files = ['package.json', 'CHANGELOG.md', 'yarn.lock']
+    for (const file of files) {
+      // git add fails when trying to add files that weren't changed
+      if (await isChanged(file)) {
+        await gitAdd(file)
+      }
+    }
+
+    // git commit fails when trying to commit files that weren't changed
+    if (await isChanged(files)) {
       const pkgName = JSON.parse(fs.readFileSync(path.resolve(cwd, 'package.json'))).name
       await gitCommit(`[auto commit] ${pkgName}: upgrade deps`)
     }

--- a/packages/sdk-release-kit/src/git/index.js
+++ b/packages/sdk-release-kit/src/git/index.js
@@ -25,7 +25,7 @@ async function gitStatus() {
 async function isChanged(...files) {
   const {stdout} = await gitStatus()
   const modifiedFiles = stdout.split('\n')
-  return files.some(file => modifiedFiles.includes(`M  ${file}`))
+  return files.some(file => modifiedFiles.includes(`M ${file}`))
 }
 
 module.exports = {

--- a/packages/sdk-release-kit/src/git/index.js
+++ b/packages/sdk-release-kit/src/git/index.js
@@ -24,7 +24,7 @@ async function gitStatus() {
 
 async function isChanged(...files) {
   const {stdout} = await gitStatus()
-  const modifiedFiles = stdout.split('\n')
+  const modifiedFiles = stdout.split('\n').map(line => line.trim())
   return files.some(file => modifiedFiles.includes(`M ${file}`))
 }
 

--- a/packages/sdk-release-kit/test/git/fixtures/changed.json
+++ b/packages/sdk-release-kit/test/git/fixtures/changed.json
@@ -1,0 +1,3 @@
+{
+    "change": "this"
+}

--- a/packages/sdk-release-kit/test/git/fixtures/changed.json
+++ b/packages/sdk-release-kit/test/git/fixtures/changed.json
@@ -1,3 +1,3 @@
 {
-  "change": "new value"
+  "change": 0.7870997949178407
 }

--- a/packages/sdk-release-kit/test/git/fixtures/changed.json
+++ b/packages/sdk-release-kit/test/git/fixtures/changed.json
@@ -1,3 +1,3 @@
 {
-    "change": "this"
+  "change": "new value"
 }

--- a/packages/sdk-release-kit/test/git/git.spec.js
+++ b/packages/sdk-release-kit/test/git/git.spec.js
@@ -1,15 +1,33 @@
 const assert = require('assert')
 const {gitStatus, isChanged} = require('../../src/git')
+const jsonFile = require('./fixtures/changed.json')
 const path = require('path')
 // eslint-disable-next-line node/no-unsupported-features/node-builtins
 const fs = require('fs').promises
 
+async function randomizeJson() {
+  const json = {...jsonFile}
+  json.change = Math.random(1)
+  await fs.writeFile(path.join(__dirname, 'fixtures/changed.json'), JSON.stringify(json, null, 2))
+}
+
 describe('git', () => {
+  afterEach(async () => {
+    await fs.writeFile(
+      path.join(__dirname, 'fixtures/changed.json'),
+      JSON.stringify(jsonFile, null, 2),
+    )
+  })
+
   it('should get changed files', async () => {
-    const json = require('./fixtures/changed.json')
-    json.change = 'new value'
-    await fs.writeFile(path.join(__dirname, 'fixtures/changed.json'), JSON.stringify(json, null, 2))
-    const changed = await isChanged('packages/sdk-release-kit/test/git/fixtures/changed.json')
+    await randomizeJson()
+    const changed = await isChanged('test/git/fixtures/changed.json')
     assert.strictEqual(changed, true)
+  })
+
+  it('should do git status', async () => {
+    await randomizeJson()
+    const {stdout} = await gitStatus()
+    assert(stdout.includes('changed.json'))
   })
 })

--- a/packages/sdk-release-kit/test/git/git.spec.js
+++ b/packages/sdk-release-kit/test/git/git.spec.js
@@ -5,14 +5,11 @@ const path = require('path')
 const fs = require('fs').promises
 
 describe('git', () => {
-  afterEach(async () => {
-    // await fs.unlink(path.join(__dirname + '/hello.txt'))
-  })
-
   it('should get changed files', async () => {
-    await fs.writeFile(path.join(__dirname + '/hello.txt'), 'test')
-    const files = ['hello.txt']
-    const changed = await isChanged(files)
+    const json = require('./fixtures/changed.json')
+    json.change = 'new value'
+    await fs.writeFile(path.join(__dirname, 'fixtures/changed.json'), JSON.stringify(json, null, 2))
+    const changed = await isChanged('packages/sdk-release-kit/test/git/fixtures/changed.json')
     assert.strictEqual(changed, true)
   })
 })

--- a/packages/sdk-release-kit/test/git/git.spec.js
+++ b/packages/sdk-release-kit/test/git/git.spec.js
@@ -1,0 +1,18 @@
+const assert = require('assert')
+const {gitStatus, isChanged} = require('../../src/git')
+const path = require('path')
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
+const fs = require('fs').promises
+
+describe('git', () => {
+  afterEach(async () => {
+    // await fs.unlink(path.join(__dirname + '/hello.txt'))
+  })
+
+  it('should get changed files', async () => {
+    await fs.writeFile(path.join(__dirname + '/hello.txt'), 'test')
+    const files = ['hello.txt']
+    const changed = await isChanged(files)
+    assert.strictEqual(changed, true)
+  })
+})


### PR DESCRIPTION
- include `yarn.lock` in final commit
- run at the very end of the `preversion` and `deps` flow
- doesn't break CI when some files weren't changed (`git add` and `git commit` give out an exit code 1 if the provided files did not change)