### PR TITLE
Include non-emitted tests in coverage tests report

### DIFF
--- a/packages/sdk-coverage-tests/CHANGELOG.md
+++ b/packages/sdk-coverage-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Include non-emitted tests in the report
 
 ## 2.3.6 - 2021/1/31
 

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -2,20 +2,20 @@ const convert = require('xml-js')
 const {logDebug} = require('../log')
 
 function convertJunitXmlToResultSchema({junit, browser, metadata}) {
-  const tests = parseJunitXmlForTests(junit).filter(test => !test.skipped && !test.ignored)
+  const tests = parseJunitXmlForTests(junit)
   logDebug(tests)
-  return tests.map(test => {
-    const testName = parseBareTestName(test._attributes.name)
-    const meta = metadata[testName] || {}
+  return Object.entries(metadata).map(([testName, testMeta]) => {
+    const testResult = tests.find(t => testName === parseBareTestName(t._attributes.name))
+    const isSkipped = testMeta.skip || testMeta.skipEmit || false // we explicitly set false to preserve backwards compatibility
     return {
-      test_name: meta.name || testName,
+      test_name: testMeta.name || testName,
       parameters: {
         browser: browser || 'chrome',
-        mode: meta.executionMode,
+        mode: testMeta.executionMode,
       },
-      passed: !test.failure,
-      isGeneric: meta.isGeneric,
-      isSkipped: meta.skip || meta.skipEmit || false, // we explicitly set false to preserve backwards compatibility
+      passed: testResult && !isSkipped ? !testResult.failure : undefined,
+      isGeneric: testMeta.isGeneric,
+      isSkipped,
     }
   })
 }

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -19,18 +19,24 @@ const metadata = {
   TestCheckWindow: {
     isGeneric: true,
     executionMode: 'css',
-    name: 'TestCheckWindow',
+    name: 'test check window with css',
   },
   TestCheckWindow_VG: {
     isGeneric: true,
     executionMode: 'visualgrid',
-    name: 'TestCheckWindow',
+    name: 'test check window with vg',
     skip: true,
   },
   TestCheckWindow_Scroll: {
     isGeneric: true,
     executionMode: 'scroll',
-    name: 'TestCheckWindow',
+    name: 'test check window with scroll',
+    skip: true,
+  },
+  TestThatWasNotEmitted: {
+    isGeneric: true,
+    executionMode: 'bla',
+    name: 'test that was not emitted',
     skipEmit: true,
   },
 }
@@ -91,30 +97,10 @@ describe('Report', () => {
     assert.deepStrictEqual(convertSdkNameToReportName('eyes.webdriverio.javascript4'), 'js_wdio_4')
     assert.deepStrictEqual(convertSdkNameToReportName('eyes-images'), 'js_images')
   })
-  it(`should omit skipped testcases`, () => {
-    const altXmlResult = loadFixture('single-suite-skipped-test.xml')
-    const result = convertJunitXmlToResultSchema({junit: altXmlResult})
-    assert.deepStrictEqual(result.length, 0)
-  })
-  it(`should omit skipped testcases with multiple testcases`, () => {
-    const altXmlResult = loadFixture('single-suite-multiple-tests-with-skipped.xml')
-    const result = convertJunitXmlToResultSchema({junit: altXmlResult, metadata: {}})
-    assert.deepStrictEqual(result.length, 3)
-  })
   it('should convert xml report to QA report schema as JSON', () => {
     assert.deepStrictEqual(convertJunitXmlToResultSchema({junit, metadata}), [
       {
-        test_name: 'TestCheckWindow',
-        parameters: {
-          browser: 'chrome',
-          mode: 'visualgrid',
-        },
-        passed: false,
-        isSkipped: true,
-        isGeneric: true,
-      },
-      {
-        test_name: 'TestCheckWindow',
+        test_name: 'test check window with css',
         parameters: {
           browser: 'chrome',
           mode: 'css',
@@ -124,12 +110,32 @@ describe('Report', () => {
         isGeneric: true,
       },
       {
-        test_name: 'TestCheckWindow',
+        test_name: 'test check window with vg',
+        parameters: {
+          browser: 'chrome',
+          mode: 'visualgrid',
+        },
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test check window with scroll',
         parameters: {
           browser: 'chrome',
           mode: 'scroll',
         },
-        passed: true,
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test that was not emitted',
+        parameters: {
+          browser: 'chrome',
+          mode: 'bla',
+        },
+        passed: undefined,
         isSkipped: true,
         isGeneric: true,
       },
@@ -143,34 +149,44 @@ describe('Report', () => {
       sandbox: false,
       results: [
         {
-          test_name: 'TestCheckWindow',
-          isGeneric: true,
-          parameters: {
-            browser: 'chrome',
-            mode: 'visualgrid',
-          },
-          isSkipped: true,
-          passed: false,
-        },
-        {
-          test_name: 'TestCheckWindow',
-          isGeneric: true,
+          test_name: 'test check window with css',
           parameters: {
             browser: 'chrome',
             mode: 'css',
           },
-          isSkipped: false,
           passed: true,
+          isSkipped: false,
+          isGeneric: true,
         },
         {
-          test_name: 'TestCheckWindow',
+          test_name: 'test check window with vg',
+          parameters: {
+            browser: 'chrome',
+            mode: 'visualgrid',
+          },
+          passed: undefined,
+          isSkipped: true,
           isGeneric: true,
+        },
+        {
+          test_name: 'test check window with scroll',
           parameters: {
             browser: 'chrome',
             mode: 'scroll',
           },
+          passed: undefined,
           isSkipped: true,
-          passed: true,
+          isGeneric: true,
+        },
+        {
+          test_name: 'test that was not emitted',
+          parameters: {
+            browser: 'chrome',
+            mode: 'bla',
+          },
+          passed: undefined,
+          isSkipped: true,
+          isGeneric: true,
         },
       ],
       id: undefined,
@@ -186,34 +202,44 @@ describe('Report', () => {
         sandbox: false,
         results: [
           {
-            test_name: 'TestCheckWindow',
-            isGeneric: true,
-            parameters: {
-              browser: 'chrome',
-              mode: 'visualgrid',
-            },
-            isSkipped: true,
-            passed: false,
-          },
-          {
-            test_name: 'TestCheckWindow',
-            isGeneric: true,
+            test_name: 'test check window with css',
             parameters: {
               browser: 'chrome',
               mode: 'css',
             },
-            isSkipped: false,
             passed: true,
+            isSkipped: false,
+            isGeneric: true,
           },
           {
-            test_name: 'TestCheckWindow',
+            test_name: 'test check window with vg',
+            parameters: {
+              browser: 'chrome',
+              mode: 'visualgrid',
+            },
+            passed: undefined,
+            isSkipped: true,
             isGeneric: true,
+          },
+          {
+            test_name: 'test check window with scroll',
             parameters: {
               browser: 'chrome',
               mode: 'scroll',
             },
+            passed: undefined,
             isSkipped: true,
-            passed: true,
+            isGeneric: true,
+          },
+          {
+            test_name: 'test that was not emitted',
+            parameters: {
+              browser: 'chrome',
+              mode: 'bla',
+            },
+            passed: undefined,
+            isSkipped: true,
+            isGeneric: true,
           },
         ],
         id: '111111',


### PR DESCRIPTION
This PR switches the order in which we discover what tests to report.
Before this PR we were reading the xunit results file and then mounting more information on each test from the metadata.
Now, we read the metadata and add the `passed` status from the xunit results file.
This means that information about skipped tests is not coming from what happened in runtime, but rather from what was defined during coverage test generation.