### PR TITLE
Support Variant ID

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - support `agentRunId`
+- support `variantId`
 
 ## 12.16.3 - 2021/3/22
 

--- a/packages/eyes-sdk-core/lib/MatchWindowAndCloseTask.js
+++ b/packages/eyes-sdk-core/lib/MatchWindowAndCloseTask.js
@@ -35,7 +35,16 @@ class MatchWindowAndCloseTask extends MatchWindowTask {
    * @param {ImageMatchSettings} imageMatchSettings - The settings to use.
    * @return {Promise<TestResults>} - The match result.
    */
-  async performMatch(userInputs, appOutput, name, renderId, ignoreMismatch, imageMatchSettings) {
+  async performMatch(
+    userInputs,
+    appOutput,
+    name,
+    renderId,
+    ignoreMismatch,
+    imageMatchSettings,
+    source,
+    variantId,
+  ) {
     // Prepare match model.
     const options = new Options({
       name,
@@ -46,6 +55,8 @@ class MatchWindowAndCloseTask extends MatchWindowTask {
       forceMismatch: false,
       forceMatch: false,
       imageMatchSettings,
+      source,
+      variantId,
     })
     const data = new MatchWindowAndCloseData({
       startInfo: this._startInfo,

--- a/packages/eyes-sdk-core/lib/MatchWindowTask.js
+++ b/packages/eyes-sdk-core/lib/MatchWindowTask.js
@@ -434,8 +434,10 @@ class MatchWindowTask {
       checkSettings,
     )
     const renderId = checkSettings.getRenderId()
-    debugger
-    const variantId = checkSettings.getVariantId()
+    const variantId = TypeUtils.getOrDefault(
+      checkSettings.getVariantId(),
+      this._eyes._configuration.getVariantId(),
+    )
     const screenshot = appOutput.getScreenshot()
     const matchSettings = await this.createImageMatchSettings(checkSettings, screenshot)
     this._matchResult = await this.performMatch(

--- a/packages/eyes-sdk-core/lib/MatchWindowTask.js
+++ b/packages/eyes-sdk-core/lib/MatchWindowTask.js
@@ -63,6 +63,7 @@ class MatchWindowTask {
     ignoreMismatch,
     imageMatchSettings,
     source,
+    variantId,
   ) {
     // Prepare match model.
     const options = new Options({
@@ -75,6 +76,7 @@ class MatchWindowTask {
       forceMatch: false,
       imageMatchSettings,
       source,
+      variantId,
     })
     const data = new MatchWindowData({
       userInputs,
@@ -432,6 +434,8 @@ class MatchWindowTask {
       checkSettings,
     )
     const renderId = checkSettings.getRenderId()
+    debugger
+    const variantId = checkSettings.getVariantId()
     const screenshot = appOutput.getScreenshot()
     const matchSettings = await this.createImageMatchSettings(checkSettings, screenshot)
     this._matchResult = await this.performMatch(
@@ -442,6 +446,7 @@ class MatchWindowTask {
       ignoreMismatch,
       matchSettings,
       source,
+      variantId,
     )
     return screenshot
   }

--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -251,6 +251,9 @@ class Configuration {
     /** @type {boolean} */
     this._ignoreGitMergeBase = undefined
 
+    /** @type {string} */
+    this._variantId = undefined
+
     if (configuration) {
       this.mergeConfig(configuration)
     }
@@ -1346,6 +1349,16 @@ class Configuration {
   setIgnoreGitMergeBase(input) {
     ArgumentGuard.isBoolean(input, 'ignoreGitMergeBase')
     this._ignoreGitMergeBase = input
+    return this
+  }
+
+  getVariantId() {
+    return this._variantId
+  }
+
+  setVariantId(input) {
+    ArgumentGuard.isString(input, 'variantId')
+    this._variantId = input
     return this
   }
 

--- a/packages/eyes-sdk-core/lib/fluent/CheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/CheckSettings.js
@@ -42,6 +42,8 @@ class CheckSettings {
     this._stitchContent = false
     /** @type {string} */
     this._renderId = undefined
+    /** @type {string} */
+    this._variantId = undefined
 
     this._timeout = timeout
     this._targetRegion = region ? new Region(region) : undefined
@@ -110,6 +112,15 @@ class CheckSettings {
    */
   getRenderId() {
     return this._renderId
+  }
+
+  variantId(variantId) {
+    this._variantId = variantId
+    return this
+  }
+
+  getVariantId() {
+    return this._variantId
   }
 
   /**

--- a/packages/eyes-sdk-core/lib/fluent/CheckSettingsUtils.js
+++ b/packages/eyes-sdk-core/lib/fluent/CheckSettingsUtils.js
@@ -62,7 +62,7 @@ function toCheckWindowConfiguration({checkSettings, configuration}) {
       configuration.getEnablePatterns(),
     ),
     useDom: TypeUtils.getOrDefault(checkSettings.getUseDom(), configuration.getUseDom()),
-    variantId: checkSettings.getVariantId(),
+    variantId: TypeUtils.getOrDefault(checkSettings.getVariantId(), configuration.getVariantId()),
   }
 
   if (config.target === 'region') {

--- a/packages/eyes-sdk-core/lib/fluent/CheckSettingsUtils.js
+++ b/packages/eyes-sdk-core/lib/fluent/CheckSettingsUtils.js
@@ -62,6 +62,7 @@ function toCheckWindowConfiguration({checkSettings, configuration}) {
       configuration.getEnablePatterns(),
     ),
     useDom: TypeUtils.getOrDefault(checkSettings.getUseDom(), configuration.getUseDom()),
+    variantId: checkSettings.getVariantId(),
   }
 
   if (config.target === 'region') {

--- a/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
+++ b/packages/eyes-sdk-core/lib/fluent/DriverCheckSettings.js
@@ -192,6 +192,8 @@ class CheckSettings {
     this._visualGridOptions = undefined
     /** @private @type {number[]|boolean} */
     this._layoutBreakpoints = undefined
+    /** @private @type {string} */
+    this._variantId = undefined
   }
   /**
    * Create check settings from an object
@@ -297,6 +299,9 @@ class CheckSettings {
     }
     if (object.disableBrowserFetching) {
       settings.disableBrowserFetching()
+    }
+    if (object.variantId) {
+      settings.variantId(object.variantId)
     }
     return settings
   }
@@ -976,6 +981,14 @@ class CheckSettings {
   }
   getDisableBrowserFetching() {
     return this._disableBrowserFetching
+  }
+
+  variantId(variantId) {
+    this._variantId = variantId
+    return this
+  }
+  getVariantId() {
+    return this._variantId
   }
 
   /**

--- a/packages/eyes-sdk-core/lib/match/ImageMatchOptions.js
+++ b/packages/eyes-sdk-core/lib/match/ImageMatchOptions.js
@@ -32,6 +32,7 @@ class ImageMatchOptions {
     forceMatch,
     imageMatchSettings,
     source,
+    variantId,
   } = {}) {
     if (arguments.length > 1) {
       throw new TypeError('Please, use object as a parameter to the constructor!')
@@ -48,6 +49,7 @@ class ImageMatchOptions {
     this._forceMatch = forceMatch
     this._imageMatchSettings = imageMatchSettings
     this._source = source
+    this._variantId = variantId
   }
 
   /**

--- a/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
+++ b/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
@@ -33,6 +33,7 @@ const STRING_CONFIGS = [
   '_hostAppInfo',
   '_hostOSInfo',
   '_deviceInfo',
+  '_variantId',
 ]
 
 const BOOLEAN_CONFIGS = [
@@ -182,6 +183,7 @@ describe('Configuration', () => {
       configuration.setMatchLevel(MatchLevel.Layout)
       configuration.setLayoutBreakpoints(true)
       configuration.setDisableBrowserFetching(true)
+      configuration.setVariantId('variant-id')
 
       const configurationCopy = new Configuration(configuration)
 
@@ -206,6 +208,7 @@ describe('Configuration', () => {
 
       assert.strictEqual(configuration.getDisplayName(), 'test name1')
       assert.strictEqual(configurationCopy.getDisplayName(), 'test name2')
+      assert.strictEqual(configurationCopy.getVariantId(), 'variant-id')
     })
 
     it('from object', () => {

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettings.spec.js
@@ -32,6 +32,7 @@ describe('CheckSettings', () => {
       visualGridOptions: {polyfillAdoptedStyleSheets: true},
       layoutBreakpoints: true,
       disableBrowserFetching: true,
+      variantId: 'variant-id',
     }
     const checkSettings = CheckSettings.from(object)
 
@@ -57,6 +58,7 @@ describe('CheckSettings', () => {
       .visualGridOption('polyfillAdoptedStyleSheets', true)
       .layoutBreakpoints()
       .disableBrowserFetching()
+      .variantId('variant-id')
 
     assert.deepStrictEqual(checkSettings, checkSettings2)
   })

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettingsUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettingsUtils.spec.js
@@ -327,4 +327,14 @@ describe('CheckSettingsUtils', () => {
 
     assert.deepStrictEqual(checkWindowConfiguration.useDom, true)
   })
+  it('toCheckWindowConfiguration handles variantId', () => {
+    const checkSettings = new CheckSettings().variantId('variant-id')
+
+    const checkWindowConfiguration = toCheckWindowConfiguration({
+      checkSettings,
+      configuration: new Configuration(),
+    })
+
+    assert.deepStrictEqual(checkWindowConfiguration.variantId, 'variant-id')
+  })
 })

--- a/packages/eyes-sdk-core/test/unit/fluent/CheckSettingsUtils.spec.js
+++ b/packages/eyes-sdk-core/test/unit/fluent/CheckSettingsUtils.spec.js
@@ -337,4 +337,14 @@ describe('CheckSettingsUtils', () => {
 
     assert.deepStrictEqual(checkWindowConfiguration.variantId, 'variant-id')
   })
+  it('toCheckWindowConfiguration handles variantId from configuration', () => {
+    const checkSettings = new CheckSettings()
+
+    const checkWindowConfiguration = toCheckWindowConfiguration({
+      checkSettings,
+      configuration: new Configuration({variantId: 'variant-id-from-configuration'}),
+    })
+
+    assert.deepStrictEqual(checkWindowConfiguration.variantId, 'variant-id-from-configuration')
+  })
 })

--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - support `agentRunId`
+- support `variantId`
 
 ## 15.6.4 - 2021/3/22
 

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -54,6 +54,7 @@ function makeCheckWindow({
     visualGridOptions = _visualGridOptions,
     closeAfterMatch,
     throwEx = true,
+    variantId,
   }) {
     const snapshots = Array.isArray(snapshot) ? snapshot : Array(browsers.length).fill(snapshot)
 
@@ -272,6 +273,7 @@ function makeCheckWindow({
         ignoreDisplacements,
         renderId,
         matchLevel,
+        variantId,
       })
 
       logger.verbose(

--- a/packages/visual-grid-client/src/sdk/createCheckSettings.js
+++ b/packages/visual-grid-client/src/sdk/createCheckSettings.js
@@ -20,6 +20,7 @@ function createCheckSettings({
   ignoreDisplacements,
   renderId,
   matchLevel,
+  variantId,
 }) {
   const checkSettings = new CheckSettings(0)
   setEachRegion(ignore, checkSettings.ignoreRegions.bind(checkSettings))
@@ -71,6 +72,9 @@ function createCheckSettings({
   }
   if (matchLevel !== undefined) {
     checkSettings.matchLevel(matchLevel)
+  }
+  if (variantId !== undefined) {
+    checkSettings.variantId(variantId)
   }
 
   return checkSettings


### PR DESCRIPTION
This PR adds the following API:

```
configuration.getVariantId()
configuration.setVariantId(variantId)

checkSettings.variantId(variantId)
checkSettings.getVariantId()
```

When set, the value is sent in the `options` field of `MatchWindowData`.
As usual, checkSettings overrides configuration.

Generic tests:
https://github.com/applitools/sdk.coverage.tests/pull/72