### PR TITLE
Fix legacy concurrency in Storybook

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix regression with `concurrency` that was introduced in version 3.17.1
 
 ## 3.20.1 - 2021/3/17
 

--- a/packages/eyes-storybook/src/defaultConfig.js
+++ b/packages/eyes-storybook/src/defaultConfig.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = {
-  testConcurrency: 5,
   storybookPort: 9000,
   storybookHost: 'localhost',
   storybookConfigDir: '.storybook',

--- a/packages/eyes-storybook/src/generateConfig.js
+++ b/packages/eyes-storybook/src/generateConfig.js
@@ -38,7 +38,11 @@ function generateConfig({argv = {}, defaultConfig = {}, externalConfigParams = [
     result.showLogs = true;
   }
 
-  if (result.storyDataGap === undefined && result.testConcurrency !== undefined) {
+  if (!result.testConcurrency && !result.concurrency) {
+    result.testConcurrency = 5; // TODO require from core
+  }
+
+  if (result.storyDataGap === undefined) {
     result.storyDataGap = result.testConcurrency;
   }
   return result;

--- a/packages/eyes-storybook/src/processResults.js
+++ b/packages/eyes-storybook/src/processResults.js
@@ -4,7 +4,6 @@ const chalk = require('chalk');
 const {TestResultsError, TestResultsFormatter} = require('@applitools/eyes-sdk-core');
 const uniq = require('./uniq');
 const concurrencyMsg = require('./concurrencyMsg');
-const defaultConfig = require('./defaultConfig');
 
 function processResults({results = [], totalTime, testConcurrency}) {
   let outputStr = '\n';
@@ -79,7 +78,8 @@ function processResults({results = [], totalTime, testConcurrency}) {
     outputStr += `\n${seeDetailsStr}\nTotal time: ${Math.round(totalTime / 1000)} seconds\n`;
   }
 
-  if (Number(testConcurrency) === defaultConfig.testConcurrency) {
+  if (Number(testConcurrency) === 5) {
+    // TODO require from core
     outputStr += `\n${concurrencyMsg}\n`;
   }
 

--- a/packages/eyes-storybook/test/fixtures/applitools-legacy-concurrency.config.js
+++ b/packages/eyes-storybook/test/fixtures/applitools-legacy-concurrency.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  concurrency: 2,
+  appName: 'appName',
+  storybookConfigDir: 'test/fixtures/appWithStorybook/',
+  storybookStaticDir: 'test/fixtures',
+  include: ({name}) => !/^\[SKIP\]/.test(name),
+  variations: ({name}) => {
+    if (/should also do RTL/.test(name)) {
+      return ['rtl'];
+    }
+  },
+};

--- a/packages/eyes-storybook/test/unit/generateConfig.test.js
+++ b/packages/eyes-storybook/test/unit/generateConfig.test.js
@@ -3,6 +3,8 @@ const {describe, it, beforeEach, afterEach} = require('mocha');
 const {expect} = require('chai');
 const generateConfig = require('../../src/generateConfig');
 
+const sideEffectConfig = {testConcurrency: 5, storyDataGap: 5};
+
 describe('generateConfig', function() {
   let env;
   beforeEach(() => {
@@ -19,7 +21,7 @@ describe('generateConfig', function() {
       defaultConfig: {bla: 1},
     });
 
-    expect(config).to.eql({bla: 1});
+    expect(config).to.eql({bla: 1, ...sideEffectConfig});
   });
 
   it('handles argv', () => {
@@ -29,7 +31,7 @@ describe('generateConfig', function() {
       argv: {knownProp: 'from argv', unknownProp: 3},
     });
 
-    expect(config).to.eql({knownProp: 'from argv'});
+    expect(config).to.eql({knownProp: 'from argv', ...sideEffectConfig});
   });
 
   it('handles env config', () => {
@@ -37,26 +39,26 @@ describe('generateConfig', function() {
     const config = generateConfig({
       defaultConfig: {bla: 'from default'},
     });
-    expect(config).to.eql({bla: 'from env'});
+    expect(config).to.eql({bla: 'from env', ...sideEffectConfig});
   });
 
   it('handles externalConfigParams', () => {
     const config = generateConfig({
       externalConfigParams: ['bla'],
     });
-    expect(config).to.eql({});
+    expect(config).to.eql({...sideEffectConfig});
 
     process.env.APPLITOOLS_BLA = 'bla from env';
     const config2 = generateConfig({
       externalConfigParams: ['bla'],
     });
-    expect(config2).to.eql({bla: 'bla from env'});
+    expect(config2).to.eql({bla: 'bla from env', ...sideEffectConfig});
 
     const config3 = generateConfig({
       externalConfigParams: ['bla'],
       defaultConfig: {kuku: 'buku'},
     });
-    expect(config3).to.eql({bla: 'bla from env', kuku: 'buku'});
+    expect(config3).to.eql({bla: 'bla from env', kuku: 'buku', ...sideEffectConfig});
   });
 
   it('handles externalConfigParams with argv', () => {
@@ -65,7 +67,7 @@ describe('generateConfig', function() {
       externalConfigParams: ['bla'],
       argv: {bla: 'bla from argv'},
     });
-    expect(config).to.eql({bla: 'bla from argv'});
+    expect(config).to.eql({bla: 'bla from argv', ...sideEffectConfig});
   });
 
   it('handles number waitBeforeScreenshot from env variable', () => {
@@ -73,7 +75,7 @@ describe('generateConfig', function() {
     const config = generateConfig({
       externalConfigParams: ['waitBeforeScreenshot'],
     });
-    expect(config).to.eql({waitBeforeScreenshot: 1234});
+    expect(config).to.eql({waitBeforeScreenshot: 1234, ...sideEffectConfig});
   });
 
   it('backward compatible for waitBeforeScreenshots', () => {


### PR DESCRIPTION
PR #375 created a regression, where `concurrency` parameter was masked by the default value of `testConcurrency`.
The solution is to not have either `concurrency` or `testConcurrency` in the `defaultConfig` object, but rather populate the default dynamically.

There was a burning need to test this e2e. Otherwise there's no assurance that the correct concurrency take effect.
I implemented it in storybook's version of the fake eyes server.

The next steps for this are:
1. Consolidate the value for default testConcurrency into one place (I left `// TODO require from core` comments).
2. Provide this in the fake eyes server that's also outside of storybook (maybe even consolidate the two - we have a technical debt here).
3. Ideally this would be available for generic tests so that they could be tested for concurrency as well.