### PR TITLE
fix(sdk-coverage-tests): fixing custom coverage tests in report

### DIFF
--- a/packages/sdk-coverage-tests/CHANGELOG.md
+++ b/packages/sdk-coverage-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- include custom tests in report
 
 ## 2.3.9 - 2021/4/1
 

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -4,11 +4,12 @@ const {logDebug} = require('../log')
 function convertJunitXmlToResultSchema({junit, browser, metadata}) {
   const tests = parseJunitXmlForTests(junit)
   logDebug(tests)
-  return Object.entries(metadata)
-    .map(([testName, testMeta]) => {
-      const testResult = tests.find(t => testName === parseBareTestName(t._attributes.name))
+  return tests
+    .map(testResults => {
+      const testName = parseBareTestName(testResults._attributes.name)
+      const testMeta = metadata[testName] || {name: testName, isGeneric: false}
       const isSkipped = testMeta.skip || testMeta.skipEmit || false // we explicitly set false to preserve backwards compatibility
-      if (!testResult && !isSkipped) return
+      if (!testMeta && !isSkipped) return
 
       return {
         test_name: testMeta.name || testName,
@@ -16,7 +17,7 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
           browser: browser || 'chrome',
           mode: testMeta.executionMode,
         },
-        passed: testResult && !isSkipped ? !testResult.failure : undefined,
+        passed: testResults && !isSkipped ? !testResults.failure : undefined,
         isGeneric: testMeta.isGeneric,
         isSkipped,
       }

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -10,9 +10,9 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
     return acc
   }, metadata)
 
-  return Object.entries(allTests).reduce((acc, [testName, testMeta]) => {
+  return Object.entries(allTests).map(([testName, testMeta]) => {
     const isSkipped = testMeta.skip || testMeta.skipEmit || false // we explicitly set false to preserve backwards compatibility
-    acc.push({
+    return {
       test_name: testMeta.name || testName,
       parameters: {
         browser: browser || 'chrome',
@@ -22,10 +22,8 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
       passed: isSkipped ? undefined : !testMeta.failure,
       isGeneric: !!testMeta.isGeneric,
       isSkipped,
-    })
-
-    return acc
-  }, [])
+    }
+  })
 }
 
 function parseBareTestName(testCaseName) {

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -6,8 +6,7 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
   logDebug(tests)
   const allTests = tests.reduce((acc, test) => {
     const name = parseBareTestName(test._attributes.name)
-    const testData = metadata[name] || {skip: Number(test._attributes.time) === 0, ...test}
-    acc[name] = testData
+    acc[name] = metadata[name] || {skip: Number(test._attributes.time) === 0, ...test}
     return acc
   }, metadata)
 
@@ -37,7 +36,7 @@ function parseBareTestName(testCaseName) {
 }
 
 function parseJunitXmlForTests(xmlResult) {
-  const jsonResult = convert.xml2js(xmlResult, {compact: true, spaces: 2})
+  const jsonResult = JSON.parse(convert.xml2json(xmlResult, {compact: true, spaces: 2}))
   if (jsonResult.hasOwnProperty('testsuites')) {
     const testsuite = jsonResult.testsuites.testsuite
     return Array.isArray(testsuite)

--- a/packages/sdk-coverage-tests/src/report/xml.js
+++ b/packages/sdk-coverage-tests/src/report/xml.js
@@ -6,7 +6,8 @@ function convertJunitXmlToResultSchema({junit, browser, metadata}) {
   logDebug(tests)
   const allTests = tests.reduce((acc, test) => {
     const name = parseBareTestName(test._attributes.name)
-    acc[name] = metadata[name] || test
+    const testData = metadata[name] || {skip: Number(test._attributes.time) === 0, ...test}
+    acc[name] = testData
     return acc
   }, metadata)
 
@@ -36,7 +37,7 @@ function parseBareTestName(testCaseName) {
 }
 
 function parseJunitXmlForTests(xmlResult) {
-  const jsonResult = JSON.parse(convert.xml2json(xmlResult, {compact: true, spaces: 2}))
+  const jsonResult = convert.xml2js(xmlResult, {compact: true, spaces: 2})
   if (jsonResult.hasOwnProperty('testsuites')) {
     const testsuite = jsonResult.testsuites.testsuite
     return Array.isArray(testsuite)

--- a/packages/sdk-coverage-tests/test/fixtures/multiple-suites-with-custom-tests.xml
+++ b/packages/sdk-coverage-tests/test/fixtures/multiple-suites-with-custom-tests.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="3" failures="1" time="40.117">
+  <testsuite name="Coverage Tests" errors="0" failures="1" skipped="0" timestamp="2020-04-13T16:50:42" time="31.828" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_VG" name="Coverage Tests TestCheckWindow_VG" time="27.808">
+    </testcase>
+  </testsuite>
+  <testsuite name="Coverage Tests" errors="0" failures="0" skipped="0" timestamp="2020-04-13T16:50:42" time="38.052" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow" name="Coverage Tests TestCheckWindow" time="34.05">
+    </testcase>
+  </testsuite>
+  <testsuite name="Coverage Tests" errors="0" failures="0" skipped="0" timestamp="2020-04-13T16:50:42" time="39.486" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_Scroll" name="Coverage Tests TestCheckWindow_Scroll" time="35.484">
+    </testcase>
+  </testsuite>
+  <testsuite name="Custom Test" errors="0" failures="0" skipped="0" timestamp="2020-04-13T16:50:42" time="39.486" tests="1">
+    <testcase classname="Coverage Tests TestCheckWindow_Scroll" name="some custom test" time="35.484">
+    <failure>DiffsFoundError: Test &apos;TestCheckWindow_VG&apos; of &apos;Eyes Selenium SDK - Classic API&apos; detected differences!. See details at: https://eyes.applitools.com/app/batches/00000251815504138512/00000251815504137477?accountId=xIpd7EWjhU6cjJzDGrMcUw~~
+    at EyesWrapper.close (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/node_modules/@applitools/eyes-sdk-core/lib/EyesBase.js:1201:19)
+    at processTicksAndRejections (internal/process/task_queues.js:94:5)
+    at /Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/visual-grid-client/src/sdk/makeClose.js:50:41
+    at async Promise.all (index 0)
+    at Object.&lt;anonymous&gt; (/Users/tourdedave/_dev/applitools/eyes.sdk.javascript1/packages/eyes-selenium/test/coverage/generic/TestCheckWindow_VG.spec.js:46:5)</failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -121,7 +121,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'css',
-          api: undefined,
+          api: 'classic',
         },
         passed: true,
         isSkipped: false,
@@ -163,7 +163,7 @@ describe('Report', () => {
           parameters: {
             browser: 'chrome',
             mode: 'css',
-            api: undefined,
+            api: 'classic',
           },
           passed: true,
           isSkipped: false,
@@ -209,7 +209,7 @@ describe('Report', () => {
             parameters: {
               browser: 'chrome',
               mode: 'css',
-              api: undefined,
+              api: 'classic',
             },
             passed: true,
             isSkipped: false,
@@ -241,6 +241,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'visualgrid',
+          api: undefined,
         },
         passed: undefined,
         isSkipped: true,
@@ -251,6 +252,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'css',
+          api: 'classic',
         },
         passed: true,
         isSkipped: false,
@@ -261,6 +263,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: 'scroll',
+          api: undefined,
         },
         passed: undefined,
         isSkipped: true,
@@ -271,6 +274,7 @@ describe('Report', () => {
         parameters: {
           browser: 'chrome',
           mode: undefined,
+          api: undefined,
         },
         passed: false,
         isSkipped: false,

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -104,18 +104,8 @@ describe('Report', () => {
     assert.deepStrictEqual(convertSdkNameToReportName('eyes-images'), 'js_images')
   })
   it('should convert xml report to QA report schema as JSON', () => {
-    assert.deepStrictEqual(convertJunitXmlToResultSchema({junit, metadata}), [
-      {
-        test_name: 'test check window with vg',
-        parameters: {
-          browser: 'chrome',
-          mode: 'visualgrid',
-          api: undefined,
-        },
-        passed: undefined,
-        isSkipped: true,
-        isGeneric: true,
-      },
+    const result = convertJunitXmlToResultSchema({junit, metadata})
+    assert.deepStrictEqual(result, [
       {
         test_name: 'test check window with css',
         parameters: {
@@ -125,6 +115,17 @@ describe('Report', () => {
         },
         passed: true,
         isSkipped: false,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test check window with vg',
+        parameters: {
+          browser: 'chrome',
+          mode: 'visualgrid',
+          api: undefined,
+        },
+        passed: undefined,
+        isSkipped: true,
         isGeneric: true,
       },
       {
@@ -138,6 +139,28 @@ describe('Report', () => {
         isSkipped: true,
         isGeneric: true,
       },
+      {
+        test_name: 'test that was not emitted',
+        parameters: {
+          browser: 'chrome',
+          mode: 'bla',
+          api: undefined,
+        },
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test that was emitted but not executed',
+        parameters: {
+          browser: 'chrome',
+          mode: 'bla',
+          api: undefined,
+        },
+        passed: true,
+        isSkipped: false,
+        isGeneric: true,
+      },
     ])
   })
 
@@ -147,17 +170,6 @@ describe('Report', () => {
       group: 'selenium',
       sandbox: false,
       results: [
-        {
-          test_name: 'test check window with vg',
-          parameters: {
-            browser: 'chrome',
-            mode: 'visualgrid',
-            api: undefined,
-          },
-          passed: undefined,
-          isSkipped: true,
-          isGeneric: true,
-        },
         {
           test_name: 'test check window with css',
           parameters: {
@@ -170,6 +182,17 @@ describe('Report', () => {
           isGeneric: true,
         },
         {
+          test_name: 'test check window with vg',
+          parameters: {
+            browser: 'chrome',
+            mode: 'visualgrid',
+            api: undefined,
+          },
+          passed: undefined,
+          isSkipped: true,
+          isGeneric: true,
+        },
+        {
           test_name: 'test check window with scroll',
           parameters: {
             browser: 'chrome',
@@ -178,6 +201,28 @@ describe('Report', () => {
           },
           passed: undefined,
           isSkipped: true,
+          isGeneric: true,
+        },
+        {
+          test_name: 'test that was not emitted',
+          parameters: {
+            browser: 'chrome',
+            mode: 'bla',
+            api: undefined,
+          },
+          passed: undefined,
+          isSkipped: true,
+          isGeneric: true,
+        },
+        {
+          test_name: 'test that was emitted but not executed',
+          parameters: {
+            browser: 'chrome',
+            mode: 'bla',
+            api: undefined,
+          },
+          passed: true,
+          isSkipped: false,
           isGeneric: true,
         },
       ],
@@ -194,17 +239,6 @@ describe('Report', () => {
         sandbox: false,
         results: [
           {
-            test_name: 'test check window with vg',
-            parameters: {
-              browser: 'chrome',
-              mode: 'visualgrid',
-              api: undefined,
-            },
-            passed: undefined,
-            isSkipped: true,
-            isGeneric: true,
-          },
-          {
             test_name: 'test check window with css',
             parameters: {
               browser: 'chrome',
@@ -213,6 +247,17 @@ describe('Report', () => {
             },
             passed: true,
             isSkipped: false,
+            isGeneric: true,
+          },
+          {
+            test_name: 'test check window with vg',
+            parameters: {
+              browser: 'chrome',
+              mode: 'visualgrid',
+              api: undefined,
+            },
+            passed: undefined,
+            isSkipped: true,
             isGeneric: true,
           },
           {
@@ -226,6 +271,28 @@ describe('Report', () => {
             isSkipped: true,
             isGeneric: true,
           },
+          {
+            test_name: 'test that was not emitted',
+            parameters: {
+              browser: 'chrome',
+              mode: 'bla',
+              api: undefined,
+            },
+            passed: undefined,
+            isSkipped: true,
+            isGeneric: true,
+          },
+          {
+            test_name: 'test that was emitted but not executed',
+            parameters: {
+              browser: 'chrome',
+              mode: 'bla',
+              api: undefined,
+            },
+            passed: true,
+            isSkipped: false,
+            isGeneric: true,
+          },
         ],
         id: '111111',
       },
@@ -234,19 +301,8 @@ describe('Report', () => {
 
   it('should create a report with custom coverage tests', () => {
     const junit = loadFixture('multiple-suites-with-custom-tests.xml')
-    const results = convertJunitXmlToResultSchema({junit, metadata})
-    assert.deepStrictEqual(results, [
-      {
-        test_name: 'test check window with vg',
-        parameters: {
-          browser: 'chrome',
-          mode: 'visualgrid',
-          api: undefined,
-        },
-        passed: undefined,
-        isSkipped: true,
-        isGeneric: true,
-      },
+    const result = convertJunitXmlToResultSchema({junit, metadata})
+    assert.deepStrictEqual(result, [
       {
         test_name: 'test check window with css',
         parameters: {
@@ -256,6 +312,17 @@ describe('Report', () => {
         },
         passed: true,
         isSkipped: false,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test check window with vg',
+        parameters: {
+          browser: 'chrome',
+          mode: 'visualgrid',
+          api: undefined,
+        },
+        passed: undefined,
+        isSkipped: true,
         isGeneric: true,
       },
       {
@@ -270,11 +337,33 @@ describe('Report', () => {
         isGeneric: true,
       },
       {
-        test_name: 'some custom test',
+        test_name: 'test that was not emitted',
         parameters: {
           browser: 'chrome',
-          mode: undefined,
+          mode: 'bla',
           api: undefined,
+        },
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test that was emitted but not executed',
+        parameters: {
+          browser: 'chrome',
+          mode: 'bla',
+          api: undefined,
+        },
+        passed: true,
+        isSkipped: false,
+        isGeneric: true,
+      },
+      {
+        test_name: 'some custom test',
+        parameters: {
+          api: undefined,
+          browser: 'chrome',
+          mode: undefined,
         },
         passed: false,
         isSkipped: false,

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -56,7 +56,6 @@ describe('Report', () => {
       const result = parseJunitXmlForTests(junit)
       assert(result[0].hasOwnProperty('_attributes'))
     })
-
     it('should support multiple suites with multiple tests at every suite', () => {
       const altXmlResult = loadFixture('multiple-suites-multiple-tests-each.xml')
       const result = parseJunitXmlForTests(altXmlResult)
@@ -72,7 +71,6 @@ describe('Report', () => {
       const result = parseJunitXmlForTests(altXmlResult)
       assert(result[0].hasOwnProperty('_attributes'))
     })
-
     it('should support a single suite with a single test', () => {
       const altXmlResult = loadFixture('single-suite-single-test.xml')
       const result = parseJunitXmlForTests(altXmlResult)
@@ -105,8 +103,7 @@ describe('Report', () => {
     assert.deepStrictEqual(convertSdkNameToReportName('eyes-images'), 'js_images')
   })
   it('should convert xml report to QA report schema as JSON', () => {
-    const results = convertJunitXmlToResultSchema({junit, metadata})
-    assert.deepStrictEqual(results, [
+    assert.deepStrictEqual(convertJunitXmlToResultSchema({junit, metadata}), [
       {
         test_name: 'test check window with vg',
         parameters: {

--- a/packages/sdk-coverage-tests/test/report.spec.js
+++ b/packages/sdk-coverage-tests/test/report.spec.js
@@ -56,6 +56,7 @@ describe('Report', () => {
       const result = parseJunitXmlForTests(junit)
       assert(result[0].hasOwnProperty('_attributes'))
     })
+
     it('should support multiple suites with multiple tests at every suite', () => {
       const altXmlResult = loadFixture('multiple-suites-multiple-tests-each.xml')
       const result = parseJunitXmlForTests(altXmlResult)
@@ -71,6 +72,7 @@ describe('Report', () => {
       const result = parseJunitXmlForTests(altXmlResult)
       assert(result[0].hasOwnProperty('_attributes'))
     })
+
     it('should support a single suite with a single test', () => {
       const altXmlResult = loadFixture('single-suite-single-test.xml')
       const result = parseJunitXmlForTests(altXmlResult)
@@ -103,17 +105,8 @@ describe('Report', () => {
     assert.deepStrictEqual(convertSdkNameToReportName('eyes-images'), 'js_images')
   })
   it('should convert xml report to QA report schema as JSON', () => {
-    assert.deepStrictEqual(convertJunitXmlToResultSchema({junit, metadata}), [
-      {
-        test_name: 'test check window with css',
-        parameters: {
-          browser: 'chrome',
-          mode: 'css',
-        },
-        passed: true,
-        isSkipped: false,
-        isGeneric: true,
-      },
+    const results = convertJunitXmlToResultSchema({junit, metadata})
+    assert.deepStrictEqual(results, [
       {
         test_name: 'test check window with vg',
         parameters: {
@@ -125,20 +118,20 @@ describe('Report', () => {
         isGeneric: true,
       },
       {
+        test_name: 'test check window with css',
+        parameters: {
+          browser: 'chrome',
+          mode: 'css',
+        },
+        passed: true,
+        isSkipped: false,
+        isGeneric: true,
+      },
+      {
         test_name: 'test check window with scroll',
         parameters: {
           browser: 'chrome',
           mode: 'scroll',
-        },
-        passed: undefined,
-        isSkipped: true,
-        isGeneric: true,
-      },
-      {
-        test_name: 'test that was not emitted',
-        parameters: {
-          browser: 'chrome',
-          mode: 'bla',
         },
         passed: undefined,
         isSkipped: true,
@@ -154,16 +147,6 @@ describe('Report', () => {
       sandbox: false,
       results: [
         {
-          test_name: 'test check window with css',
-          parameters: {
-            browser: 'chrome',
-            mode: 'css',
-          },
-          passed: true,
-          isSkipped: false,
-          isGeneric: true,
-        },
-        {
           test_name: 'test check window with vg',
           parameters: {
             browser: 'chrome',
@@ -174,20 +157,20 @@ describe('Report', () => {
           isGeneric: true,
         },
         {
+          test_name: 'test check window with css',
+          parameters: {
+            browser: 'chrome',
+            mode: 'css',
+          },
+          passed: true,
+          isSkipped: false,
+          isGeneric: true,
+        },
+        {
           test_name: 'test check window with scroll',
           parameters: {
             browser: 'chrome',
             mode: 'scroll',
-          },
-          passed: undefined,
-          isSkipped: true,
-          isGeneric: true,
-        },
-        {
-          test_name: 'test that was not emitted',
-          parameters: {
-            browser: 'chrome',
-            mode: 'bla',
           },
           passed: undefined,
           isSkipped: true,
@@ -207,16 +190,6 @@ describe('Report', () => {
         sandbox: false,
         results: [
           {
-            test_name: 'test check window with css',
-            parameters: {
-              browser: 'chrome',
-              mode: 'css',
-            },
-            passed: true,
-            isSkipped: false,
-            isGeneric: true,
-          },
-          {
             test_name: 'test check window with vg',
             parameters: {
               browser: 'chrome',
@@ -224,6 +197,16 @@ describe('Report', () => {
             },
             passed: undefined,
             isSkipped: true,
+            isGeneric: true,
+          },
+          {
+            test_name: 'test check window with css',
+            parameters: {
+              browser: 'chrome',
+              mode: 'css',
+            },
+            passed: true,
+            isSkipped: false,
             isGeneric: true,
           },
           {
@@ -236,19 +219,56 @@ describe('Report', () => {
             isSkipped: true,
             isGeneric: true,
           },
-          {
-            test_name: 'test that was not emitted',
-            parameters: {
-              browser: 'chrome',
-              mode: 'bla',
-            },
-            passed: undefined,
-            isSkipped: true,
-            isGeneric: true,
-          },
         ],
         id: '111111',
       },
     )
+  })
+
+  it('should create a report with custom coverage tests', () => {
+    const junit = loadFixture('multiple-suites-with-custom-tests.xml')
+    const results = convertJunitXmlToResultSchema({junit, metadata})
+    assert.deepStrictEqual(results, [
+      {
+        test_name: 'test check window with vg',
+        parameters: {
+          browser: 'chrome',
+          mode: 'visualgrid',
+        },
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test check window with css',
+        parameters: {
+          browser: 'chrome',
+          mode: 'css',
+        },
+        passed: true,
+        isSkipped: false,
+        isGeneric: true,
+      },
+      {
+        test_name: 'test check window with scroll',
+        parameters: {
+          browser: 'chrome',
+          mode: 'scroll',
+        },
+        passed: undefined,
+        isSkipped: true,
+        isGeneric: true,
+      },
+      {
+        test_name: 'some custom test',
+        parameters: {
+          browser: 'chrome',
+          mode: undefined,
+        },
+        passed: false,
+        isSkipped: false,
+        isGeneric: false,
+      },
+    ])
   })
 })


### PR DESCRIPTION
our coverage report was consistently missing the custom coverage tests.

the `convertJunitXmlToResultSchema` function in `sdk-coverage-tests` used to iterate over the json metadata file, which by definition does not contain any information about custom tests.

with this PR, we are running on *all* test results in the xml file - mapping any generic test to it's own object as before, but this time, including the custom coverage tests as well.


