### PR TITLE
chore(release): save coverage test report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: coverage-tests-report
+          retention-days: 30
           path: |
             packages/${{github.event.inputs.name}}/coverage-tests-metadata.json
             packages/${{github.event.inputs.name}}/coverage-test-report.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
           git merge $BRANCH
           git push origin master
           echo "::endgroup::"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-tests-report
+          path: |
+            packages/${{github.event.inputs.name}}/coverage-tests-metadata.json
+            packages/${{github.event.inputs.name}}/coverage-test-report.xml
     env:
       CVG_TESTS_REMOTE: http://localhost:4444/wd/hub
       APPLITOOLS_API_KEY_SDK: ${{secrets.APPLITOOLS_API_KEY_SDK}}


### PR DESCRIPTION
[trello](https://trello.com/c/hL7aN2J2/828-save-coverage-test-results-in-github-actions)

this PR introduces saving the `coverage-test-report.xml` and `coverage-test-metadata.json` files for each release.

this was implemented in `Coverage test a package` action, with default retention.

since we run `release` more often than `Coverage test a package` - we need to decide on the retention period for these release runs.
`retention-days` - defaults to 90 days, if not set.
