### PR TITLE
chore(cypress): don't format output when running in interactive mode

### DIFF
--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -31,7 +31,10 @@ if (!Cypress.config('eyesIsDisabled')) {
     };
     let browser = getGlobalConfigProperty('eyesBrowser');
     handleCypressViewport(browser).then({timeout: 86400000}, () =>
-      sendRequest({command: 'batchStart', data: {viewport, userAgent}}),
+      sendRequest({
+        command: 'batchStart',
+        data: {viewport, userAgent, isInteractive: getGlobalConfigProperty('isInteractive')},
+      }),
     );
   });
 
@@ -75,11 +78,11 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
       browser.name = 'chrome';
     }
   }
-
+  const isInteractive = getGlobalConfigProperty('isInteractive');
   return handleCypressViewport(browser).then({timeout: 15000}, () =>
     sendRequest({
       command: 'open',
-      data: Object.assign({testName}, args),
+      data: Object.assign({testName, isInteractive}, args),
     }),
   );
 });

--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -78,11 +78,10 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
       browser.name = 'chrome';
     }
   }
-  const isInteractive = getGlobalConfigProperty('isInteractive');
   return handleCypressViewport(browser).then({timeout: 15000}, () =>
     sendRequest({
       command: 'open',
-      data: Object.assign({testName, isInteractive}, args),
+      data: Object.assign({testName}, args),
     }),
   );
 });

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -52,7 +52,6 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
   }
 
   function colorify(msg, color) {
-    console.log(color);
     return isInteractive ? msg : chalk[color](msg);
   }
 }

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -1,6 +1,6 @@
 'use strict';
 const chalk = require('chalk');
-const RESET = '\x1b[0m';
+
 const formatByStatus = {
   Passed: {
     color: 'green',
@@ -40,7 +40,7 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
         acc.push(
           `${colorify(symbol, color)} ${colorify(
             error || stringifyTestResults(testResults),
-            RESET,
+            'reset',
           )}`,
         );
       }
@@ -52,6 +52,7 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
   }
 
   function colorify(msg, color) {
+    console.log(color);
     return isInteractive ? msg : chalk[color](msg);
   }
 }

--- a/packages/eyes-cypress/src/plugin/handlers.js
+++ b/packages/eyes-cypress/src/plugin/handlers.js
@@ -78,7 +78,7 @@ function makeHandlers({
         processCloseAndAbort,
         getErrorsAndDiffs,
         errorDigest,
-        isInteractive: data.isInteractive,
+        isInteractive: GeneralUtils.getPropertyByPath(data, 'isInteractive'),
         handleBatchResultsFile: makeHandleBatchResultsFile(config),
       });
       pollBatchEnd = pollingHandler(

--- a/packages/eyes-cypress/src/plugin/handlers.js
+++ b/packages/eyes-cypress/src/plugin/handlers.js
@@ -78,6 +78,7 @@ function makeHandlers({
         processCloseAndAbort,
         getErrorsAndDiffs,
         errorDigest,
+        isInteractive: data.isInteractive,
         handleBatchResultsFile: makeHandleBatchResultsFile(config),
       });
       pollBatchEnd = pollingHandler(

--- a/packages/eyes-cypress/src/plugin/waitForBatch.js
+++ b/packages/eyes-cypress/src/plugin/waitForBatch.js
@@ -9,6 +9,7 @@ function makeWaitForBatch({
   getErrorsAndDiffs,
   errorDigest,
   handleBatchResultsFile,
+  isInteractive,
 }) {
   return async function(runningTests, closeBatch) {
     logger.log(`Waiting for test results of ${runningTests.length} tests.`);
@@ -22,7 +23,7 @@ function makeWaitForBatch({
     }
 
     if (failed.length || diffs.length) {
-      throw new Error(errorDigest({passed, failed, diffs, logger}));
+      throw new Error(errorDigest({passed, failed, diffs, logger, isInteractive}));
     }
 
     return passed.length;

--- a/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
@@ -124,4 +124,40 @@ describe('errorDigest', () => {
 
     expect(output).to.deep.equal(expectedOutput);
   });
+
+  it('should not print formatting codes when isInteractive', () => {
+    const passed = [
+      new TestResults({
+        name: 'test3',
+        hostDisplaySize: {width: 1, height: 2},
+        status: 'Passed',
+      }),
+    ];
+    const failed = [];
+    const diffs = [
+      new TestResults({
+        name: 'test1',
+        hostDisplaySize: {width: 100, height: 200},
+        url: 'some_url',
+        status: 'Unresolved',
+      }),
+    ];
+    const output = errorDigest({
+      passed,
+      failed,
+      diffs,
+      logger: {log: () => {}},
+      isInteractive: true,
+    });
+
+    const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
+       Passed - 1 tests
+         \u2713 test3 [1x2]
+       Diffs detected - 1 tests
+         \u26A0 test1 [100x200]
+
+       See details at: some_url`;
+
+    expect(output).to.deep.equal(expectedOutput);
+  });
 });

--- a/packages/eyes-cypress/test/unit/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/handlers.test.js
@@ -41,7 +41,7 @@ describe('handlers', () => {
   });
 
   it('handles "open"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     const {checkWindow} = await handlers.open({__test: 123, accessibilityValidation: 'bla'});
     const checkResult = await checkWindow();
     expect(checkResult.__test).to.equal('checkWindow_123');
@@ -50,7 +50,7 @@ describe('handlers', () => {
   });
 
   it('throws when calling "checkWindow" before "open"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     expect(
       await handlers.checkWindow({}).then(
         x => x,
@@ -70,7 +70,7 @@ describe('handlers', () => {
         openEyes: openEyesWithCloseRejection,
       }),
     });
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     expect(
       await handlers.checkWindow({}).then(
         x => x,
@@ -87,7 +87,7 @@ describe('handlers', () => {
   });
 
   it('throws when calling "close" before "open"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     expect(
       await handlers.close().then(
         x => x,
@@ -107,7 +107,7 @@ describe('handlers', () => {
         openEyes: openEyesWithCloseRejection,
       }),
     });
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     expect(
       await handlers.close().then(
         x => x,
@@ -124,7 +124,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     const cdt = 'cdt';
@@ -210,7 +210,7 @@ describe('handlers', () => {
   });
 
   it('handles an array of snapshots', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     handlers.putResource('id1', 'buff1');
@@ -234,7 +234,7 @@ describe('handlers', () => {
   });
 
   it('handles "putResource"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     handlers.putResource('id1', 'buff1');
@@ -258,7 +258,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow" with errorStatusCode resources', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     const blobData = [{url: 'id1', errorStatusCode: 500}];
@@ -272,7 +272,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow" with nested frames', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     const blobData = [{url: 'id1', type: 'type1'}];
@@ -359,7 +359,7 @@ describe('handlers', () => {
   });
 
   it('cleans resources on close', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({__test: 123});
 
     handlers.putResource('id', 'buff');
@@ -396,7 +396,7 @@ describe('handlers', () => {
   });
 
   it('handles "close"', async () => {
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     const {checkWindow, close} = await handlers.open({__test: 123});
 
     expect((await checkWindow()).__test).to.equal('checkWindow_123');
@@ -408,7 +408,7 @@ describe('handlers', () => {
     handlers = makeHandlers({
       makeVisualGridClient: () => (flag = 'flag'),
     });
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     expect(flag).to.equal('flag');
   });
 
@@ -450,7 +450,7 @@ describe('handlers', () => {
       errorDigest: ({passed, failed, diffs}) => `${passed}::${failed}##${diffs}`,
     });
 
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await openAndClose();
 
     // IDLE ==> WIP
@@ -540,7 +540,7 @@ describe('handlers', () => {
         },
       }),
     });
-    handlers.batchStart({isInteractive: true});
+    handlers.batchStart({});
     await handlers.open({}).catch(x => x);
     const err = await handlers.close().then(
       x => x,

--- a/packages/eyes-cypress/test/unit/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/handlers.test.js
@@ -41,7 +41,7 @@ describe('handlers', () => {
   });
 
   it('handles "open"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     const {checkWindow} = await handlers.open({__test: 123, accessibilityValidation: 'bla'});
     const checkResult = await checkWindow();
     expect(checkResult.__test).to.equal('checkWindow_123');
@@ -50,7 +50,7 @@ describe('handlers', () => {
   });
 
   it('throws when calling "checkWindow" before "open"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     expect(
       await handlers.checkWindow({}).then(
         x => x,
@@ -70,7 +70,7 @@ describe('handlers', () => {
         openEyes: openEyesWithCloseRejection,
       }),
     });
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     expect(
       await handlers.checkWindow({}).then(
         x => x,
@@ -87,7 +87,7 @@ describe('handlers', () => {
   });
 
   it('throws when calling "close" before "open"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     expect(
       await handlers.close().then(
         x => x,
@@ -107,7 +107,7 @@ describe('handlers', () => {
         openEyes: openEyesWithCloseRejection,
       }),
     });
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     expect(
       await handlers.close().then(
         x => x,
@@ -124,7 +124,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     const cdt = 'cdt';
@@ -210,7 +210,7 @@ describe('handlers', () => {
   });
 
   it('handles an array of snapshots', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     handlers.putResource('id1', 'buff1');
@@ -234,7 +234,7 @@ describe('handlers', () => {
   });
 
   it('handles "putResource"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     handlers.putResource('id1', 'buff1');
@@ -258,7 +258,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow" with errorStatusCode resources', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     const blobData = [{url: 'id1', errorStatusCode: 500}];
@@ -272,7 +272,7 @@ describe('handlers', () => {
   });
 
   it('handles "checkWindow" with nested frames', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     const blobData = [{url: 'id1', type: 'type1'}];
@@ -359,7 +359,7 @@ describe('handlers', () => {
   });
 
   it('cleans resources on close', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({__test: 123});
 
     handlers.putResource('id', 'buff');
@@ -396,7 +396,7 @@ describe('handlers', () => {
   });
 
   it('handles "close"', async () => {
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     const {checkWindow, close} = await handlers.open({__test: 123});
 
     expect((await checkWindow()).__test).to.equal('checkWindow_123');
@@ -408,7 +408,7 @@ describe('handlers', () => {
     handlers = makeHandlers({
       makeVisualGridClient: () => (flag = 'flag'),
     });
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     expect(flag).to.equal('flag');
   });
 
@@ -450,7 +450,7 @@ describe('handlers', () => {
       errorDigest: ({passed, failed, diffs}) => `${passed}::${failed}##${diffs}`,
     });
 
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await openAndClose();
 
     // IDLE ==> WIP
@@ -540,7 +540,7 @@ describe('handlers', () => {
         },
       }),
     });
-    handlers.batchStart();
+    handlers.batchStart({isInteractive: true});
     await handlers.open({}).catch(x => x);
     const err = await handlers.close().then(
       x => x,

--- a/packages/eyes-cypress/test/unit/plugin/waitForBatch.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/waitForBatch.test.js
@@ -3,6 +3,7 @@ const {describe, it} = require('mocha');
 const {expect} = require('chai');
 const makeWaitForBatch = require('../../../src/plugin/waitForBatch');
 const {concurrencyMsg} = require('../../../src/plugin/concurrencyMsg');
+const {presult} = require('@applitools/functional-commons');
 
 function getErrorsAndDiffs(testResultsArr) {
   return testResultsArr.reduce(
@@ -41,6 +42,20 @@ describe('waitForBatch', () => {
   it("returns test count when there's no error", async () => {
     const runningTests = [['passed'], ['passed'], ['passed', 'passed']];
     expect(await waitForBatch(runningTests)).to.eql(4);
+  });
+
+  it('passes isInteractive to errorDigest', async () => {
+    let works = false;
+    const waitForBatch = makeWaitForBatch({
+      logger,
+      processCloseAndAbort,
+      getErrorsAndDiffs: () => ({failed: [0]}),
+      handleBatchResultsFile: results => results,
+      errorDigest: ({isInteractive}) => (works = isInteractive),
+      isInteractive: true,
+    });
+    await presult(waitForBatch([]));
+    expect(works).to.be.true;
   });
 
   it('throws error with digest when found errors', async () => {


### PR DESCRIPTION
we have the ability to get a config property from `cypress` which indicates whether the run is interactive or not, meaning was the test run started with `cypress open` or `cypress run` respectively.

when running in interactive mode - we do not want to format the output with color codes - as it makes the output unreadable.
we could not rely on `process.stdout.isTTY` because it's always `true`.

