### PR TITLE
chore(eyes-cypress): global cypress test

### DIFF
--- a/packages/eyes-cypress/test/it/browser/commands.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/commands.it.test.js
@@ -19,8 +19,13 @@ function override(target, method, name) {
 }
 
 function fakeCypress(modulePath, calls = {}) {
-  const stub = {called: false, callCount: 0, args: []};
-  this.state = {viewport: {...stub}, fetch: {...stub}};
+  function setFake(name, args) {
+    this.state[name].called = true;
+    this.state[name].args = args;
+    this.state[name].callCount++;
+  }
+  const fake = {called: false, callCount: 0, args: []};
+  this.state = {viewport: {...fake}, fetch: {...fake}};
   this.Cypress = {
     Commands: {add: (name, func) => (calls[name] = func)},
     config: () => {},
@@ -29,18 +34,14 @@ function fakeCypress(modulePath, calls = {}) {
   };
   this.cy = {
     viewport: (...args) => {
-      this.state.viewport.called = true;
-      this.state.viewport.args = args;
-      this.state.viewport.callCount++;
+      setFake('viewport', args);
       return {then: (_args, cb) => (this.state.viewport.cb = cb)};
     },
   };
 
   this.window = {
     fetch: (...args) => {
-      this.state.fetch.called = true;
-      this.state.fetch.callCount++;
-      this.state.fetch.args = args;
+      setFake('fetch', args);
       return {
         then: () => ({
           json: () => {},

--- a/packages/eyes-cypress/test/it/browser/commands.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/commands.it.test.js
@@ -1,0 +1,82 @@
+const {describe, it} = require('mocha');
+const chai = require('chai');
+const spies = require('chai-spies');
+const expect = chai.expect;
+chai.use(spies);
+
+function override(target, method, name) {
+  Object.defineProperty(target, name, {
+    accessCount: 0,
+    accessed: false,
+    [method]: function() {
+      const fakeUserAgent = `fake_${name}`;
+      this.value = fakeUserAgent;
+      this.accessed = true;
+      this.accessCount = this.accessCount ? this.accessCount + 1 : 1;
+      return fakeUserAgent;
+    },
+  });
+}
+
+function fakeCypress(modulePath, calls = {}) {
+  this.Cypress = {
+    Commands: {add: (name, func) => (calls[name] = func)},
+    config: () => {},
+    log: () => {},
+    config: () => {},
+  };
+  this.cy = {
+    _viewport: {called: false, callCount: 0},
+    async viewport(...args) {
+      this._viewport.called = true;
+      this._viewport.args = args;
+      this._viewport.callCount++;
+      return Promise.resolve(...args);
+    },
+  };
+
+  this.window = {};
+  this.navigator = {};
+  override(this.navigator, 'get', 'userAgent');
+  override(this.window, 'get', 'fetch');
+
+  delete require.cache[require.resolve(modulePath)];
+  require(modulePath);
+  return {context: this, calls};
+}
+
+describe('commands', () => {
+  describe('eyesOpen', () => {
+    let context, eyesOpen, self, cypress, browser;
+
+    beforeEach(() => {
+      cypress = fakeCypress('../../../src/browser/commands');
+      context = cypress.context;
+      browser = {width: 800, height: 600};
+      eyesOpen = cypress.calls['eyesOpen'];
+      self = {
+        currentTest: {
+          title: 'test',
+        },
+      };
+    });
+
+    it('should call handleViewport with correct viewport', async () => {
+      eyesOpen.call(self, {browser});
+      expect(context.cy._viewport.called).to.be.true;
+      expect(context.cy._viewport.args).to.deep.equal([800, 600]);
+    });
+
+    it('should access userAgent on global navigator', async () => {
+      eyesOpen.call(self, {browser});
+      expect(context.navigator.accessed).to.be.true;
+      expect(context.navigator.accessCount).to.equal(1);
+    });
+
+    it('should access fetch on global window', async () => {
+      eyesOpen.call(self, {browser});
+      expect(context.window.accessed).to.be.true;
+      expect(context.window.accessCount).to.equal(1);
+    });
+  });
+});

--- a/packages/eyes-cypress/test/it/browser/commands.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/commands.it.test.js
@@ -84,8 +84,9 @@ describe('commands', () => {
     it('should validate args to sendRequest', async () => {
       eyesOpen.call(self, {browser});
       context.state.viewport.cb();
+      const [, args] = context.state.fetch.args;
       expect(context.state.fetch.called).to.be.true;
-      expect(JSON.parse(context.state.fetch.args[1].body)).to.deep.equal({
+      expect(JSON.parse(args.body)).to.deep.equal({
         testName: 'test',
         browser: {width: 800, height: 600, name: 'chrome'},
         userAgent: 'fake_userAgent',
@@ -101,7 +102,6 @@ describe('commands', () => {
     it('should call fetch on global window', async () => {
       eyesOpen.call(self, {browser});
       context.state.viewport.cb();
-      expect(context.state.fetch.called).to.be.true;
       expect(context.state.fetch.called).to.be.true;
       expect(context.state.fetch.callCount).to.equal(1);
     });

--- a/packages/eyes-cypress/test/it/browser/commands.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/commands.it.test.js
@@ -21,16 +21,19 @@ describe('commands', () => {
     });
 
     it('should call handleViewport with correct viewport', async () => {
+      const viewport = context.journal.cy.viewport;
       eyesOpen.call(self, {browser});
-      expect(context.state.viewport.called).to.be.true;
-      expect(context.state.viewport.args).to.deep.equal([800, 600]);
+      expect(viewport.called).to.be.true;
+      expect(viewport.args).to.deep.equal([800, 600]);
     });
 
     it('should validate args to sendRequest', async () => {
+      const viewport = context.journal.cy.viewport;
+      const fetch = context.journal.window.fetch;
       eyesOpen.call(self, {browser});
-      context.state.viewport.cb();
-      const [, args] = context.state.fetch.args;
-      expect(context.state.fetch.called).to.be.true;
+      viewport.cb();
+      const [, args] = fetch.args;
+      expect(fetch.called).to.be.true;
       expect(JSON.parse(args.body)).to.deep.equal({
         testName: 'test',
         browser: {width: 800, height: 600, name: 'chrome'},
@@ -46,9 +49,9 @@ describe('commands', () => {
 
     it('should call fetch on global window', async () => {
       eyesOpen.call(self, {browser});
-      context.state.viewport.cb();
-      expect(context.state.fetch.called).to.be.true;
-      expect(context.state.fetch.callCount).to.equal(1);
+      context.journal.cy.viewport.cb();
+      expect(context.journal.window.fetch.called).to.be.true;
+      expect(context.journal.window.fetch.callCount).to.equal(1);
     });
   });
 });

--- a/packages/eyes-cypress/test/util/fakeCypress.js
+++ b/packages/eyes-cypress/test/util/fakeCypress.js
@@ -1,0 +1,59 @@
+function override(target, name) {
+  Object.defineProperty(target, name, {
+    accessCount: 0,
+    accessed: false,
+    get: function() {
+      const fake = `fake_${name}`;
+      this.value = fake;
+      this.accessed = true;
+      this.accessCount = this.accessCount ? this.accessCount + 1 : 1;
+      return fake;
+    },
+  });
+}
+
+function setFake(context, name, args) {
+  context.state[name].called = true;
+  context.state[name].args = args;
+  context.state[name].callCount++;
+}
+
+function fakeCypress(modulePath, calls = {}) {
+  const fake = {called: false, callCount: 0, args: []};
+  function createContext(modulePath) {
+    this.state = {viewport: {...fake}, fetch: {...fake}};
+    this.Cypress = {
+      Commands: {add: (name, func) => (calls[name] = func)},
+      config: () => {},
+      log: () => {},
+      config: () => {},
+    };
+    this.cy = {
+      viewport: (...args) => {
+        setFake(this, 'viewport', args);
+        return {then: (_args, cb) => (this.state.viewport.cb = cb)};
+      },
+    };
+    this.window = {
+      fetch: (...args) => {
+        setFake(this, 'fetch', args);
+        return {
+          then: () => ({
+            json: () => {},
+            then: () => 'fake',
+          }),
+        };
+      },
+    };
+    this.navigator = {};
+    delete require.cache[require.resolve(modulePath)];
+    require(modulePath);
+    return this;
+  }
+  const context = createContext(modulePath);
+
+  override(context.navigator, 'userAgent');
+  return {context, calls};
+}
+
+module.exports = fakeCypress;


### PR DESCRIPTION
following the work of #384, this PR is an attempt to create a wrapper around the `Cypress` and `cy` objects for testing purposes.

the `fakeCypress` method accepts a relative path to a module and `require`s it with overwritten globals, such as `window`, `navigator`, `cy` and `Cypress`.

we can validate access to global variables and `Cypress`/`cy` methods, as well as arguments to `sendRequest` - which is ultimately what the commands in `commands.js` are doing.

an example test can look like this:
```javascript
it('should call handleViewport with correct viewport', async () => {
  const {context, calls} = fakeCypress(path.resolve(__dirname, '../../../src/browser/commands'));
  const eyesOpen = calls['eyesOpen'];
  const browser = {width: 800, height: 600};
  eyesOpen.call({currentTest: {title: 'test' }}, {browser});
  const viewport = context.journal.cy.viewport;
  expect(viewport.called).to.be.true;
  expect(viewport.callCount).to.equal(1);
  expect(viewport.args).to.deep.equal([800, 600]);
});
```

breakdown:
- we call `fakeCypress` with a path to our module (`commands.js` in this case)
- we destructure `calls` and `context`:
  - `calls` is an object with the keys being the `eyes` commands (e.g `eyesOpen`, `eyesCheckWindow`etc...)
  - `context` is the object which overrides `Cypress`, `cy`, `window` and `navigator`
- call the function `eyesOpen` with an object that will replace `this` (because of usage such as `this.currentTest` in `eyesOpen`)
- use the `journal` object on `context` which records the arguments and calls metadata about a given function.
- validate args and calls metadata

at this point we need to extend `fakeCypress` to include more methods for `cy` (currently only `viewport` implemented)

example of args validation:
```javascript
it('should validate args to sendRequest', async () => {
  const {context, calls} = fakeCypress(path.resolve(__dirname, '../../../src/browser/commands'));
  const eyesOpen = calls['eyesOpen'];
  const browser = {width: 800, height: 600};
  eyesOpen.call({currentTest: {title: 'test' }}, {browser});
  const viewport = context.journal.cy.viewport;
  const fetch = context.journal.window.fetch;
  viewport.cb();
  const [, args] = fetch.args;
  expect(fetch.called).to.be.true;
  expect(JSON.parse(args.body)).to.deep.equal({
    testName: 'test',
    browser: {width: 800, height: 600, name: 'chrome'},
    userAgent: 'fake_userAgent',
  });
});
```