### PR TITLE
chore(cypress): add device error handling

### DIFF
--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -100,6 +100,14 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
           browser.iosDeviceInfo || browser.chromeEmulationInfo || browser;
         const command = browser.iosDeviceInfo ? 'getIosDevicesSizes' : 'getEmulatedDevicesSizes';
         return sendRequest({command}).then(devicesSizes => {
+          if (!devicesSizes.hasOwnProperty(deviceName)) {
+            const category = browser.iosDeviceInfo ? 'iOS' : 'emulated';
+            const deviceListUrl =
+              'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config/DeviceName.js';
+            throw new Error(
+              `'${deviceName}' does not exist in the list of ${category} devices.\nplease see the device list at: ${deviceListUrl}`,
+            );
+          }
           const size = devicesSizes[deviceName][screenOrientation];
           return {name: deviceName, ...size};
         });

--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -101,11 +101,19 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
         const command = browser.iosDeviceInfo ? 'getIosDevicesSizes' : 'getEmulatedDevicesSizes';
         return sendRequest({command}).then(devicesSizes => {
           if (!devicesSizes.hasOwnProperty(deviceName)) {
-            const category = browser.iosDeviceInfo ? 'iOS' : 'emulated';
-            const deviceListUrl =
-              'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config/DeviceName.js';
+            const baseUrl =
+              'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config';
+            const category = browser.iosDeviceInfo
+              ? {
+                  name: 'iOS',
+                  url: `${baseUrl}/IosDeviceName.js`,
+                }
+              : {
+                  name: 'emulated',
+                  url: `${baseUrl}/DeviceName.js`,
+                };
             throw new Error(
-              `'${deviceName}' does not exist in the list of ${category} devices.\nplease see the device list at: ${deviceListUrl}`,
+              `'${deviceName}' does not exist in the list of ${category.name} devices.\nplease see the device list at: ${category.url}`,
             );
           }
           const size = devicesSizes[deviceName][screenOrientation];

--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -101,20 +101,7 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
         const command = browser.iosDeviceInfo ? 'getIosDevicesSizes' : 'getEmulatedDevicesSizes';
         return sendRequest({command}).then(devicesSizes => {
           if (!devicesSizes.hasOwnProperty(deviceName)) {
-            const baseUrl =
-              'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config';
-            const category = browser.iosDeviceInfo
-              ? {
-                  name: 'iOS',
-                  url: `${baseUrl}/IosDeviceName.js`,
-                }
-              : {
-                  name: 'emulated',
-                  url: `${baseUrl}/DeviceName.js`,
-                };
-            throw new Error(
-              `'${deviceName}' does not exist in the list of ${category.name} devices.\nplease see the device list at: ${category.url}`,
-            );
+            handleDeviceError(deviceName);
           }
           const size = devicesSizes[deviceName][screenOrientation];
           return {name: deviceName, ...size};
@@ -153,4 +140,21 @@ function mapBlob({url, type, value}) {
   return {url, type: type || 'application/x-applitools-unknown', value};
 }
 
+function handleDeviceError(browser) {
+  const baseUrl =
+    'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config';
+  const deviceName = browser.deviceName;
+  const category = browser.iosDeviceInfo
+    ? {
+        name: 'iOS',
+        url: `${baseUrl}/IosDeviceName.js`,
+      }
+    : {
+        name: 'emulated',
+        url: `${baseUrl}/DeviceName.js`,
+      };
+  throw new Error(
+    `'${deviceName}' does not exist in the list of ${category.name} devices.\nplease see the device list at: ${category.url}`,
+  );
+}
 module.exports = makeEyesCheckWindow;


### PR DESCRIPTION
adding a clause that will check if a given device name exists in the list of devices we got from the server.

there is room for confusion when it comes to device configuration, therefore I added an indicative error message that points to the device list (similar to the readme) and details whether it's an emulated device or iOS.

![image](https://user-images.githubusercontent.com/16037265/104882058-0d090600-596b-11eb-92b1-4d0cb2fe52ec.png)
