### PR TITLE
Add API for getting device sizes from VGC

### DIFF
--- a/packages/visual-grid-client/src/sdk/EyesWrapper.js
+++ b/packages/visual-grid-client/src/sdk/EyesWrapper.js
@@ -144,6 +144,14 @@ class EyesWrapper extends EyesBase {
     return this._serverConnector.renderStatusById(renderId)
   }
 
+  getEmulatedDevicesSizes() {
+    return this._serverConnector.getEmulatedDevicesSizes()
+  }
+
+  getIosDevicesSizes() {
+    return this._serverConnector.getIosDevicesSizes()
+  }
+
   logEvents(events) {
     return this._serverConnector.logEvents(events)
   }

--- a/packages/visual-grid-client/src/sdk/getRenderMethods.js
+++ b/packages/visual-grid-client/src/sdk/getRenderMethods.js
@@ -9,6 +9,8 @@ function getRenderMethods(renderWrapper) {
   const setRenderingInfo = renderWrapper.setRenderingInfo.bind(renderWrapper)
   const doGetRenderJobInfo = renderWrapper.getRenderJobInfo.bind(renderWrapper)
   const doLogEvents = renderWrapper.logEvents.bind(renderWrapper)
+  const doGetEmulatedDevicesSizes = renderWrapper.getEmulatedDevicesSizes.bind(renderWrapper)
+  const doGetIosDevicesSizes = renderWrapper.getIosDevicesSizes.bind(renderWrapper)
   return {
     doGetRenderInfo,
     doRenderBatch,
@@ -18,6 +20,8 @@ function getRenderMethods(renderWrapper) {
     setRenderingInfo,
     doGetRenderJobInfo,
     doLogEvents,
+    doGetEmulatedDevicesSizes,
+    doGetIosDevicesSizes,
   }
 }
 

--- a/packages/visual-grid-client/src/sdk/renderingGridClient.js
+++ b/packages/visual-grid-client/src/sdk/renderingGridClient.js
@@ -129,6 +129,8 @@ function makeRenderingGridClient({
     setRenderingInfo,
     doGetRenderJobInfo,
     doLogEvents,
+    doGetEmulatedDeviceSizes,
+    doGetIosDevicesSizes,
   } = getRenderMethods(renderWrapper)
   const resourceCache = createResourceCache()
   const fetchCache = createResourceCache()
@@ -220,12 +222,17 @@ function makeRenderingGridClient({
   const closeBatch = makeCloseBatch({globalState, dontCloseBatches, isDisabled})
   const testWindow = makeTestWindow(openConfig)
 
+  let emulatedDevicesSizes
+  let iosDevicesSizes
+
   return {
     openEyes,
     closeBatch,
     globalState,
     testWindow,
     getResourceUrlsInCache,
+    getIosDevicesSizes,
+    getEmulatedDevicesSizes,
   }
 
   async function getInitialData() {
@@ -267,6 +274,20 @@ function makeRenderingGridClient({
 
     setRenderingInfo(renderInfo)
     return {renderInfo}
+  }
+
+  async function getEmulatedDevicesSizes() {
+    if (!emulatedDevicesSizes) {
+      emulatedDevicesSizes = await doGetEmulatedDeviceSizes()
+    }
+    return emulatedDevicesSizes
+  }
+
+  async function getIosDevicesSizes() {
+    if (!iosDevicesSizes) {
+      iosDevicesSizes = await doGetIosDevicesSizes()
+    }
+    return iosDevicesSizes
   }
 
   function getResourceUrlsInCache() {

--- a/packages/visual-grid-client/src/sdk/renderingGridClient.js
+++ b/packages/visual-grid-client/src/sdk/renderingGridClient.js
@@ -129,7 +129,7 @@ function makeRenderingGridClient({
     setRenderingInfo,
     doGetRenderJobInfo,
     doLogEvents,
-    doGetEmulatedDeviceSizes,
+    doGetEmulatedDevicesSizes,
     doGetIosDevicesSizes,
   } = getRenderMethods(renderWrapper)
   const resourceCache = createResourceCache()
@@ -278,7 +278,7 @@ function makeRenderingGridClient({
 
   async function getEmulatedDevicesSizes() {
     if (!emulatedDevicesSizes) {
-      emulatedDevicesSizes = await doGetEmulatedDeviceSizes()
+      emulatedDevicesSizes = await doGetEmulatedDevicesSizes()
     }
     return emulatedDevicesSizes
   }

--- a/packages/visual-grid-client/test/it/renderingGridClient.it.test.js
+++ b/packages/visual-grid-client/test/it/renderingGridClient.it.test.js
@@ -45,4 +45,28 @@ describe('renderingGridClient', () => {
       expect(err.message).to.equal(apiKeyFailMsg)
     }
   })
+
+  it('getEmulatedDevicesSizes calls proper method on EyesWrapper', async () => {
+    const wrapper = createFakeWrapper('http://some_url')
+    const {getEmulatedDevicesSizes} = makeRenderingGridClient({
+      showLogs: process.env.APPLITOOLS_SHOW_LOGS,
+      appName,
+      renderWrapper: wrapper,
+    })
+
+    const result = await getEmulatedDevicesSizes()
+    expect(result).to.eql(['emulated device 1', 'emulated device 2'])
+  })
+
+  it('getIosDevicesSizes calls proper method on EyesWrapper', async () => {
+    const wrapper = createFakeWrapper('http://some_url')
+    const {getIosDevicesSizes} = makeRenderingGridClient({
+      showLogs: process.env.APPLITOOLS_SHOW_LOGS,
+      appName,
+      renderWrapper: wrapper,
+    })
+
+    const result = await getIosDevicesSizes()
+    expect(result).to.eql(['ios device 1', 'ios device 2'])
+  })
 })

--- a/packages/visual-grid-client/test/util/FakeEyesWrapper.js
+++ b/packages/visual-grid-client/test/util/FakeEyesWrapper.js
@@ -64,6 +64,8 @@ class FakeEyesWrapper extends EventEmitter {
     this.closeErr = closeErr
     this.failRender = failRender
     this._serverConnector = {deleteBatchSessions: () => {}}
+    this._emulatedDevices = ['emulated device 1', 'emulated device 2']
+    this._iosDevices = ['ios device 1', 'ios device 2']
   }
 
   async open(...args) {
@@ -476,6 +478,14 @@ class FakeEyesWrapper extends EventEmitter {
 
   getProxy() {
     return this.proxy
+  }
+
+  async getEmulatedDevicesSizes() {
+    return this._emulatedDevices
+  }
+
+  async getIosDevicesSizes() {
+    return this._iosDevices
   }
 }
 


### PR DESCRIPTION
This is needed for Storybook and Cypress to get device information when layoutBreakpoints is used.
Caching is done inside VGC, and requests are fired lazily.