### PR TITLE
adding param to eyesGetAllTestResults to not throw when we have errors

### DIFF
--- a/packages/eyes-webdriverio-5/src/eyes-service.js
+++ b/packages/eyes-webdriverio-5/src/eyes-service.js
@@ -94,8 +94,8 @@ class EyesService {
       return this._eyes.getConfiguration()
     })
 
-    global.browser.addCommand('eyesGetAllTestResults', async () => {
-      return this._eyes.getRunner().getAllTestResults()
+    global.browser.addCommand('eyesGetAllTestResults', async (throwEx = true) => {
+      return this._eyes.getRunner().getAllTestResults(throwEx)
     })
   }
 


### PR DESCRIPTION
This function does not seem to be in the documentation.

Calling eyesGetTestResults only returns one test, even when you have multiple browsers enabled.

Calling eyesGetAllTestResults when a check failed causes the function to throw, which also prevents me from getting the full list of checks.