### PR TITLE
eyes-images: expose and fix error in getScreenshot

### DIFF
--- a/packages/eyes-images/CHANGELOG.md
+++ b/packages/eyes-images/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: update getScreenshot to support the correct return type when performing a full page stitch ([Trello](https://trello.com/c/6oVADkSf))
 
 ## 4.19.0 - 2021/2/22
 
@@ -12,7 +13,7 @@
 
 - chore: add husky
 - updated to @applitools/eyes-sdk-core@12.13.5 (from 12.10.0)
-- updated to @applitools/eyes-sdk-core@12.13.5 (from 12.10.0)
+
 ## 4.18.0 - 2020/12/18
 
 - updated to @applitools/eyes-sdk-core@12.10.0 (from 12.9.1)

--- a/packages/eyes-images/lib/Eyes.js
+++ b/packages/eyes-images/lib/Eyes.js
@@ -419,8 +419,8 @@ class Eyes extends EyesBase {
    */
   async getScreenshot() {
     if (this._screenshotProvider) {
-      const screenshot = await this._screenshotProvider.getImage()
-      return new EyesSimpleScreenshot(screenshot)
+      const {image} = await this._screenshotProvider.getImage()
+      return new EyesSimpleScreenshot(image)
     }
 
     if (this._screenshot) {

--- a/packages/eyes-images/test/unit/Eyes.spec.js
+++ b/packages/eyes-images/test/unit/Eyes.spec.js
@@ -1,0 +1,17 @@
+const {Eyes, RectangleSize} = require('../..')
+const assert = require('assert')
+
+describe('Eyes', () => {
+  it('getScreenshot', async () => {
+    const eyes = new Eyes()
+    eyes._screenshotProvider = {
+      getImage: async () => {
+        return {image: new RectangleSize(800, 600)}
+      },
+    }
+    // eslint-disable-next-line
+    await assert.doesNotReject(async () => {
+      await eyes.getScreenshot()
+    })
+  })
+})


### PR DESCRIPTION
SIDE Eyes uses eyes-images under the hood for classic execution. In this scenario `getScreenshot` is ultimately calling `FullPageCaptureAlgorithm` which was recently changed to return a different object structure ([link](https://github.com/applitools/eyes.sdk.javascript1/commit/6412cea720605cf56c4ff0e4896f6b9350064a47)). This change was not propagated to eyes-images, which causes it to throw. There was no test to surface it which is why it went unnoticed when releasing eyes-images with the change. Currently, this error causes classic execution in SIDE Eyes to break (__in production__). I've confirmed that this patch fixes it.

re: [Trello 822](https://trello.com/c/6oVADkSf)

The error throws inside of the constructor in `eyes-sdk-core/lib/capture/EyesSimpleScreenshot`. Arguably, a better fix might be to make the change there (then it would be seamless to eyes-images). Open to that direction as well, but didn't look into the potential impacts of it.