### PR TITLE
Handle story parameters with circular reference better

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle story parameters with circular reference better
 
   ## 3.20.0 - 2021/3/17
 

--- a/packages/eyes-storybook/src/browser/getStories.js
+++ b/packages/eyes-storybook/src/browser/getStories.js
@@ -107,18 +107,27 @@ async function getStories({timeout = DEFAULT_TIMEOUT} = {timeout: DEFAULT_TIMEOU
   function getStoriesThroughClientAPI(clientApi) {
     return clientApi.getStories().map((story, index) => {
       const {name, kind, parameters} = story;
+      const hasEyesParameters =
+        parameters && parameters.eyes && typeof parameters.eyes === 'object';
       let parametersIfSerialized, error;
       try {
         parametersIfSerialized = JSON.parse(JSON.stringify(parameters));
-        if (parameters && parameters.eyes && typeof parameters.eyes === 'object') {
-          for (const prop in parameters.eyes) {
-            if (typeof parameters.eyes[prop] === 'function') {
-              parametersIfSerialized.eyes[prop] = '__func';
-            }
+      } catch (e) {
+        try {
+          if (hasEyesParameters) {
+            parametersIfSerialized = JSON.parse(JSON.stringify({eyes: parameters.eyes}));
+          }
+        } catch (ex) {
+          error = `Ignoring parameters for story: "${name} ${kind}" since they are not serilizable. Error: "${e.message}"`;
+        }
+      }
+
+      if (parametersIfSerialized && hasEyesParameters) {
+        for (const prop in parameters.eyes) {
+          if (typeof parameters.eyes[prop] === 'function') {
+            parametersIfSerialized.eyes[prop] = '__func';
           }
         }
-      } catch (e) {
-        error = `Ignoring parameters for story: "${name} ${kind}" since they are not serilizable. Error: "${e.message}"`;
       }
 
       return {

--- a/packages/eyes-storybook/test/fixtures/appWithStorybook/index.js
+++ b/packages/eyes-storybook/test/fixtures/appWithStorybook/index.js
@@ -83,6 +83,7 @@ storiesOf('skipped tests', module)
   )
   .add('[SKIP] this story should not be checked visually by eyes-storybook because of global config',
     () => <div>this story should not be checked visually by eyes-storybook because of global config</div>)
+  .add('testing circular parameters', () => <div>nothing to see here</div>, {circular, eyes: {include: false}})
 
 storiesOf('Text', module)
   .add(

--- a/packages/eyes-storybook/test/it/getStories.it.test.js
+++ b/packages/eyes-storybook/test/it/getStories.it.test.js
@@ -28,12 +28,17 @@ describe('getStories', () => {
     try {
       await page.goto('http://localhost:9001');
       const stories = await page.evaluate(getStories);
+      const parameters = {
+        fileName: './test/fixtures/appWithStorybook/index.js',
+        framework: 'react',
+      };
       expect(stories).to.eql(
         [
           {
             name: 'with text',
             kind: 'Button',
             parameters: {
+              ...parameters,
               someParam: 'i was here, goodbye',
               eyes: {ignoreRegions: [{selector: '.ignore-this'}]},
             },
@@ -43,39 +48,56 @@ describe('getStories', () => {
             kind: 'Button',
             error: `Ignoring parameters for story: "with some emoji Button" since they are not serilizable. Error: "Converting circular structure to JSON\n    --> starting at object with constructor 'Object'\n    --- property 'inner' closes the circle"`,
           },
-          {name: 'image', kind: 'Image'},
-          {name: 'story 1', kind: 'Nested'},
-          {name: 'story 1.1', kind: 'Nested/Component'},
-          {name: 'story 1.2', kind: 'Nested/Component'},
-          {name: 'a yes-a b', kind: 'Button with-space yes-indeed'},
-          {name: 'b yes-a b', kind: 'Button with-space yes-indeed/nested with-space yes'},
+          {name: 'image', kind: 'Image', parameters},
+          {name: 'story 1', kind: 'Nested', parameters},
+          {name: 'story 1.1', kind: 'Nested/Component', parameters},
+          {name: 'story 1.2', kind: 'Nested/Component', parameters},
+          {name: 'a yes-a b', kind: 'Button with-space yes-indeed', parameters},
+          {
+            name: 'b yes-a b',
+            kind: 'Button with-space yes-indeed/nested with-space yes',
+            parameters,
+          },
           {
             name: 'c yes-a b',
             kind: 'Button with-space yes-indeed/nested with-space yes/nested again-yes a',
+            parameters,
           },
-          {name: 'story 1.1', kind: 'SOME section|Nested/Component'},
-          {name: 'story 1.2', kind: 'SOME section|Nested/Component'},
+          {name: 'story 1.1', kind: 'SOME section|Nested/Component', parameters},
+          {name: 'story 1.2', kind: 'SOME section|Nested/Component', parameters},
           {
             name: 'c yes-a b',
             kind: 'Wow|one with-space yes-indeed/nested with-space yes/nested again-yes a',
+            parameters,
           },
-          {name: 'should also do RTL', kind: 'RTL'},
-          {name: 'local RTL config', kind: 'RTL', parameters: {eyes: {variations: ['rtl']}}},
+          {name: 'should also do RTL', kind: 'RTL', parameters},
+          {
+            name: 'local RTL config',
+            kind: 'RTL',
+            parameters: {...parameters, eyes: {variations: ['rtl']}},
+          },
           {
             name:
               'this story should not be checked visually by eyes-storybook because of local parameter',
             kind: 'skipped tests',
-            parameters: {eyes: {include: false}},
+            parameters: {...parameters, eyes: {include: false}},
           },
           {
             name:
               '[SKIP] this story should not be checked visually by eyes-storybook because of global config',
             kind: 'skipped tests',
+            parameters,
+          },
+          {
+            name: 'testing circular parameters',
+            kind: 'skipped tests',
+            parameters: {eyes: {include: false}}, // note that fileName and framework parameters are not present here because of the circular reference
           },
           {
             kind: 'Text',
             name: 'appears after a delay',
             parameters: {
+              ...parameters,
               eyes: {
                 waitBeforeScreenshot: '.ready',
               },
@@ -84,31 +106,19 @@ describe('getStories', () => {
           {
             name: 'Popover',
             kind: 'Interaction',
-            parameters: {bgColor: 'lime', eyes: {runBefore: '__func'}},
+            parameters: {...parameters, bgColor: 'lime', eyes: {runBefore: '__func'}},
           },
           {
             kind: 'Responsive UI',
             name: 'Red/green',
+            parameters,
           },
         ].map((story, index) => {
-          const {name, kind, parameters, error} = story;
-          const res = {
+          return {
+            ...story,
             index,
-            name,
-            kind,
             isApi: true,
           };
-          if (!error) {
-            res.parameters = {
-              fileName: './test/fixtures/appWithStorybook/index.js',
-              framework: 'react',
-              ...parameters,
-            };
-          } else {
-            res.error = error;
-          }
-
-          return res;
         }),
       );
     } finally {


### PR DESCRIPTION
Today, when a story has a circular reference in parameters (see below example) we show an error to the console that we ignore parameters for this story.
But there's no need to do this if the circular reference is unrelated to the eyes section of the parameters. We only care about the eyes section.
You could argue that we don't need to return the entire parameters object from the browser at all. That might be right. But it's both a big change in code, and also we don't lose anything from it, and we might want to use it in the future. We just need to not let it fail us.

```
const circular = {param: true}
circular.inner = circular

storiesOf('bla bla', module)
  .add('testing circular parameters', () => <div>nothing to see here</div>, {circular, eyes: {include: false}})
```
