### PR TITLE
TestCafe: fix window full page

### DIFF
--- a/packages/eyes-testcafe/CHANGELOG.md
+++ b/packages/eyes-testcafe/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix default checkWindow behavior- take full page when no target is specified
 
 ## 1.12.4 - 2021/1/27
 

--- a/packages/eyes-testcafe/src/sdk.js
+++ b/packages/eyes-testcafe/src/sdk.js
@@ -70,11 +70,16 @@ class DecoratedEyesFactory extends sdk.EyesFactory {
       async checkWindow(args) {
         let preparedArgs
         if (TypeUtils.isObject(args)) {
-          if (args.tag && Object.keys(args).length === 1)
-            preparedArgs = {tag: args.tag, target: 'window', fully: true}
-          else if (args.window && !args.fully) preparedArgs = {...args, fully: true}
-          else preparedArgs = {...args}
-        } else preparedArgs = {tag: args, target: 'window', fully: true}
+          preparedArgs = {...args}
+          if (!args.hasOwnProperty('target')) {
+            preparedArgs.target = 'window'
+          }
+          if (preparedArgs.target === 'window' && !args.hasOwnProperty('fully')) {
+            preparedArgs.fully = true
+          }
+        } else {
+          preparedArgs = {tag: args, target: 'window', fully: true}
+        }
 
         await _check(translateArgsToCheckSettings(preparedArgs))
       },

--- a/packages/eyes-testcafe/test/it/legacy-api.spec.js
+++ b/packages/eyes-testcafe/test/it/legacy-api.spec.js
@@ -57,7 +57,7 @@ test('eyes.checkWindow fully (implicit default)', async t => {
 })
 test('eyes.checkWindow fully (target: window)', async t => {
   await t.navigateTo('https://applitools.github.io/demo/TestPages/FramesTestPage/')
-  await eyes.open({t, appName: 'eyes-testcafe', testName: 'legacy api test: checkWindow viewport'})
+  await eyes.open({t, appName: 'eyes-testcafe', testName: 'legacy api test: checkWindow fully'})
   await eyes.checkWindow({target: 'window'})
   await eyes.close(true)
 })


### PR DESCRIPTION
It seems that after this commit https://github.com/applitools/eyes.sdk.javascript1/commit/772ffef975cd3406cc1f407db55aabcf5990058e the screenshot still turns out viewport when no `target` is specified and no `fully`.
The changes in this PR are complementary to the baseline updates here:
[https://eyes.applitools.com/app/test-results/00000251790254269161/?accountId=UAujt6tHnEKUivQXIz7G6A~~](https://eyes.applitools.com/app/test-results/00000251790254269161/?accountId=UAujt6tHnEKUivQXIz7G6A~~)