### PR TITLE
Reset color in Cypress error message

### DIFF
--- a/packages/eyes-cypress/package.json
+++ b/packages/eyes-cypress/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@applitools/dom-snapshot": "4.4.11",
     "@applitools/functional-commons": "1.6.0",
+    "@applitools/snaptdout": "^1.0.0",
     "@applitools/visual-grid-client": "15.5.22",
     "body-parser": "1.19.0",
     "chalk": "3.0.0",

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -14,6 +14,7 @@ const formatByStatus = {
   },
   Unresolved: {
     color: 'yellow',
+    chalkFunction: chalk.ansi256(214),
     symbol: '\u26A0',
     title: tests => `Diffs detected - ${tests} tests`,
   },
@@ -23,17 +24,19 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
   logger.log('errorDigest: diff errors', diffs);
   logger.log('errorDigest: test errors', failed);
 
-  const testLink = diffs.length ? `\n${indent()}See details at: ${diffs[0].getUrl()}` : '';
+  const testResultsUrl = diffs.length ? diffs[0].getUrl() : '';
+  const testResultsPrefix = testResultsUrl ? `\n${indent()}See details at: ` : '';
   return (
     colorify('Eyes-Cypress detected diffs or errors during execution of visual tests:', 'reset') +
     testResultsToString(passed, 'Passed') +
     testResultsToString(diffs, 'Unresolved') +
     testResultsToString(failed, 'Failed') +
-    colorify(testLink, 'reset')
+    colorify(testResultsPrefix, 'reset') +
+    colorify(testResultsUrl, 'reset', chalk.ansi256(86))
   );
 
   function testResultsToString(testResultsArr, category) {
-    const {color, title, symbol} = formatByStatus[category];
+    const {color, title, symbol, chalkFunction} = formatByStatus[category];
     const results = testResultsArr.reduce((acc, testResults) => {
       if (!testResults.isEmpty) {
         const error = hasError(testResults) ? stringifyError(testResults) : undefined;
@@ -47,12 +50,14 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
       return acc;
     }, []);
 
-    const coloredTitle = results.length ? colorify(title(results.length), color) : '';
+    const coloredTitle = results.length
+      ? colorify(title(results.length), color, chalkFunction)
+      : '';
     return testResultsSection(coloredTitle, results);
   }
 
-  function colorify(msg, color) {
-    return isInteractive ? msg : chalk[color](msg);
+  function colorify(msg, color, chalkFunction = chalk[color]) {
+    return isInteractive ? msg : chalkFunction(msg);
   }
 }
 

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -25,11 +25,11 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
 
   const testLink = diffs.length ? `\n${indent()}See details at: ${diffs[0].getUrl()}` : '';
   return (
-    'Eyes-Cypress detected diffs or errors during execution of visual tests:' +
+    colorify('Eyes-Cypress detected diffs or errors during execution of visual tests:', 'reset') +
     testResultsToString(passed, 'Passed') +
     testResultsToString(diffs, 'Unresolved') +
     testResultsToString(failed, 'Failed') +
-    `${testLink}`
+    colorify(testLink, 'reset')
   );
 
   function testResultsToString(testResultsArr, category) {

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -25,14 +25,18 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
   logger.log('errorDigest: test errors', failed);
 
   const testResultsUrl = diffs.length ? diffs[0].getUrl() : '';
-  const testResultsPrefix = testResultsUrl ? `\n${indent()}See details at: ` : '';
+  const seeDetails = testResultsUrl ? 'See details at:' : '';
+  const testResultsPrefix = `\n${indent()}${seeDetails}`;
+  const footer = testResultsUrl
+    ? `\n\n${colorify(testResultsPrefix)} ${colorify(testResultsUrl, 'reset', chalk.ansi256(86))}`
+    : '';
   return (
-    colorify('Eyes-Cypress detected diffs or errors during execution of visual tests:', 'reset') +
+    colorify('Eyes-Cypress detected diffs or errors during execution of visual tests.') +
+    colorify(` ${seeDetails} ${testResultsUrl}`) +
     testResultsToString(passed, 'Passed') +
     testResultsToString(diffs, 'Unresolved') +
     testResultsToString(failed, 'Failed') +
-    colorify(testResultsPrefix, 'reset') +
-    colorify(testResultsUrl, 'reset', chalk.ansi256(86))
+    footer
   );
 
   function testResultsToString(testResultsArr, category) {
@@ -41,10 +45,7 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
       if (!testResults.isEmpty) {
         const error = hasError(testResults) ? stringifyError(testResults) : undefined;
         acc.push(
-          `${colorify(symbol, color)} ${colorify(
-            error || stringifyTestResults(testResults),
-            'reset',
-          )}`,
+          `${colorify(symbol, color)} ${colorify(error || stringifyTestResults(testResults))}`,
         );
       }
       return acc;
@@ -56,7 +57,7 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
     return testResultsSection(coloredTitle, results);
   }
 
-  function colorify(msg, color, chalkFunction = chalk[color]) {
+  function colorify(msg, color = 'reset', chalkFunction = chalk[color]) {
     return isInteractive ? msg : chalkFunction(msg);
   }
 }

--- a/packages/eyes-cypress/src/plugin/errorDigest.js
+++ b/packages/eyes-cypress/src/plugin/errorDigest.js
@@ -24,19 +24,20 @@ function errorDigest({passed, failed, diffs, logger, isInteractive}) {
   logger.log('errorDigest: diff errors', diffs);
   logger.log('errorDigest: test errors', failed);
 
-  const testResultsUrl = diffs.length ? diffs[0].getUrl() : '';
+  const testResultsUrl = diffs.length
+    ? colorify(diffs[0].getUrl(), 'reset', chalk.ansi256(86))
+    : '';
   const seeDetails = testResultsUrl ? 'See details at:' : '';
   const testResultsPrefix = `\n${indent()}${seeDetails}`;
-  const footer = testResultsUrl
-    ? `\n\n${colorify(testResultsPrefix)} ${colorify(testResultsUrl, 'reset', chalk.ansi256(86))}`
-    : '';
+  const footer = testResultsUrl ? `${colorify(testResultsPrefix)} ${testResultsUrl}` : '';
   return (
     colorify('Eyes-Cypress detected diffs or errors during execution of visual tests.') +
     colorify(` ${seeDetails} ${testResultsUrl}`) +
     testResultsToString(passed, 'Passed') +
     testResultsToString(diffs, 'Unresolved') +
     testResultsToString(failed, 'Failed') +
-    footer
+    footer +
+    '\n\n'
   );
 
   function testResultsToString(testResultsArr, category) {

--- a/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
@@ -30,7 +30,7 @@ describe('errorDigest', () => {
       new TestResults({
         name: 'test1',
         hostDisplaySize: {width: 100, height: 200},
-        url: 'url1',
+        url: 'https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~',
         status: 'Unresolved',
       }),
       new TestResults({
@@ -65,7 +65,7 @@ describe('errorDigest', () => {
     const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
        ${chalk.green('Passed - 1 tests')}
          ${chalk.green('\u2713')} ${chalk.reset('test3 [1x2]')}
-       ${chalk.yellow('Diffs detected - 2 tests')}
+       ${chalk.ansi256(214)('Diffs detected - 2 tests')}
          ${chalk.yellow('\u26A0')} ${chalk.reset('test1 [100x200]')}
          ${chalk.yellow('\u26A0')} ${chalk.reset('test2 [300x400]')}
        ${chalk.red('Errors - 3 tests')}
@@ -73,7 +73,7 @@ describe('errorDigest', () => {
          ${chalk.red('\u2716')} ${chalk.reset('test0 [6x7] : Error: bloo')}
          ${chalk.red('\u2716')} ${chalk.reset('[Eyes test not started] : Error: kuku')}
 
-       See details at: url1`;
+       See details at: https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~`;
 
     // console.log(_wrap(output)); // debugging
     expect(output).to.deep.equal(expectedOutput);

--- a/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
@@ -4,14 +4,10 @@ const {expect} = require('chai');
 const chalk = require('chalk');
 const errorDigest = require('../../../src/plugin/errorDigest');
 const {TestResults} = require('@applitools/visual-grid-client');
-
-// cypress wraps the error digest in red and 3 space indentation, and we throw the error digest in an `Error`
-function _wrap(str) {
-  return chalk.red(`   ${new Error(str)}`);
-}
+const snap = require('@applitools/snaptdout');
 
 describe('errorDigest', () => {
-  it('works', () => {
+  it('works', async () => {
     const err1 = new TestResults({
       name: 'test0',
       hostDisplaySize: {width: 4, height: 5},
@@ -55,31 +51,10 @@ describe('errorDigest', () => {
       logger: {log: () => {}},
     });
 
-    // NOTE: this is a try to validate the expected output.
-    // It was very hard to construct this expected string, so if this becomes a maintenance nightmare, I suggest not to try and preserve it.
-    // It was mainly written for debugging purposes in order to quickly craft the output without having to run Cypress.
-
-    //  this might help:
-    // https://github.com/avajs/ava/blob/master/docs/04-snapshot-testing.md
-
-    const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
-       ${chalk.green('Passed - 1 tests')}
-         ${chalk.green('\u2713')} ${chalk.reset('test3 [1x2]')}
-       ${chalk.ansi256(214)('Diffs detected - 2 tests')}
-         ${chalk.yellow('\u26A0')} ${chalk.reset('test1 [100x200]')}
-         ${chalk.yellow('\u26A0')} ${chalk.reset('test2 [300x400]')}
-       ${chalk.red('Errors - 3 tests')}
-         ${chalk.red('\u2716')} ${chalk.reset('test0 [4x5] : Error: bla')}
-         ${chalk.red('\u2716')} ${chalk.reset('test0 [6x7] : Error: bloo')}
-         ${chalk.red('\u2716')} ${chalk.reset('[Eyes test not started] : Error: kuku')}
-
-       See details at: https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~`;
-
-    // console.log(_wrap(output)); // debugging
-    expect(output).to.deep.equal(expectedOutput);
+    await snap(output, 'works');
   });
 
-  it('should only print existing results', () => {
+  it('should only print existing results', async () => {
     const emptyResult = new TestResults();
     emptyResult.isEmpty = true;
     const passed = [
@@ -99,14 +74,10 @@ describe('errorDigest', () => {
       logger: {log: () => {}},
     });
 
-    const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
-       ${chalk.green('Passed - 1 tests')}
-         ${chalk.green('\u2713')} ${chalk.reset('test3 [1x2]')}`;
-
-    expect(output).to.deep.equal(expectedOutput);
+    await snap(output, 'existing results');
   });
 
-  it('should handle error results', () => {
+  it('should handle error results', async () => {
     const failure = new Error('i failed you');
     const passed = [];
     const failed = [failure];
@@ -118,14 +89,10 @@ describe('errorDigest', () => {
       logger: {log: () => {}},
     });
 
-    const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
-       ${chalk.red('Errors - 1 tests')}
-         ${chalk.red('\u2716')} ${chalk.reset('[Eyes test not started] : Error: i failed you')}`;
-
-    expect(output).to.deep.equal(expectedOutput);
+    await snap(output, 'error results');
   });
 
-  it('should not print formatting codes when isInteractive', () => {
+  it('should not print formatting codes when isInteractive', async () => {
     const passed = [
       new TestResults({
         name: 'test3',
@@ -150,14 +117,6 @@ describe('errorDigest', () => {
       isInteractive: true,
     });
 
-    const expectedOutput = `Eyes-Cypress detected diffs or errors during execution of visual tests:
-       Passed - 1 tests
-         \u2713 test3 [1x2]
-       Diffs detected - 1 tests
-         \u26A0 test1 [100x200]
-
-       See details at: some_url`;
-
-    expect(output).to.deep.equal(expectedOutput);
+    await snap(output, 'isInteractive');
   });
 });

--- a/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
+++ b/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
@@ -1,0 +1,35 @@
+{
+  "works": [
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "       \u001b[32mPassed - 1 tests\u001b[39m",
+    "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m",
+    "       \u001b[38;2;255;153;0mDiffs detected - 2 tests\u001b[39m",
+    "         \u001b[33m⚠\u001b[39m \u001b[0mtest1 [100x200]\u001b[0m",
+    "         \u001b[33m⚠\u001b[39m \u001b[0mtest2 [300x400]\u001b[0m",
+    "       \u001b[31mErrors - 3 tests\u001b[39m",
+    "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [4x5] : Error: bla\u001b[0m",
+    "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [6x7] : Error: bloo\u001b[0m",
+    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: kuku\u001b[0m\u001b[0m\u001b[0m",
+    "\u001b[0m\u001b[0m",
+    "\u001b[0m       See details at: \u001b[0m\u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
+  ],
+  "existing results": [
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "       \u001b[32mPassed - 1 tests\u001b[39m",
+    "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m"
+  ],
+  "error results": [
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "       \u001b[31mErrors - 1 tests\u001b[39m",
+    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: i failed you\u001b[0m"
+  ],
+  "isInteractive": [
+    "Eyes-Cypress detected diffs or errors during execution of visual tests:",
+    "       Passed - 1 tests",
+    "         ✓ test3 [1x2]",
+    "       Diffs detected - 1 tests",
+    "         ⚠ test1 [100x200]",
+    "",
+    "       See details at: some_url"
+  ]
+}

--- a/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
+++ b/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
@@ -1,6 +1,6 @@
 {
   "works": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m See details at:  https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[0m",
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m See details at: https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[0m",
     "       \u001b[32mPassed - 1 tests\u001b[39m",
     "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m",
     "       \u001b[38;2;255;153;0mDiffs detected - 2 tests\u001b[39m",
@@ -13,7 +13,7 @@
     "",
     "\u001b[0m\u001b[0m",
     "\u001b[0m\u001b[0m",
-    "\u001b[0m       See details at: \u001b[0m \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
+    "\u001b[0m       See details at:\u001b[0m \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
   ],
   "existing results": [
     "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
@@ -26,7 +26,7 @@
     "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: i failed you\u001b[0m"
   ],
   "isInteractive": [
-    "Eyes-Cypress detected diffs or errors during execution of visual tests. See details at:  some_url",
+    "Eyes-Cypress detected diffs or errors during execution of visual tests. See details at: some_url",
     "       Passed - 1 tests",
     "         ✓ test3 [1x2]",
     "       Diffs detected - 1 tests",
@@ -34,6 +34,6 @@
     "",
     "",
     "",
-    "       See details at:  some_url"
+    "       See details at: some_url"
   ]
 }

--- a/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
+++ b/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
@@ -1,6 +1,20 @@
 {
+  "existing results": [
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
+    "       \u001b[32mPassed - 1 tests\u001b[39m",
+    "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m",
+    "",
+    ""
+  ],
+  "error results": [
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
+    "       \u001b[31mErrors - 1 tests\u001b[39m",
+    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: i failed you\u001b[0m",
+    "",
+    ""
+  ],
   "works": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m See details at: https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[0m",
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m See details at: \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m\u001b[0m",
     "       \u001b[32mPassed - 1 tests\u001b[39m",
     "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m",
     "       \u001b[38;2;255;153;0mDiffs detected - 2 tests\u001b[39m",
@@ -9,21 +23,11 @@
     "       \u001b[31mErrors - 3 tests\u001b[39m",
     "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [4x5] : Error: bla\u001b[0m",
     "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [6x7] : Error: bloo\u001b[0m",
-    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: kuku\u001b[0m",
+    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: kuku\u001b[0m\u001b[0m\u001b[0m",
+    "\u001b[0m\u001b[0m",
+    "\u001b[0m       See details at:\u001b[0m \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m",
     "",
-    "\u001b[0m\u001b[0m",
-    "\u001b[0m\u001b[0m",
-    "\u001b[0m       See details at:\u001b[0m \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
-  ],
-  "existing results": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
-    "       \u001b[32mPassed - 1 tests\u001b[39m",
-    "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m"
-  ],
-  "error results": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
-    "       \u001b[31mErrors - 1 tests\u001b[39m",
-    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: i failed you\u001b[0m"
+    ""
   ],
   "isInteractive": [
     "Eyes-Cypress detected diffs or errors during execution of visual tests. See details at: some_url",
@@ -32,8 +36,8 @@
     "       Diffs detected - 1 tests",
     "         ⚠ test1 [100x200]",
     "",
+    "       See details at: some_url",
     "",
-    "",
-    "       See details at: some_url"
+    ""
   ]
 }

--- a/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
+++ b/packages/eyes-cypress/test/unit/plugin/snapshots/errorDigest.test.json
@@ -1,6 +1,6 @@
 {
   "works": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m See details at:  https://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[0m",
     "       \u001b[32mPassed - 1 tests\u001b[39m",
     "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m",
     "       \u001b[38;2;255;153;0mDiffs detected - 2 tests\u001b[39m",
@@ -9,27 +9,31 @@
     "       \u001b[31mErrors - 3 tests\u001b[39m",
     "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [4x5] : Error: bla\u001b[0m",
     "         \u001b[31m✖\u001b[39m \u001b[0mtest0 [6x7] : Error: bloo\u001b[0m",
-    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: kuku\u001b[0m\u001b[0m\u001b[0m",
+    "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: kuku\u001b[0m",
+    "",
     "\u001b[0m\u001b[0m",
-    "\u001b[0m       See details at: \u001b[0m\u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
+    "\u001b[0m\u001b[0m",
+    "\u001b[0m       See details at: \u001b[0m \u001b[38;2;51;255;204mhttps://eyes.applitools.com/app/batches/1/2?accountId=UAujt6tHnEKUivQXIz7G6A~~\u001b[39m"
   ],
   "existing results": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
     "       \u001b[32mPassed - 1 tests\u001b[39m",
     "         \u001b[32m✓\u001b[39m \u001b[0mtest3 [1x2]\u001b[0m"
   ],
   "error results": [
-    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests:\u001b[0m",
+    "\u001b[0mEyes-Cypress detected diffs or errors during execution of visual tests.\u001b[0m\u001b[0m  \u001b[0m",
     "       \u001b[31mErrors - 1 tests\u001b[39m",
     "         \u001b[31m✖\u001b[39m \u001b[0m[Eyes test not started] : Error: i failed you\u001b[0m"
   ],
   "isInteractive": [
-    "Eyes-Cypress detected diffs or errors during execution of visual tests:",
+    "Eyes-Cypress detected diffs or errors during execution of visual tests. See details at:  some_url",
     "       Passed - 1 tests",
     "         ✓ test3 [1x2]",
     "       Diffs detected - 1 tests",
     "         ⚠ test1 [100x200]",
     "",
-    "       See details at: some_url"
+    "",
+    "",
+    "       See details at:  some_url"
   ]
 }

--- a/packages/eyes-cypress/yarn.lock
+++ b/packages/eyes-cypress/yarn.lock
@@ -177,6 +177,11 @@
     prettier "1.18.2"
     yargs "15.3.1"
 
+"@applitools/snaptdout@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@applitools/snaptdout/-/snaptdout-1.0.0.tgz#b3614244850dbb67e0aa240320c301a1e16f2432"
+  integrity sha512-DrASeRFutMTaAMMFlNQ7LOf4hqO6g/oOrQfj9i5/C0tduOrP3a1GV0Uc67Hga1jMHUwu8HIXq20fkYy+qTGdPA==
+
 "@applitools/snippets@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@applitools/snippets/-/snippets-2.1.1.tgz#c5ec8b5b2d35da429349c03ac4e769cf0a9da598"

--- a/packages/snaptdout/package.json
+++ b/packages/snaptdout/package.json
@@ -29,5 +29,7 @@
     "@applitools/sdk-release-kit": "^0.13.0",
     "mocha": "^8.2.1"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@applitools/snaptdout": "^1.0.1"
+  }
 }

--- a/packages/snaptdout/yarn.lock
+++ b/packages/snaptdout/yarn.lock
@@ -58,6 +58,11 @@
     prettier "1.18.2"
     yargs "15.3.1"
 
+"@applitools/snaptdout@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@applitools/snaptdout/-/snaptdout-1.0.1.tgz#d33ab8e8750bb6de3d643af92d4fcdaa99df79af"
+  integrity sha512-hP/SBrWl3xkj0K8sJD4hu9PbFeegJDyJUT7teytx0oe+RAVb6h7OxfFwGyshq49t73zIQ5c10kuM7pnQ2LnQTw==
+
 "@azure/abort-controller@^1.0.0":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.3.tgz#9fdb8d5962bbe1fd614f1df7a590c2c49bfb9b24"


### PR DESCRIPTION
I'm not sure it looks better, but I wanted to point this -
Cypress paints the error in yellow. So anything we don't reset becomes yellow:
![Screenshot from 2021-02-28 09-49-26](https://user-images.githubusercontent.com/394320/109411397-79374a80-79aa-11eb-9c27-b783726a93ba.png)

WDYT about this change?
![Screenshot from 2021-02-28 09-49-04](https://user-images.githubusercontent.com/394320/109411403-82c0b280-79aa-11eb-998e-05b66a2f812f.png)
