### PR TITLE
Fix bug with unexecuted and unskipped cvg tests

### DIFF
--- a/packages/sdk-coverage-tests/CHANGELOG.md
+++ b/packages/sdk-coverage-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix bug with unskipped and unexecuted tests
 
 ## 2.3.7 - 2021/2/6
 

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -4,20 +4,24 @@ const {logDebug} = require('../log')
 function convertJunitXmlToResultSchema({junit, browser, metadata}) {
   const tests = parseJunitXmlForTests(junit)
   logDebug(tests)
-  return Object.entries(metadata).map(([testName, testMeta]) => {
-    const testResult = tests.find(t => testName === parseBareTestName(t._attributes.name))
-    const isSkipped = testMeta.skip || testMeta.skipEmit || false // we explicitly set false to preserve backwards compatibility
-    return {
-      test_name: testMeta.name || testName,
-      parameters: {
-        browser: browser || 'chrome',
-        mode: testMeta.executionMode,
-      },
-      passed: testResult && !isSkipped ? !testResult.failure : undefined,
-      isGeneric: testMeta.isGeneric,
-      isSkipped,
-    }
-  })
+  return Object.entries(metadata)
+    .map(([testName, testMeta]) => {
+      const testResult = tests.find(t => testName === parseBareTestName(t._attributes.name))
+      const isSkipped = testMeta.skip || testMeta.skipEmit || false // we explicitly set false to preserve backwards compatibility
+      if (!testResult && !isSkipped) return
+
+      return {
+        test_name: testMeta.name || testName,
+        parameters: {
+          browser: browser || 'chrome',
+          mode: testMeta.executionMode,
+        },
+        passed: testResult && !isSkipped ? !testResult.failure : undefined,
+        isGeneric: testMeta.isGeneric,
+        isSkipped,
+      }
+    })
+    .filter(Boolean)
 }
 
 function parseBareTestName(testCaseName) {

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -39,6 +39,11 @@ const metadata = {
     name: 'test that was not emitted',
     skipEmit: true,
   },
+  TestThatWasEmittedButNotExecuted: {
+    isGeneric: true,
+    executionMode: 'bla',
+    name: 'test that was emitted but not executed',
+  },
 }
 describe('Report', () => {
   describe('JUnit XML Parser', () => {


### PR DESCRIPTION
There was a bug when a coverage test is emitted, but it's excluded from the test suite because the framework doesn't support this feature (e.g. native-selectors in Selenium). The bug is that this test is reported as `isSkipped: false` (because it's not emitted to be skipped) but with no test result status (since it was not executed).

This PR fixes the issue by filtering those cases out of the report.