### PR TITLE
fix(eyes-cypress): validate browser/device configuration

### DIFF
--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix device emulation condition
 
 ## 3.18.7 - 2021/2/2
 

--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -1,16 +1,17 @@
 /* global Cypress,cy,window,before,after,navigator */
 'use strict';
 const poll = require('./poll');
-const makeSend = require('./makeSend');
 const processPage = require('@applitools/dom-snapshot/dist/processPageCjs');
 const domSnapshotOptions = {dontFetchResources: Cypress.config('eyesDisableBrowserFetching')};
-const send = makeSend(Cypress.config('eyesPort'), window.fetch);
-const makeSendRequest = require('./sendRequest');
 const makeEyesCheckWindow = require('./eyesCheckWindow');
 const makeHandleCypressViewport = require('./makeHandleCypressViewport');
-const sendRequest = makeSendRequest(send);
-const eyesCheckWindow = makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions});
 const handleCypressViewport = makeHandleCypressViewport({cy});
+const makeSend = require('./makeSend');
+const send = makeSend(Cypress.config('eyesPort'), window.fetch);
+const makeSendRequest = require('./sendRequest');
+const sendRequest = makeSendRequest(send);
+
+const eyesCheckWindow = makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions});
 
 function getGlobalConfigProperty(prop) {
   const property = Cypress.config(prop);

--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const getAllBlobs = require('./getAllBlobs');
+const getBrowserInfo = require('./getBrowserInfo');
 
 function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypress = cy}) {
   return function eyesCheckWindow(doc, args = {}) {
@@ -30,7 +31,7 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
       return browsers
         .reduce((widths, browser, index) => {
           return widths.then(widthsMap => {
-            return getBrowserInfo(browser).then(({name, width}) => {
+            return getBrowserInfo(browser, sendRequest).then(({name, width}) => {
               const requiredWidth = getBreakpointWidth(breakpoints, width);
               let groupedBrowsers = widthsMap[requiredWidth];
               if (!groupedBrowsers) {
@@ -91,24 +92,6 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
       });
     }
 
-    function getBrowserInfo(browser) {
-      if (!browser.deviceName) {
-        const {name, width} = browser;
-        return Promise.resolve({name, width});
-      } else {
-        const {deviceName, screenOrientation = 'portrait'} =
-          browser.iosDeviceInfo || browser.chromeEmulationInfo || browser;
-        const command = browser.iosDeviceInfo ? 'getIosDevicesSizes' : 'getEmulatedDevicesSizes';
-        return sendRequest({command}).then(devicesSizes => {
-          if (!devicesSizes.hasOwnProperty(deviceName)) {
-            handleDeviceError(deviceName);
-          }
-          const size = devicesSizes[deviceName][screenOrientation];
-          return {name: deviceName, ...size};
-        });
-      }
-    }
-
     function getBreakpointWidth(breakpoints, width) {
       if (!Array.isArray(breakpoints) || breakpoints.length === 0) return width;
       const sortedBreakpoints = Array.from(new Set(breakpoints)).sort((a, b) => (a < b ? 1 : -1));
@@ -140,21 +123,4 @@ function mapBlob({url, type, value}) {
   return {url, type: type || 'application/x-applitools-unknown', value};
 }
 
-function handleDeviceError(browser) {
-  const baseUrl =
-    'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config';
-  const deviceName = browser.deviceName;
-  const category = browser.iosDeviceInfo
-    ? {
-        name: 'iOS',
-        url: `${baseUrl}/IosDeviceName.js`,
-      }
-    : {
-        name: 'emulated',
-        url: `${baseUrl}/DeviceName.js`,
-      };
-  throw new Error(
-    `'${deviceName}' does not exist in the list of ${category.name} devices.\nplease see the device list at: ${category.url}`,
-  );
-}
 module.exports = makeEyesCheckWindow;

--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -92,7 +92,7 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
     }
 
     function getBrowserInfo(browser) {
-      if (browser.name) {
+      if (!browser.deviceName) {
         const {name, width} = browser;
         return Promise.resolve({name, width});
       } else {

--- a/packages/eyes-cypress/src/browser/getBrowserInfo.js
+++ b/packages/eyes-cypress/src/browser/getBrowserInfo.js
@@ -1,0 +1,39 @@
+function getBrowserInfo(browser, sendRequest) {
+  const isMobile =
+    browser.deviceName || browser.mobile || browser.iosDeviceInfo || browser.chromeEmulationInfo;
+  if (isMobile) {
+    const {deviceName, screenOrientation = 'portrait'} =
+      browser.iosDeviceInfo || browser.chromeEmulationInfo || browser;
+    const command = browser.iosDeviceInfo ? 'getIosDevicesSizes' : 'getEmulatedDevicesSizes';
+    return sendRequest({command}).then(devicesSizes => {
+      if (!devicesSizes.hasOwnProperty(deviceName)) {
+        handleDeviceError(browser);
+      }
+      const size = devicesSizes[deviceName][screenOrientation];
+      return {name: deviceName, ...size};
+    });
+  } else {
+    const {name, width} = browser;
+    return Promise.resolve({name, width});
+  }
+}
+
+function handleDeviceError(browser) {
+  const baseUrl =
+    'https://github.com/applitools/eyes.sdk.javascript1/blob/master/packages/eyes-sdk-core/lib/config';
+  const deviceName = browser.deviceName;
+  const category = browser.iosDeviceInfo
+    ? {
+        name: 'iOS',
+        url: `${baseUrl}/IosDeviceName.js`,
+      }
+    : {
+        name: 'emulated',
+        url: `${baseUrl}/DeviceName.js`,
+      };
+  throw new Error(
+    `'${deviceName}' does not exist in the list of ${category.name} devices.\nplease see the device list at: ${category.url}`,
+  );
+}
+
+module.exports = getBrowserInfo;

--- a/packages/eyes-cypress/test/it/browser/getBrowserInfo.test.js
+++ b/packages/eyes-cypress/test/it/browser/getBrowserInfo.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const {describe, it} = require('mocha');
+const {expect} = require('chai');
+const {presult} = require('@applitools/functional-commons');
+const getBrowserInfo = require('../../../src/browser/getBrowserInfo');
+
+describe('getBrowserInfo', () => {
+  it('should return browser name and width', async () => {
+    const browser = {name: 'chrome', width: 800};
+    const result = await getBrowserInfo(browser, async () => {});
+    expect(result).to.deep.equal(browser);
+  });
+
+  it('should return emulated device information', async () => {
+    let cmd;
+    const browser = {
+      deviceName: 'Galaxy S20',
+      screenOrientation: 'landscape',
+    };
+    const result = await getBrowserInfo(browser, async ({command}) => {
+      cmd = command;
+      return {
+        'Galaxy S20': {landscape: {width: 500, height: 200}},
+      };
+    });
+    expect(cmd).to.equal('getEmulatedDevicesSizes');
+    expect(result).to.deep.equal({
+      name: 'Galaxy S20',
+      width: 500,
+      height: 200,
+    });
+  });
+
+  it('should return ios device information', async () => {
+    let cmd;
+    const browser = {
+      iosDeviceInfo: {
+        deviceName: 'iPhone XR',
+        screenOrientation: 'landscape',
+      },
+    };
+    const result = await getBrowserInfo(browser, async ({command}) => {
+      cmd = command;
+      return {
+        'iPhone XR': {landscape: {width: 500, height: 200}},
+      };
+    });
+    expect(cmd).to.equal('getIosDevicesSizes');
+    expect(result).to.deep.equal({
+      name: 'iPhone XR',
+      width: 500,
+      height: 200,
+    });
+  });
+
+  it('throws an informative error message', async () => {
+    let cmd;
+    const browser = {
+      deviceName: 'iPhone 11 Pro',
+      screenOrientation: 'landscape',
+    };
+    const [err] = await presult(
+      getBrowserInfo(browser, async ({command}) => {
+        cmd = command;
+        return {
+          'iPhone X': {landscape: {width: 500, height: 200}},
+        };
+      }),
+    );
+
+    expect(cmd).to.equal('getEmulatedDevicesSizes');
+    expect(err.toString().split('\n')[0]).to.equal(
+      `Error: 'iPhone 11 Pro' does not exist in the list of emulated devices.`,
+    );
+  });
+});


### PR DESCRIPTION
[trello](https://trello.com/c/onmEQzNx)

`eyesCheckWindow` was checking for the `name` property of a provided browser configuration.

unfortunately, we (I) also added a default browser name, that explicitly adds the `name` property to any browser configuration.
