### PR TITLE
fix: fixing storybook cli

### DIFF
--- a/packages/eyes-storybook/package.json
+++ b/packages/eyes-storybook/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint '**/*.js'",
     "storybook": "start-storybook -c test/fixtures/appWithStorybook -p 9001 -s test/fixtures",
     "storybook:heavy": "start-storybook -c test/fixtures/heavyStorybook -p 9002 -s test/fixtures",
-    "eyes-storybook": "node bin/eyes-storybook.js -f test/fixtures/applitools.config.js",
+    "eyes-storybook": "node bin/eyes-storybook.js",
     "eyes-storybook:heavy": "node bin/eyes-storybook.js -f test/fixtures/heavyStorybook/applitools.config.js",
     "eyes-storybook:configured": "node bin/eyes-storybook.js -f scripts/preconfigured.config.js",
     "changelog": "git changelog -x -p -f v$npm_package_version > History.md && git add ./History.md && git commit -am 'changelog'",

--- a/packages/eyes-storybook/src/yargsOptions.js
+++ b/packages/eyes-storybook/src/yargsOptions.js
@@ -2,17 +2,23 @@ module.exports = {
   conf: {
     alias: 'f',
     description: 'Path to applitools.config.js config file',
+    default: 'test/fixtures/applitools.config.js',
     requiresArg: true,
     string: true,
   },
-
+  serverUrl: {
+    alias: ['server-url', 'srv'],
+    description: 'URL to eyes server',
+    default: 'https://eyes.applitools.com',
+    requiresArg: true,
+    string: true,
+  },
   storybookUrl: {
     alias: ['storybook-url', 'u'],
     description: 'URL to storybook',
     requiresArg: true,
     string: true,
   },
-
   // storybook options
   storybookPort: {
     alias: ['storybook-port', 'p'],


### PR DESCRIPTION
## storybook cli
added:
- usage of `yargs` defaults.
- `server-url` option that will run against a non-default eyes-server. (defaults to `https://eyes.applitools.com`.
- `config` with default value instead of the hardcoded `-f <some-path` in `package.json`.

## improvements that are not in this PR
- use `yargs` as god intended.
- for all sdks: use a unified reporting library for test results