### PR TITLE
core: fix retry in EyesUtils.setViewportSize

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-
+- fix bug when setting the viewport size that prevented retries from working correctly and presented the user with an incorrect error message ([Trello](https://trello.com/c/xNCZNfPi))
 
 ## 12.14.10 - 2021/2/18
 

--- a/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
@@ -35,7 +35,10 @@ describe('EyesUtils', () => {
       await setViewportSize(logger, context, requiredViewportSize)
       assert.deepStrictEqual(counters.setWindowRect, 1)
     })
-    it('throws the correct error when unable to set the viewport size', () => {
+    it('throws the correct error when unable to set the viewport size', async () => {
+      const counters = {
+        setWindowRect: 0,
+      }
       const logger = {
         verbose: () => {},
       }
@@ -44,7 +47,9 @@ describe('EyesUtils', () => {
           return {width: 1280, height: 800}
         },
         driver: {
-          setWindowRect: async () => {},
+          setWindowRect: async input => {
+            if (input && input._width && input._height) counters.setWindowRect++
+          },
           getWindowRect: () => {
             return new RectangleSize({width: 1280, height: 800})
           },
@@ -52,7 +57,8 @@ describe('EyesUtils', () => {
       }
       const requiredViewportSize = new RectangleSize({width: 800, height: 600})
       // eslint-disable-next-line
-      return assert.rejects(async () => {await setViewportSize(logger, context, requiredViewportSize)}, /Failed to set viewport size!/)
+      await assert.rejects(async () => {await setViewportSize(logger, context, requiredViewportSize)}, /Failed to set viewport size!/)
+      assert.deepStrictEqual(counters.setWindowRect, 3)
     })
   })
 })

--- a/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
@@ -36,9 +36,6 @@ describe('EyesUtils', () => {
       assert.deepStrictEqual(counters.setWindowRect, 1)
     })
     it('throws the correct error when unable to set the viewport size', () => {
-      const counters = {
-        setWindowRect: 0,
-      }
       const logger = {
         verbose: () => {},
       }
@@ -47,9 +44,7 @@ describe('EyesUtils', () => {
           return {width: 1280, height: 800}
         },
         driver: {
-          setWindowRect: async () => {
-            counters.setWindowRect++
-          },
+          setWindowRect: async () => {},
           getWindowRect: () => {
             return new RectangleSize({width: 1280, height: 800})
           },

--- a/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/sdk/EyesUtils.spec.js
@@ -1,0 +1,63 @@
+const assert = require('assert')
+const {setViewportSize} = require('../../../lib/sdk/EyesUtils')
+const RectangleSize = require('../../../lib/geometry/RectangleSize')
+
+describe('EyesUtils', () => {
+  describe('setViewportSize', () => {
+    it('works', async () => {
+      let windowRect
+      const counters = {
+        setWindowRect: 0,
+      }
+      const logger = {
+        verbose: () => {},
+      }
+      const context = {
+        execute: () => {
+          const result = windowRect || {width: 1280, height: 800}
+          return new RectangleSize(result)
+        },
+        driver: {
+          setWindowRect: async input => {
+            if (input && input._width && input._height) {
+              windowRect = input
+              counters.setWindowRect++
+            }
+          },
+          getWindowRect: () => {
+            const result = windowRect || {width: 1280, height: 800}
+            return new RectangleSize(result)
+          },
+        },
+      }
+      const requiredViewportSize = new RectangleSize({width: 800, height: 600})
+      // eslint-disable-next-line
+      await setViewportSize(logger, context, requiredViewportSize)
+      assert.deepStrictEqual(counters.setWindowRect, 1)
+    })
+    it('throws the correct error when unable to set the viewport size', () => {
+      const counters = {
+        setWindowRect: 0,
+      }
+      const logger = {
+        verbose: () => {},
+      }
+      const context = {
+        execute: () => {
+          return {width: 1280, height: 800}
+        },
+        driver: {
+          setWindowRect: async () => {
+            counters.setWindowRect++
+          },
+          getWindowRect: () => {
+            return new RectangleSize({width: 1280, height: 800})
+          },
+        },
+      }
+      const requiredViewportSize = new RectangleSize({width: 800, height: 600})
+      // eslint-disable-next-line
+      return assert.rejects(async () => {await setViewportSize(logger, context, requiredViewportSize)}, /Failed to set viewport size!/)
+    })
+  })
+})


### PR DESCRIPTION
- add unit test coverage for EyesUtils.setViewportSize
- improve logging in it, and
- fix bug in its retry logic that prevented the full number of retries and
  incorrect error message from bubbling when the window/viewport is unable to
  be resized
  
  re: [Trello](https://trello.com/c/xNCZNfPi)