### PR TITLE
Add api parameter to test object in bongo report

### DIFF
--- a/packages/sdk-coverage-tests/CHANGELOG.md
+++ b/packages/sdk-coverage-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- add `api` parameter to test object in bongo report
 
 ## 2.3.8 - 2021/2/23
 

--- a/packages/sdk-coverage-tests/src/generate/save.js
+++ b/packages/sdk-coverage-tests/src/generate/save.js
@@ -18,7 +18,13 @@ async function createTestMetaData(tests, {metaDir = '', pascalizeTests = true} =
   fs.mkdirSync(targetDirectory, {recursive: true})
 
   const meta = tests.reduce((meta, test) => {
-    const data = {isGeneric: true, name: test.group, skip: test.skip, skipEmit: test.skipEmit}
+    const data = {
+      isGeneric: true,
+      name: test.group,
+      skip: test.skip,
+      skipEmit: test.skipEmit,
+      api: test.api,
+    }
     if (test.config) {
       if (test.config.stitchMode) data.executionMode = test.config.stitchMode.toLowerCase()
       else if (test.vg) data.executionMode = 'visualgrid'

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -15,6 +15,7 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
         parameters: {
           browser: browser || 'chrome',
           mode: testMeta.executionMode,
+          api: testMeta.api,
         },
         passed: testResult && !isSkipped ? !testResult.failure : undefined,
         isGeneric: testMeta.isGeneric,

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -20,6 +20,7 @@ const metadata = {
     isGeneric: true,
     executionMode: 'css',
     name: 'test check window with css',
+    api: 'classic',
   },
   TestCheckWindow_VG: {
     isGeneric: true,
@@ -109,6 +110,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'css',
+          api: 'classic',
         },
         passed: true,
         isSkipped: false,
@@ -119,6 +121,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'visualgrid',
+          api: undefined,
         },
         passed: undefined,
         isSkipped: true,
@@ -129,6 +132,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'scroll',
+          api: undefined,
         },
         passed: undefined,
         isSkipped: true,
@@ -139,6 +143,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'bla',
+          api: undefined,
         },
         passed: undefined,
         isSkipped: true,
@@ -158,6 +163,7 @@ describe('Report', () => {
           parameters: {
             browser: 'chrome',
             mode: 'css',
+            api: 'classic',
           },
           passed: true,
           isSkipped: false,
@@ -168,6 +174,7 @@ describe('Report', () => {
           parameters: {
             browser: 'chrome',
             mode: 'visualgrid',
+            api: undefined,
           },
           passed: undefined,
           isSkipped: true,
@@ -178,6 +185,7 @@ describe('Report', () => {
           parameters: {
             browser: 'chrome',
             mode: 'scroll',
+            api: undefined,
           },
           passed: undefined,
           isSkipped: true,
@@ -188,6 +196,7 @@ describe('Report', () => {
           parameters: {
             browser: 'chrome',
             mode: 'bla',
+            api: undefined,
           },
           passed: undefined,
           isSkipped: true,
@@ -211,6 +220,7 @@ describe('Report', () => {
             parameters: {
               browser: 'chrome',
               mode: 'css',
+              api: 'classic',
             },
             passed: true,
             isSkipped: false,
@@ -221,6 +231,7 @@ describe('Report', () => {
             parameters: {
               browser: 'chrome',
               mode: 'visualgrid',
+              api: undefined,
             },
             passed: undefined,
             isSkipped: true,
@@ -231,6 +242,7 @@ describe('Report', () => {
             parameters: {
               browser: 'chrome',
               mode: 'scroll',
+              api: undefined,
             },
             passed: undefined,
             isSkipped: true,
@@ -241,6 +253,7 @@ describe('Report', () => {
             parameters: {
               browser: 'chrome',
               mode: 'bla',
+              api: undefined,
             },
             passed: undefined,
             isSkipped: true,


### PR DESCRIPTION
Currently tests with fluent vs. classic API are reported with exactly the same parameters to bongo, causing them to not be counted in the report.
This PR adds `api` entry to the metadata file, then after tests are executed it reads from the metadata file and populates it in the test object in the report.