### PR TITLE
support agentRunId

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- support `agentRunId`
 
 ## 12.16.3 - 2021/3/22
 

--- a/packages/eyes-sdk-core/lib/sdk/EyesBase.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesBase.js
@@ -2032,6 +2032,7 @@ class EyesBase {
       properties: this._configuration.getProperties(),
       agentSessionId: GeneralUtils.guid(),
       timeout: this._configuration.getAbortIdleTestTimeout(),
+      agentRunId: this.agentRunId,
     })
 
     this._logger.verbose('Starting server session...')

--- a/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesVisualGrid.js
@@ -2,6 +2,7 @@
 const BrowserType = require('../config/BrowserType')
 const Configuration = require('../config/Configuration')
 const TypeUtils = require('../utils/TypeUtils')
+const GeneralUtils = require('../utils/GeneralUtils')
 const ArgumentGuard = require('../utils/ArgumentGuard')
 const TestResultsFormatter = require('../TestResultsFormatter')
 const CorsIframeHandler = require('../capture/CorsIframeHandler')
@@ -207,9 +208,11 @@ class EyesVisualGrid extends EyesCore {
       await this.setViewportSize(vs)
     }
 
-    const {checkWindow, close, abort} = await openEyes(
-      this._configuration.toOpenEyesConfiguration(),
-    )
+    const openParams = this._configuration.toOpenEyesConfiguration()
+    const {checkWindow, close, abort} = await openEyes({
+      ...openParams,
+      agentRunId: `${openParams.testName}--${GeneralUtils.randomAlphanumeric(10)}`,
+    })
 
     this._isOpen = true
     this._checkWindowCommand = checkWindow

--- a/packages/eyes-sdk-core/lib/server/SessionStartInfo.js
+++ b/packages/eyes-sdk-core/lib/server/SessionStartInfo.js
@@ -52,6 +52,7 @@ class SessionStartInfo {
     render,
     properties,
     agentSessionId,
+    agentRunId,
     timeout,
   } = {}) {
     ArgumentGuard.notNullOrEmpty(agentId, 'agentId')
@@ -83,6 +84,7 @@ class SessionStartInfo {
     this._properties = properties
     this._concurrencyVersion = 2
     this._agentSessionId = agentSessionId
+    this._agentRunId = agentRunId
     this._timeout = timeout
   }
 

--- a/packages/eyes-sdk-core/test/it/EyesVisualGrid.spec.js
+++ b/packages/eyes-sdk-core/test/it/EyesVisualGrid.spec.js
@@ -98,6 +98,18 @@ describe('EyesVisualGrid', async () => {
     )
   })
 
+  // TODO unskip after releasing vgc
+  it.skip('should populate agentRunId', async () => {
+    await eyes.open(driver, 'FakeApp', 'FakeTest')
+    await eyes.check()
+    const results = await eyes.close()
+    const session = await getSession(results, serverUrl)
+    const agentRunId = session.startInfo.agentRunId
+    const [testName, random] = agentRunId.split('--')
+    expect(testName).to.equal('FakeTest')
+    expect(random).to.have.length(10)
+  })
+
   async function extractMatchSettings(results) {
     const session = await getSession(results, serverUrl)
     const imageMatchSettings = session.steps[0].matchWindowData.options.imageMatchSettings

--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- support `agentRunId`
 
 ## 15.6.4 - 2021/3/22
 

--- a/packages/visual-grid-client/src/sdk/EyesWrapper.js
+++ b/packages/visual-grid-client/src/sdk/EyesWrapper.js
@@ -193,6 +193,10 @@ class EyesWrapper extends EyesBase {
   async setIgnoreGitMergeBase(input) {
     this._configuration.setIgnoreGitMergeBase(input)
   }
+
+  setAgentRunId(value) {
+    this.agentRunId = value
+  }
 }
 
 module.exports = EyesWrapper

--- a/packages/visual-grid-client/src/sdk/openEyes.js
+++ b/packages/visual-grid-client/src/sdk/openEyes.js
@@ -104,6 +104,7 @@ function makeOpenEyes({
     ignoreBaseline = _ignoreBaseline,
     notifyOnCompletion,
     visualGridOptions = _visualGridOptions,
+    agentRunId,
   }) {
     logger.verbose(`openEyes: testName=${testName}, browser=`, browser)
 
@@ -212,6 +213,7 @@ function makeOpenEyes({
       serverUrl,
       agentId,
       ignoreGitMergeBase,
+      agentRunId,
     })
 
     if (!globalState.batchStore.hasCloseBatch()) {

--- a/packages/visual-grid-client/src/sdk/wrapperUtils.js
+++ b/packages/visual-grid-client/src/sdk/wrapperUtils.js
@@ -58,6 +58,7 @@ function configureWrappers({
   enablePatterns,
   ignoreDisplacements,
   ignoreGitMergeBase,
+  agentRunId,
 }) {
   for (let i = 0, ii = wrappers.length; i < ii; i++) {
     const wrapper = wrappers[i]
@@ -93,6 +94,7 @@ function configureWrappers({
     serverUrl !== undefined && wrapper.setServerUrl(serverUrl)
     agentId !== undefined && wrapper.setBaseAgentId(agentId)
     ignoreGitMergeBase !== undefined && wrapper.setIgnoreGitMergeBase(ignoreGitMergeBase)
+    agentRunId !== undefined && wrapper.setAgentRunId(agentRunId)
   }
 }
 

--- a/packages/visual-grid-client/test/it/openEyes.it.test.js
+++ b/packages/visual-grid-client/test/it/openEyes.it.test.js
@@ -1141,6 +1141,7 @@ Received: 'firefox-1'.`,
       ignoreBaseline: 'ignoreBaseline',
       browser: [{deviceName: 'device1'}, {deviceName: 'device2'}, {}],
       agentId: 'agentId',
+      agentRunId: 'agentRunId',
       batchNotify: true,
     })
 
@@ -1164,6 +1165,7 @@ Received: 'firefox-1'.`,
       expect(wrapper.serverUrl).to.equal('serverUrl')
       expect(wrapper.baseAgentId).to.equal('agentId')
       expect(wrapper.batch.getNotifyOnCompletion()).to.be.true
+      expect(wrapper.agentRunId).to.equal('agentRunId')
     }
 
     expect(wrappers[0].deviceInfo).to.equal('device1 (Chrome emulation)')

--- a/packages/visual-grid-client/test/util/FakeEyesWrapper.js
+++ b/packages/visual-grid-client/test/util/FakeEyesWrapper.js
@@ -511,6 +511,10 @@ class FakeEyesWrapper extends EventEmitter {
   setIgnoreGitMergeBase(input) {
     this._configuration.ignoreGitMergeBase = input
   }
+
+  setAgentRunId(value) {
+    this.agentRunId = value
+  }
 }
 
 module.exports = FakeEyesWrapper


### PR DESCRIPTION
The property `agentRunId` represents all the tests that originate from the same `eyes.open` user command.
This is relevant only in VG mode, where multiple tests can be started from a single command.

I populate this value with the test name plus a random string, so that it is easy to track and correlate when reading logs.

This PR has one skipped integration test in core, because of the cyclic dependecy core<-->vgc.

The generic test is in this PR: https://github.com/applitools/sdk.coverage.tests/pull/69