### PR TITLE
fix(eyes-cypress): eyes check window timeout

### DIFF
--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- set explicit timeout for eyesCheckWindow [trello](https://trello.com/c/5Thz1QFs)
 
 ## 3.19.1 - 2021/2/24
 

--- a/packages/eyes-cypress/src/browser/eyesCheckWindow.js
+++ b/packages/eyes-cypress/src/browser/eyesCheckWindow.js
@@ -53,7 +53,7 @@ function makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions, cypr
             cypress
               .viewport(Number(requiredWidth), height, {log: false})
               .wait(300, {log: false})
-              .then(() => {
+              .then({log: false, timeout: 900000}, () => {
                 return takeDomSnapshot(options).then(snapshot => {
                   browsersInfo.forEach(({index}) => (snapshots[index] = snapshot));
                 });

--- a/packages/eyes-cypress/test/e2e/cypress-run-breakpoints.test.js
+++ b/packages/eyes-cypress/test/e2e/cypress-run-breakpoints.test.js
@@ -4,13 +4,26 @@ const {exec} = require('child_process');
 const {promisify: p} = require('util');
 const path = require('path');
 const pexec = p(exec);
+const testServer = require('@applitools/sdk-shared/src/run-test-server');
 const fs = require('fs');
 
 const sourceTestAppPath = path.resolve(__dirname, '../fixtures/testApp');
 const targetTestAppPath = path.resolve(__dirname, '../fixtures/testAppCopies/testApp-breakpoint');
 
 describe('layout breakpoints', () => {
+  let closeServer;
   before(async () => {
+    const middlewareFile = path.resolve(
+      __dirname,
+      '../../../sdk-shared/coverage-tests/util/slow-middleware.js',
+    );
+    const staticPath = path.resolve(__dirname, '../fixtures');
+    const server = await testServer({
+      port: 5555,
+      staticPath,
+      middlewareFile,
+    });
+    closeServer = server.close;
     if (fs.existsSync(targetTestAppPath)) {
       fs.rmdirSync(targetTestAppPath, {recursive: true});
     }
@@ -23,6 +36,7 @@ describe('layout breakpoints', () => {
 
   after(async () => {
     fs.rmdirSync(targetTestAppPath, {recursive: true});
+    await closeServer();
   });
 
   it('works for js layouts', async () => {

--- a/packages/eyes-cypress/test/fixtures/breakpoints.html
+++ b/packages/eyes-cypress/test/fixtures/breakpoints.html
@@ -1,0 +1,76 @@
+
+<html lang="en">
+    <head>
+      <meta name="viewport" content="width=device-width, initial-scale=1">
+      <meta charset="UTF-8">
+      <title>JS Layout</title>
+      <style>
+        html, body {
+          margin: 0;
+          padding: 0;
+        }
+        #root {
+          position: relative;
+          height: 100%;
+          padding: 10px;
+          box-sizing: border-box;
+        }
+        #text {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          text-align: center;
+          font-family: Helvetica;
+          font-weight: bold;
+          font-size: 30px;
+        }
+        #indicator {
+          width: 30px;
+          height: 30px;
+          background: cornflowerblue;
+        }
+        @media (max-width: 999px) {
+          #indicator {
+            background: greenyellow
+          }
+        }
+        @media (max-width: 499px) {
+          #indicator {
+            background: coral
+          }
+        }
+      </style>
+    </head>
+    <body>
+      <div id="root">
+        <div id="indicator"></div>
+        <div id="text">DEFAULT</div>
+      </div>
+      <script>
+        var root = document.querySelector('#root')
+        var text = document.querySelector('#text')
+        function handleResize() {
+            if (window.matchMedia('(max-width: 499px)').matches) {
+            text.innerText = 'SMALL'
+            root.style.background = 'coral'
+          } else if (window.matchMedia('(max-width: 999px)').matches) {
+            text.innerText = 'MEDIUM'
+            root.style.background = 'greenyellow'
+          } else {
+            text.innerText = 'LARGE'
+            root.style.background = 'cornflowerblue'
+          }
+        }
+        window.addEventListener('load', handleResize)
+        window.addEventListener('resize', handleResize)
+      </script>
+      <script>
+        setTimeout(() => {
+          var img = document.createElement('img')
+          img.src = './smurfs.jpg'
+          document.body.appendChild(img)
+        }, 3000) 
+      </script>
+    </body>
+    </html>

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
@@ -51,7 +51,7 @@ describe('JS layout', () => {
   });
 
   it('should not hit the cypress default command timeout', () => {
-    cy.visit('https://apple.com/');
+    cy.visit('http://localhost:5555/breakpoints.html');
     cy.eyesOpen({
       appName: 'JS layout',
       testName: 'testing js layout support in cypress',

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
@@ -50,7 +50,7 @@ describe('JS layout', () => {
     cy.eyesClose();
   });
 
-  it.only('should not hit the cypress default command timeout', () => {
+  it('should not hit the cypress default command timeout', () => {
     cy.visit('https://apple.com/');
     cy.eyesOpen({
       appName: 'JS layout',

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
@@ -49,4 +49,20 @@ describe('JS layout', () => {
     cy.eyesCheckWindow('layoutBreakpoints = true');
     cy.eyesClose();
   });
+
+  it.only('should not hit the cypress default command timeout', () => {
+    cy.visit('https://apple.com/');
+    cy.eyesOpen({
+      appName: 'JS layout',
+      testName: 'testing js layout support in cypress',
+      browser: [
+        {name: 'chrome', width: 1000, height: 800},
+        {iosDeviceInfo: {deviceName: 'iPad (7th generation)'}},
+        {chromeEmulationInfo: {deviceName: 'Pixel 4 XL'}},
+      ],
+      layoutBreakpoints: true,
+    });
+    cy.eyesCheckWindow('cypress default command timeout');
+    cy.eyesClose();
+  });
 });

--- a/packages/sdk-shared/coverage-tests/util/slow-middleware.js
+++ b/packages/sdk-shared/coverage-tests/util/slow-middleware.js
@@ -1,0 +1,10 @@
+// this middleware causes any request to be delayed for a configurable amount of time
+module.exports = async (req, res, next) => {
+  const extensions = ['jpg', 'css', 'jpeg', 'png'];
+  const currentExtension = req.url.split('.')[1];
+  if (extensions.includes(currentExtension)) { 
+    setTimeout(next, 5000);
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
[trello](https://trello.com/c/5Thz1QFs/808-experian-cypress-timeout-when-setlayoutbreakpoint-is-enabled)

while #376 removed eyesTimeout, we notice customers that are hitting the default cypress command timeout (4 seconds) when using js-layouts.

the fix is to set explicit timeout for the `cy.then` that wrap our `takeDomSnapshot` call.

I set it to 900,000 ms which is 15 minutes.