### PR TITLE
fix: Appium viewport size extraction

### DIFF
--- a/packages/eyes-sdk-core/lib/sdk/EyesElement.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesElement.js
@@ -93,13 +93,16 @@ class EyesElement {
     return this.withRefresh(async () => {
       if (this._context.driver.isNative) {
         const rect = await this.spec.getElementRect(this._context.unwrapped, this._element)
-        return new Region({
+        const region = new Region({
           left: rect.x,
           top: rect.y,
           width: rect.width,
           height: rect.height,
           coordinatesType: CoordinatesTypes.CONTEXT_RELATIVE,
         })
+        return this._context.driver._pixelRatio
+          ? region.scale(1 / this._context.driver._pixelRatio)
+          : region
       } else {
         return EyesUtils.getElementRect(this._logger, this._context, this)
       }

--- a/packages/eyes-selenium/src/spec-driver.selenium3.js
+++ b/packages/eyes-selenium/src/spec-driver.selenium3.js
@@ -109,9 +109,13 @@ async function findElements(driver, selector) {
   return driver.findElements(transformSelector(selector))
 }
 async function getElementRect(_driver, element) {
-  const {x, y} = await element.getLocation()
-  const {width, height} = await element.getSize()
-  return {x, y, width, height}
+  if (TypeUtils.isFunction(element.getRect)) {
+    return element.getRect()
+  } else {
+    const {x, y} = await element.getLocation()
+    const {width, height} = await element.getSize()
+    return {x, y, width, height}
+  }
 }
 async function getWindowRect(driver) {
   try {
@@ -188,15 +192,20 @@ async function getDriverInfo(driver) {
   const browserName = capabilities.get('browserName')
   const browserVersion = capabilities.get('browserVersion')
   const isMobile = ['android', 'ios'].includes(platformName && platformName.toLowerCase())
+  const isNative = isMobile && !browserName
+  const viewportRect = isNative ? capabilities.get('viewportRect') : null
+  const pixelRatio = isNative ? capabilities.get('pixelRatio') : null
   return {
     sessionId,
     isMobile,
-    isNative: isMobile && !browserName,
+    isNative,
     deviceName,
     platformName,
     platformVersion,
     browserName,
     browserVersion,
+    viewportRect,
+    pixelRatio,
   }
 }
 async function getTitle(driver) {

--- a/packages/eyes-selenium/src/spec-driver.selenium4.js
+++ b/packages/eyes-selenium/src/spec-driver.selenium4.js
@@ -138,16 +138,20 @@ async function getDriverInfo(driver) {
   const browserName = capabilities.get('browserName')
   const browserVersion = capabilities.get('browserVersion')
   const isMobile = ['android', 'ios'].includes(platformName && platformName.toLowerCase())
-
+  const isNative = isMobile && !browserName
+  const viewportRect = isNative ? capabilities.get('viewportRect') : null
+  const pixelRatio = isNative ? capabilities.get('pixelRatio') : null
   return {
     sessionId,
     isMobile,
-    isNative: isMobile && !browserName,
+    isNative,
     deviceName,
     platformName,
     platformVersion,
     browserName,
     browserVersion,
+    viewportRect,
+    pixelRatio,
   }
 }
 async function getTitle(driver) {

--- a/packages/eyes-webdriverio-5/src/spec-driver.js
+++ b/packages/eyes-webdriverio-5/src/spec-driver.js
@@ -208,10 +208,11 @@ async function getOrientation(browser) {
   return orientation.toLowerCase()
 }
 async function getDriverInfo(browser) {
+  const isNative = browser.isMobile && !browser.capabilities.browserName
   return {
     sessionId: browser.sessionId,
     isMobile: browser.isMobile,
-    isNative: browser.isMobile && !browser.capabilities.browserName,
+    isNative,
     deviceName: browser.capabilities.desired
       ? browser.capabilities.desired.deviceName
       : browser.capabilities.deviceName,
@@ -219,6 +220,8 @@ async function getDriverInfo(browser) {
     platformVersion: browser.capabilities.platformVersion,
     browserName: browser.capabilities.browserName,
     browserVersion: browser.capabilities.browserVersion,
+    viewportRect: isNative ? browser.capabilities.viewportRect : null,
+    pixelRatio: isNative ? browser.capabilities.pixelRatio : null,
   }
 }
 async function getTitle(browser) {


### PR DESCRIPTION
I find out that the capabilities of the appium drivers contain information that allows us to detect viewport size correctly without doing any extra calls to the driver. Before this PR the viewport size (and screenshot) never wasn't properly scaled and also include a status bar on the top.