### PR TITLE
fix(takeDomSnapshot): fix CORS frames with same src attribute

### DIFF
--- a/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
@@ -6,6 +6,7 @@ const {promisify} = require('util')
 const TypeUtils = require('./TypeUtils')
 const DateTimeUtils = require('./DateTimeUtils')
 const chalk = require('chalk')
+const {URL} = require('url')
 
 const promisifiedExec = promisify && exec && promisify(exec)
 const ENV_PREFIXES = ['APPLITOOLS_', 'bamboo_APPLITOOLS_']
@@ -51,6 +52,18 @@ function stripTrailingSlash(url) {
  */
 function isAbsoluteUrl(url) {
   return /^[a-z][a-z0-9+.-]*:/.test(url)
+}
+
+/**
+ * Add unique query parameter to URL
+ *
+ * @param {string} url
+ * @return {string} - URL with unique query parameter
+ */
+function uniqueUrl(url, query) {
+  const uniqueId = guid()
+  const uniqueUrl = new URL(url)
+  return uniqueUrl.searchParams.append(query, uniqueId)
 }
 
 /**
@@ -506,4 +519,5 @@ module.exports = {
   cachify,
   getBreakpointWidth,
   deprecationWarning,
+  uniqueUrl,
 }

--- a/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
+++ b/packages/eyes-sdk-core/lib/utils/GeneralUtils.js
@@ -63,7 +63,8 @@ function isAbsoluteUrl(url) {
 function uniqueUrl(url, query) {
   const uniqueId = guid()
   const uniqueUrl = new URL(url)
-  return uniqueUrl.searchParams.append(query, uniqueId)
+  if (!url.includes(query)) uniqueUrl.searchParams.append(query, uniqueId)
+  return uniqueUrl.href
 }
 
 /**

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -10,6 +10,8 @@ const ArgumentGuard = require('./ArgumentGuard')
 const EyesUtils = require('../sdk/EyesUtils')
 const deserializeDomSnapshotResult = require('./deserializeDomSnapshotResult')
 const createFramesPaths = require('./createFramesPaths')
+const GeneralUtils = require('./GeneralUtils')
+const {URL} = require('url')
 
 const EXECUTION_TIMEOUT = 5 * 60 * 1000
 const POLL_TIMEOUT = 200
@@ -88,6 +90,10 @@ async function takeDomSnapshot(logger, driver, options = {}) {
         })
       if (frameContext) {
         const frameSnapshot = await takeContextDomSnapshot(frameContext)
+        const uniqueId = GeneralUtils.guid()
+        const url = new URL(frameSnapshot.url)
+        url.searchParams.append('applitools-iframe', uniqueId)
+        frameSnapshot.url = url.href
         parentSnapshot.frames.push(frameSnapshot)
         cdtNode.attributes.push({name: 'data-applitools-src', value: frameSnapshot.url})
       }

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -90,9 +90,7 @@ async function takeDomSnapshot(logger, driver, options = {}) {
         })
       if (frameContext) {
         const frameSnapshot = await takeContextDomSnapshot(frameContext)
-        if (frameSnapshot.url) {
-          frameSnapshot.url = generateUniqueUrl(frameSnapshot.url, 'applitools-iframe')
-        }
+        frameSnapshot.url = generateUniqueUrl(frameSnapshot.url, 'applitools-iframe')
         parentSnapshot.frames.push(frameSnapshot)
         cdtNode.attributes.push({name: 'data-applitools-src', value: frameSnapshot.url})
       }

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -90,10 +90,12 @@ async function takeDomSnapshot(logger, driver, options = {}) {
         })
       if (frameContext) {
         const frameSnapshot = await takeContextDomSnapshot(frameContext)
-        const uniqueId = GeneralUtils.guid()
-        const url = new URL(frameSnapshot.url)
-        url.searchParams.append('applitools-iframe', uniqueId)
-        frameSnapshot.url = url.href
+        if (frameSnapshot.url) {
+          const uniqueId = GeneralUtils.guid()
+          const url = new URL(frameSnapshot.url)
+          url.searchParams.append('applitools-iframe', uniqueId)
+          frameSnapshot.url = url.href
+        }
         parentSnapshot.frames.push(frameSnapshot)
         cdtNode.attributes.push({name: 'data-applitools-src', value: frameSnapshot.url})
       }

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -16,7 +16,7 @@ const EXECUTION_TIMEOUT = 5 * 60 * 1000
 const POLL_TIMEOUT = 200
 const DEFAULT_CHUNK_BYTE_LENGTH = 262144000 // 250MB (could be 256MB but decide to leave a 6MB buffer)
 
-async function takeDomSnapshot(logger, driver, options = {}) {
+async function takeDomSnapshot(logger, driver, options = {uniqueUrl}) {
   ArgumentGuard.notNull(logger, 'logger')
   ArgumentGuard.notNull(driver, 'driver')
   const {
@@ -29,7 +29,7 @@ async function takeDomSnapshot(logger, driver, options = {}) {
     skipResources,
     removeReverseProxyURLPrefixes = !!process.env
       .APPLITOOLS_SCRIPT_REMOVE_REVERSE_PROXY_URL_PREFIXES,
-    generateUniqueUrl = uniqueUrl,
+    uniqueUrl,
   } = options
   const isLegacyBrowser = driver.isIE || driver.isEdgeLegacy
   const arg = {
@@ -90,7 +90,7 @@ async function takeDomSnapshot(logger, driver, options = {}) {
         })
       if (frameContext) {
         const frameSnapshot = await takeContextDomSnapshot(frameContext)
-        frameSnapshot.url = generateUniqueUrl(frameSnapshot.url, 'applitools-iframe')
+        frameSnapshot.url = uniqueUrl(frameSnapshot.url, 'applitools-iframe')
         parentSnapshot.frames.push(frameSnapshot)
         cdtNode.attributes.push({name: 'data-applitools-src', value: frameSnapshot.url})
       }

--- a/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
+++ b/packages/eyes-sdk-core/lib/utils/takeDomSnapshot.js
@@ -10,8 +10,7 @@ const ArgumentGuard = require('./ArgumentGuard')
 const EyesUtils = require('../sdk/EyesUtils')
 const deserializeDomSnapshotResult = require('./deserializeDomSnapshotResult')
 const createFramesPaths = require('./createFramesPaths')
-const GeneralUtils = require('./GeneralUtils')
-const {URL} = require('url')
+const {uniqueUrl} = require('./GeneralUtils')
 
 const EXECUTION_TIMEOUT = 5 * 60 * 1000
 const POLL_TIMEOUT = 200
@@ -30,6 +29,7 @@ async function takeDomSnapshot(logger, driver, options = {}) {
     skipResources,
     removeReverseProxyURLPrefixes = !!process.env
       .APPLITOOLS_SCRIPT_REMOVE_REVERSE_PROXY_URL_PREFIXES,
+    generateUniqueUrl = uniqueUrl,
   } = options
   const isLegacyBrowser = driver.isIE || driver.isEdgeLegacy
   const arg = {
@@ -91,10 +91,7 @@ async function takeDomSnapshot(logger, driver, options = {}) {
       if (frameContext) {
         const frameSnapshot = await takeContextDomSnapshot(frameContext)
         if (frameSnapshot.url) {
-          const uniqueId = GeneralUtils.guid()
-          const url = new URL(frameSnapshot.url)
-          url.searchParams.append('applitools-iframe', uniqueId)
-          frameSnapshot.url = url.href
+          frameSnapshot.url = generateUniqueUrl(frameSnapshot.url, 'applitools-iframe')
         }
         parentSnapshot.frames.push(frameSnapshot)
         cdtNode.attributes.push({name: 'data-applitools-src', value: frameSnapshot.url})

--- a/packages/eyes-sdk-core/test/it/takeDomSnapshot.spec.js
+++ b/packages/eyes-sdk-core/test/it/takeDomSnapshot.spec.js
@@ -69,15 +69,15 @@ describe('takeDomSnapshot', () => {
             crossFrames: [{selector: '[data-applitools-selector="123"]', index: 0}],
           })
     })
-    const snapshot = await takeDomSnapshot(logger, eyesDriver)
-    derandomizeUrls(snapshot)
+    const uniqueUrl = 'https://cors.com/?applitools-iframe=0'
+    const snapshot = await takeDomSnapshot(logger, eyesDriver, {
+      generateUniqueUrl: () => uniqueUrl,
+    })
     expect(snapshot).to.eql({
       cdt: [
         {
           nodeName: 'IFRAME',
-          attributes: [
-            {name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=0'},
-          ],
+          attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
         },
       ],
       resourceContents: {},
@@ -88,7 +88,7 @@ describe('takeDomSnapshot', () => {
         {
           cdt: 'frame-cdt',
           frames: [],
-          url: 'http://cors.com/?applitools-iframe=0',
+          url: uniqueUrl,
           resourceContents: {},
           resourceUrls: [],
           scriptVersion: 'mock value',
@@ -134,21 +134,17 @@ describe('takeDomSnapshot', () => {
           })
       }
     })
-    const snapshot = await takeDomSnapshot(logger, eyesDriver)
-    derandomizeUrls(snapshot)
+    const uniqueUrl = 'http://cors.com/?applitools-iframe=0'
+    const snapshot = await takeDomSnapshot(logger, eyesDriver, {generateUniqueUrl: () => uniqueUrl})
     expect(snapshot).to.eql({
       cdt: [
         {
           nodeName: 'IFRAME',
-          attributes: [
-            {name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=0'},
-          ],
+          attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
         },
         {
           nodeName: 'IFRAME',
-          attributes: [
-            {name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=1'},
-          ],
+          attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
         },
       ],
       resourceContents: {},
@@ -159,7 +155,7 @@ describe('takeDomSnapshot', () => {
         {
           cdt: 'frame-cdt',
           frames: [],
-          url: 'http://cors.com/?applitools-iframe=0',
+          url: uniqueUrl,
           resourceContents: {},
           resourceUrls: [],
           scriptVersion: 'mock value',
@@ -168,7 +164,7 @@ describe('takeDomSnapshot', () => {
         {
           cdt: 'another-frame-cdt',
           frames: [],
-          url: 'http://cors.com/?applitools-iframe=1',
+          url: uniqueUrl,
           resourceContents: {},
           resourceUrls: [],
           scriptVersion: 'mock value',
@@ -212,16 +208,13 @@ describe('takeDomSnapshot', () => {
           })
       }
     })
-
-    const snapshot = await takeDomSnapshot(logger, eyesDriver)
-    derandomizeUrls(snapshot)
+    const uniqueUrl = 'https://random.com/?applitools-iframe=1'
+    const snapshot = await takeDomSnapshot(logger, eyesDriver, {generateUniqueUrl: () => uniqueUrl})
     expect(snapshot).to.eql({
       cdt: [
         {
           nodeName: 'IFRAME',
-          attributes: [
-            {name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=0'},
-          ],
+          attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
         },
       ],
       frames: [
@@ -229,23 +222,21 @@ describe('takeDomSnapshot', () => {
           cdt: [
             {
               nodeName: 'IFRAME',
-              attributes: [
-                {name: 'data-applitools-src', value: 'http://cors-2.com/?applitools-iframe=0'},
-              ],
+              attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
             },
           ],
           frames: [
             {
               cdt: 'nested frame',
               frames: [],
-              url: 'http://cors-2.com/?applitools-iframe=0',
+              url: uniqueUrl,
               resourceContents: {},
               resourceUrls: [],
               scriptVersion: 'mock value',
               srcAttr: null,
             },
           ],
-          url: 'http://cors.com/?applitools-iframe=0',
+          url: uniqueUrl,
           resourceContents: {},
           resourceUrls: [],
           scriptVersion: 'mock value',
@@ -273,6 +264,7 @@ describe('takeDomSnapshot', () => {
       },
     ])
 
+    const uniqueUrl = 'https://cors.com/?applitools-iframe=0'
     driver.mockScript('dom-snapshot', function() {
       switch (this.name) {
         case '[data-applitools-selector="456"]':
@@ -287,8 +279,8 @@ describe('takeDomSnapshot', () => {
             frames: [
               generateSnapshotObject({
                 cdt: [{nodeName: 'IFRAME', attributes: []}],
+                url: uniqueUrl,
                 selector: '[data-applitools-selector="123"]',
-                url: 'https://cors.com/?applitools-iframe=1231324134134',
                 crossFrames: [{selector: '[data-applitools-selector="456"]', index: 0}],
               }),
             ],
@@ -296,8 +288,7 @@ describe('takeDomSnapshot', () => {
       }
     })
 
-    const snapshot = await takeDomSnapshot(logger, eyesDriver)
-    derandomizeUrls(snapshot)
+    const snapshot = await takeDomSnapshot(logger, eyesDriver, {generateUniqueUrl: () => uniqueUrl})
     expect(snapshot).to.eql({
       cdt: 'top page',
       frames: [
@@ -305,15 +296,13 @@ describe('takeDomSnapshot', () => {
           cdt: [
             {
               nodeName: 'IFRAME',
-              attributes: [
-                {name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=0'},
-              ],
+              attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
             },
           ],
           frames: [
             {
               cdt: 'nested frame',
-              url: 'http://cors.com/?applitools-iframe=0',
+              url: uniqueUrl,
               frames: [],
               resourceContents: {},
               resourceUrls: [],
@@ -325,7 +314,7 @@ describe('takeDomSnapshot', () => {
           resourceUrls: [],
           scriptVersion: 'mock value',
           srcAttr: null,
-          url: 'https://cors.com/?applitools-iframe=0',
+          url: uniqueUrl,
         },
       ],
       resourceContents: {},
@@ -420,13 +409,12 @@ describe('takeDomSnapshot', () => {
           })
       }
     })
-
-    const {cdt} = await takeDomSnapshot(logger, eyesDriver)
-    derandomizeUrls({cdt, frames: []})
+    const uniqueUrl = 'https://cors.com/?applitools-iframe=0'
+    const {cdt} = await takeDomSnapshot(logger, eyesDriver, {generateUniqueUrl: () => uniqueUrl})
     expect(cdt).to.deep.equal([
       {
         nodeName: 'IFRAME',
-        attributes: [{name: 'data-applitools-src', value: 'http://cors.com/?applitools-iframe=0'}],
+        attributes: [{name: 'data-applitools-src', value: uniqueUrl}],
       },
     ])
   })
@@ -446,32 +434,5 @@ function generateSnapshotObject(overrides) {
     crossFrames: undefined,
     scriptVersion: 'mock value',
     ...overrides,
-  }
-}
-// TODO move to sdk-shared
-function derandomizeUrls(snapshot) {
-  let counter = 0
-  for (const node of snapshot.cdt) {
-    if (node.attributes) {
-      for (const attr of node.attributes) {
-        attr.value = derandomizeValue(attr.value, counter++)
-      }
-    }
-  }
-  // reset counter for frames
-  counter = 0
-
-  for (const frame of snapshot.frames) {
-    frame.url = derandomizeValue(frame.url, counter++)
-    derandomizeUrls(frame)
-  }
-}
-
-function derandomizeValue(value, counter) {
-  if (value && value.includes('?applitools-iframe')) {
-    const randomNumber = value.match(/[^?=]*$/)[0]
-    return value.replace(randomNumber, counter)
-  } else {
-    return value
   }
 }

--- a/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const assert = require('assert')
+const chai = require('chai')
+chai.use(require('chai-uuid'))
+const expect = chai.expect
 const {URL} = require('url')
 
 const {GeneralUtils} = require('../../../index')
@@ -68,12 +71,11 @@ describe('GeneralUtils', () => {
   })
 
   describe('uniqueUrl()', () => {
-    const validGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
     it('generates a url with a query parameter that has a unique value', () => {
       const uniqueUrl = GeneralUtils.uniqueUrl('https://google.com', 'some_query')
       const parsedUrl = new URL(uniqueUrl)
       const guid = parsedUrl.searchParams.get('some_query')
-      assert.ok(validGuid.test(guid))
+      expect(guid).to.be.a.guid()
     })
 
     it('adds a unique guid to urls with existing query parameters', () => {
@@ -81,13 +83,13 @@ describe('GeneralUtils', () => {
       const uniqueUrl = GeneralUtils.uniqueUrl(url, 'some_search')
       const parsedUrl = new URL(uniqueUrl)
       const guid = parsedUrl.searchParams.get('some_search')
-      assert.ok(validGuid.test(guid))
+      expect(guid).to.be.a.guid()
     })
 
     it('does not generate a unique value if provided query parameter already exists', () => {
       const url = 'https://google.com/?some_query=some_value'
       const uniqueUrl = GeneralUtils.uniqueUrl(url, 'some_query')
-      assert.strictEqual(uniqueUrl, url)
+      expect(uniqueUrl).to.deep.equal(url)
     })
   })
 

--- a/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/GeneralUtils.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const {URL} = require('url')
 
 const {GeneralUtils} = require('../../../index')
 
@@ -63,6 +64,30 @@ describe('GeneralUtils', () => {
       assert.ok(!GeneralUtils.isAbsoluteUrl('/foo/bar'))
       assert.ok(!GeneralUtils.isAbsoluteUrl('foo/bar'))
       assert.ok(!GeneralUtils.isAbsoluteUrl('foo'))
+    })
+  })
+
+  describe('uniqueUrl()', () => {
+    const validGuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    it('generates a url with a query parameter that has a unique value', () => {
+      const uniqueUrl = GeneralUtils.uniqueUrl('https://google.com', 'some_query')
+      const parsedUrl = new URL(uniqueUrl)
+      const guid = parsedUrl.searchParams.get('some_query')
+      assert.ok(validGuid.test(guid))
+    })
+
+    it('adds a unique guid to urls with existing query parameters', () => {
+      const url = 'https://google.com/?some_query=some_value'
+      const uniqueUrl = GeneralUtils.uniqueUrl(url, 'some_search')
+      const parsedUrl = new URL(uniqueUrl)
+      const guid = parsedUrl.searchParams.get('some_search')
+      assert.ok(validGuid.test(guid))
+    })
+
+    it('does not generate a unique value if provided query parameter already exists', () => {
+      const url = 'https://google.com/?some_query=some_value'
+      const uniqueUrl = GeneralUtils.uniqueUrl(url, 'some_query')
+      assert.strictEqual(uniqueUrl, url)
     })
   })
 


### PR DESCRIPTION
when we encounter cross origin frames with the same `src` attribute - the resulting image will have inappropriately positioned iframes and therefore will result in a bad image.

[Trello card](https://trello.com/c/qn5glrAD)