### PR TITLE
fix(eyes-cypress): remove need for `experimentalRunEvents` flag in later cypress versions

### DIFF
--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- remove the need for `experimentalRunEvents` in cypress >= `6.7.0`
 
 ## 3.21.0 - 2021/4/22
 
@@ -9,7 +10,7 @@
 - updated to @applitools/visual-grid-client@15.8.0 (from 15.6.2)
 
 ## 3.20.4 - 2021/3/17
-
+s
 - set explicit timeout for eyesCheckWindow [trello](https://trello.com/c/5Thz1QFs)
 - updated to @applitools/dom-snapshot@4.4.14 (from 4.4.13)
 - updated to @applitools/visual-grid-client@15.6.2 (from 15.6.0)

--- a/packages/eyes-cypress/package.json
+++ b/packages/eyes-cypress/package.json
@@ -8,9 +8,9 @@
   },
   "scripts": {
     "render": "run(){ npx cypress run --config integrationFolder=test/fixtures/testApp/cypress/render,pluginsFile=test/fixtures/testApp/cypress/plugins/index-render.js,supportFile=test/fixtures/testApp/cypress/support/index-run.js --env url=$1; }; run",
-    "test:unit": "FORCE_COLOR=2 mocha --no-timeouts 'test/unit/**/*.test.js'",
+    "test:unit": "mocha --no-timeouts 'test/unit/**/*.test.js'",
     "test:it": "mocha --no-timeouts 'test/it/**/*.test.js'",
-    "test:e2e": "TERM=xterm mocha --no-timeouts 'test/e2e/**/*.test.js'",
+    "test:e2e": "mocha --no-timeouts 'test/e2e/**/*.test.js'",
     "lint": "eslint '**/*.js'",
     "test": "yarn test:unit && yarn test:it && yarn test:e2e && yarn lint",
     "cypress": "cd test/fixtures/testApp && cypress open --config integrationFolder=cypress/integration-play,pluginsFile=cypress/plugins/index-play.js,supportFile=cypress/support/index-play.js",

--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -10,6 +10,7 @@ const makeSend = require('./makeSend');
 const send = makeSend(Cypress.config('eyesPort'), window.fetch);
 const makeSendRequest = require('./sendRequest');
 const sendRequest = makeSendRequest(send);
+const shouldSetGlobalHooks = require('../plugin/shouldSetGlobalHooks');
 
 const eyesCheckWindow = makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions});
 
@@ -18,10 +19,7 @@ function getGlobalConfigProperty(prop) {
   const shouldParse = ['eyesBrowser', 'eyesLayoutBreakpoints'];
   return property ? (shouldParse.includes(prop) ? JSON.parse(property) : property) : undefined;
 }
-if (
-  !getGlobalConfigProperty('eyesIsDisabled') &&
-  (getGlobalConfigProperty('eyesLegacyHooks') || getGlobalConfigProperty('isInteractive'))
-) {
+if (!getGlobalConfigProperty('eyesIsDisabled') && !shouldSetGlobalHooks(Cypress.config())) {
   const batchEnd = poll(() => {
     return sendRequest({command: 'batchEnd'});
   });

--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -10,7 +10,6 @@ const makeSend = require('./makeSend');
 const send = makeSend(Cypress.config('eyesPort'), window.fetch);
 const makeSendRequest = require('./sendRequest');
 const sendRequest = makeSendRequest(send);
-const shouldSetGlobalHooks = require('../plugin/shouldSetGlobalHooks');
 
 const eyesCheckWindow = makeEyesCheckWindow({sendRequest, processPage, domSnapshotOptions});
 
@@ -19,7 +18,7 @@ function getGlobalConfigProperty(prop) {
   const shouldParse = ['eyesBrowser', 'eyesLayoutBreakpoints'];
   return property ? (shouldParse.includes(prop) ? JSON.parse(property) : property) : undefined;
 }
-if (!getGlobalConfigProperty('eyesIsDisabled') && !shouldSetGlobalHooks(Cypress.config())) {
+if (!getGlobalConfigProperty('eyesIsDisabled') && getGlobalConfigProperty('eyesLegacyHooks')) {
   const batchEnd = poll(() => {
     return sendRequest({command: 'batchEnd'});
   });

--- a/packages/eyes-cypress/src/plugin/config.js
+++ b/packages/eyes-cypress/src/plugin/config.js
@@ -37,7 +37,7 @@ function makeConfig() {
     eyesFailCypressOnDiff:
       config.failCypressOnDiff === undefined ? true : !!config.failCypressOnDiff,
     eyesDisableBrowserFetching: !!config.disableBrowserFetching,
-    eyesLegacyHooks: !!config.eyesLegacyHooks,
+    eyesLegacyHooks: config.eyesLegacyHooks === undefined ? true : !!config.eyesLegacyHooks,
     eyesTestConcurrency: config.testConcurrency || DEFAULT_TEST_CONCURRENCY,
   };
 

--- a/packages/eyes-cypress/src/plugin/config.js
+++ b/packages/eyes-cypress/src/plugin/config.js
@@ -37,7 +37,7 @@ function makeConfig() {
     eyesFailCypressOnDiff:
       config.failCypressOnDiff === undefined ? true : !!config.failCypressOnDiff,
     eyesDisableBrowserFetching: !!config.disableBrowserFetching,
-    eyesLegacyHooks: config.eyesLegacyHooks === undefined ? true : !!config.eyesLegacyHooks,
+    eyesLegacyHooks: true,
     eyesTestConcurrency: config.testConcurrency || DEFAULT_TEST_CONCURRENCY,
   };
 

--- a/packages/eyes-cypress/src/plugin/config.js
+++ b/packages/eyes-cypress/src/plugin/config.js
@@ -37,7 +37,7 @@ function makeConfig() {
     eyesFailCypressOnDiff:
       config.failCypressOnDiff === undefined ? true : !!config.failCypressOnDiff,
     eyesDisableBrowserFetching: !!config.disableBrowserFetching,
-    eyesLegacyHooks: true,
+    eyesLegacyHooks: !!config.eyesLegacyHooks,
     eyesTestConcurrency: config.testConcurrency || DEFAULT_TEST_CONCURRENCY,
   };
 

--- a/packages/eyes-cypress/src/plugin/hooks.js
+++ b/packages/eyes-cypress/src/plugin/hooks.js
@@ -6,11 +6,15 @@ const processCloseAndAbort = require('./processCloseAndAbort');
 const errorDigest = require('./errorDigest');
 const {tests} = require('./runningTests');
 
-function setGlobalRunHooks(on, {visualGridClient, logger}) {
+function setGlobalRunHooks(on, {visualGridClient, logger, eyesConfig}) {
   let waitForBatch;
 
   on('before:run', ({config}) => {
     const {isTextTerminal, eyesTestConcurrency: testConcurrency} = config;
+    // ugly but neccessary here - as this is the only place that cypress exposes the run mode on config
+    if (!isTextTerminal) return;
+    eyesConfig.eyesLegacyHooks = false;
+
     waitForBatch = makeWaitForBatch({
       logger: (logger.extend && logger.extend('waitForBatch')) || console,
       testConcurrency,
@@ -23,6 +27,8 @@ function setGlobalRunHooks(on, {visualGridClient, logger}) {
   });
 
   on('after:run', async ({config}) => {
+    if (!config.isTextTerminal) return;
+
     try {
       // we rely on the fact that `runningTests.reset()` wasn't called
       // so that tests that were added in `open` are available here (through `tests` in `runningTests.js`)

--- a/packages/eyes-cypress/src/plugin/pluginExport.js
+++ b/packages/eyes-cypress/src/plugin/pluginExport.js
@@ -1,6 +1,7 @@
 'use strict';
 const setGlobalRunHooks = require('./hooks');
 const CYPRESS_SUPPORTED_VERSION = '6.2.0';
+const CYPRESS_NO_FLAG_VERSION = '6.7.0';
 
 function makePluginExport({startServer, eyesConfig, visualGridClient, logger}) {
   return function pluginExport(pluginModule) {
@@ -12,7 +13,10 @@ function makePluginExport({startServer, eyesConfig, visualGridClient, logger}) {
       const moduleExportsResult = await pluginModuleExports(...args);
       const [on, config] = args;
 
-      if (config.version >= CYPRESS_SUPPORTED_VERSION && config.experimentalRunEvents) {
+      if (
+        config.version >= CYPRESS_NO_FLAG_VERSION ||
+        (config.version >= CYPRESS_SUPPORTED_VERSION && config.experimentalRunEvents)
+      ) {
         setGlobalRunHooks(on, {visualGridClient, logger});
         eyesConfig.eyesLegacyHooks = false;
       }

--- a/packages/eyes-cypress/src/plugin/pluginExport.js
+++ b/packages/eyes-cypress/src/plugin/pluginExport.js
@@ -1,7 +1,6 @@
 'use strict';
 const setGlobalRunHooks = require('./hooks');
-const CYPRESS_SUPPORTED_VERSION = '6.2.0';
-const CYPRESS_NO_FLAG_VERSION = '6.7.0';
+const shouldSetGlobalHooks = require('./shouldSetGlobalHooks');
 
 function makePluginExport({startServer, eyesConfig, visualGridClient, logger}) {
   return function pluginExport(pluginModule) {
@@ -13,10 +12,7 @@ function makePluginExport({startServer, eyesConfig, visualGridClient, logger}) {
       const moduleExportsResult = await pluginModuleExports(...args);
       const [on, config] = args;
 
-      if (
-        config.version >= CYPRESS_NO_FLAG_VERSION ||
-        (config.version >= CYPRESS_SUPPORTED_VERSION && config.experimentalRunEvents)
-      ) {
+      if (shouldSetGlobalHooks({...config, ...eyesConfig})) {
         setGlobalRunHooks(on, {visualGridClient, logger});
         eyesConfig.eyesLegacyHooks = false;
       }

--- a/packages/eyes-cypress/src/plugin/pluginExport.js
+++ b/packages/eyes-cypress/src/plugin/pluginExport.js
@@ -13,8 +13,7 @@ function makePluginExport({startServer, eyesConfig, visualGridClient, logger}) {
       const [on, config] = args;
 
       if (shouldSetGlobalHooks({...config, ...eyesConfig})) {
-        setGlobalRunHooks(on, {visualGridClient, logger});
-        eyesConfig.eyesLegacyHooks = false;
+        setGlobalRunHooks(on, {visualGridClient, logger, eyesConfig});
       }
 
       return Object.assign({}, eyesConfig, {eyesPort}, moduleExportsResult);

--- a/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
+++ b/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
@@ -1,0 +1,14 @@
+const CYPRESS_SUPPORTED_VERSION = '6.2.0';
+const CYPRESS_NO_FLAG_VERSION = '6.7.0';
+
+function setGlobalHooks(config) {
+  const {version, experimentalRunEvents, eyesLegacyHooks} = config;
+
+  return (
+    version >= CYPRESS_NO_FLAG_VERSION ||
+    (version >= CYPRESS_SUPPORTED_VERSION && experimentalRunEvents) ||
+    eyesLegacyHooks
+  );
+}
+
+module.exports = setGlobalHooks;

--- a/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
+++ b/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
@@ -2,15 +2,15 @@ const CYPRESS_SUPPORTED_VERSION = '6.2.0';
 const CYPRESS_NO_FLAG_VERSION = '6.7.0';
 
 function shouldSetGlobalHooks(config) {
-  const {version, experimentalRunEvents, eyesLegacyHooks, isInteractive} = config;
+  const {version, experimentalRunEvents, isInteractive} = config;
 
-  if (eyesLegacyHooks) {
+  if (isInteractive) {
     return false;
   }
 
   return (
     version >= CYPRESS_NO_FLAG_VERSION ||
-    (version >= CYPRESS_SUPPORTED_VERSION && !!experimentalRunEvents && !isInteractive)
+    (version >= CYPRESS_SUPPORTED_VERSION && !!experimentalRunEvents)
   );
 }
 

--- a/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
+++ b/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
@@ -2,11 +2,7 @@ const CYPRESS_SUPPORTED_VERSION = '6.2.0';
 const CYPRESS_NO_FLAG_VERSION = '6.7.0';
 
 function shouldSetGlobalHooks(config) {
-  const {version, experimentalRunEvents, isInteractive} = config;
-
-  if (isInteractive) {
-    return false;
-  }
+  const {version, experimentalRunEvents} = config;
 
   return (
     version >= CYPRESS_NO_FLAG_VERSION ||

--- a/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
+++ b/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
@@ -2,7 +2,7 @@ const CYPRESS_SUPPORTED_VERSION = '6.2.0';
 const CYPRESS_NO_FLAG_VERSION = '6.7.0';
 
 function shouldSetGlobalHooks(config) {
-  const {version, experimentalRunEvents, eyesLegacyHooks} = config;
+  const {version, experimentalRunEvents, eyesLegacyHooks, isInteractive} = config;
 
   if (eyesLegacyHooks) {
     return false;
@@ -10,7 +10,7 @@ function shouldSetGlobalHooks(config) {
 
   return (
     version >= CYPRESS_NO_FLAG_VERSION ||
-    (version >= CYPRESS_SUPPORTED_VERSION && experimentalRunEvents)
+    (version >= CYPRESS_SUPPORTED_VERSION && !!experimentalRunEvents && !isInteractive)
   );
 }
 

--- a/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
+++ b/packages/eyes-cypress/src/plugin/shouldSetGlobalHooks.js
@@ -1,14 +1,17 @@
 const CYPRESS_SUPPORTED_VERSION = '6.2.0';
 const CYPRESS_NO_FLAG_VERSION = '6.7.0';
 
-function setGlobalHooks(config) {
+function shouldSetGlobalHooks(config) {
   const {version, experimentalRunEvents, eyesLegacyHooks} = config;
+
+  if (eyesLegacyHooks) {
+    return false;
+  }
 
   return (
     version >= CYPRESS_NO_FLAG_VERSION ||
-    (version >= CYPRESS_SUPPORTED_VERSION && experimentalRunEvents) ||
-    eyesLegacyHooks
+    (version >= CYPRESS_SUPPORTED_VERSION && experimentalRunEvents)
   );
 }
 
-module.exports = setGlobalHooks;
+module.exports = shouldSetGlobalHooks;

--- a/packages/eyes-cypress/test/e2e/cypress-run-global-hooks.js
+++ b/packages/eyes-cypress/test/e2e/cypress-run-global-hooks.js
@@ -57,4 +57,21 @@ describe('global hooks', () => {
       throw ex;
     }
   });
+
+  it('works with cypress 6.7.0 or greater without flag', async () => {
+    try {
+      await pexec(`npm install cypress@latest`, {
+        maxBuffer: 1000000,
+      });
+      await pexec(
+        './node_modules/.bin/cypress run --headless --config testFiles=simple.js,integrationFolder=cypress/integration-run,pluginsFile=cypress/plugins/index-run.js,supportFile=cypress/support/index-run.js',
+        {
+          maxBuffer: 10000000,
+        },
+      );
+    } catch (ex) {
+      console.error('Error during test!', ex.stdout);
+      throw ex;
+    }
+  });
 });

--- a/packages/eyes-cypress/test/fixtures/testApp/package.json
+++ b/packages/eyes-cypress/test/fixtures/testApp/package.json
@@ -12,7 +12,7 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "cypress": "latest"
+    "cypress": "6.5.0"
   },
   "dependencies": {}
 }

--- a/packages/eyes-cypress/test/it/plugin/pluginExport.test.js
+++ b/packages/eyes-cypress/test/it/plugin/pluginExport.test.js
@@ -63,7 +63,7 @@ describe('pluginExport', () => {
       eyesDisableBrowserFetching: false,
       eyesLayoutBreakpoints: undefined,
       eyesFailCypressOnDiff: true,
-      eyesLegacyHooks: false,
+      eyesLegacyHooks: true,
       eyesIsDisabled: false,
       eyesBrowser: undefined,
       eyesTestConcurrency: 5,

--- a/packages/eyes-cypress/test/it/plugin/pluginExport.test.js
+++ b/packages/eyes-cypress/test/it/plugin/pluginExport.test.js
@@ -63,7 +63,7 @@ describe('pluginExport', () => {
       eyesDisableBrowserFetching: false,
       eyesLayoutBreakpoints: undefined,
       eyesFailCypressOnDiff: true,
-      eyesLegacyHooks: true,
+      eyesLegacyHooks: false,
       eyesIsDisabled: false,
       eyesBrowser: undefined,
       eyesTestConcurrency: 5,

--- a/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/errorDigest.test.js
@@ -1,7 +1,5 @@
 'use strict';
 const {describe, it} = require('mocha');
-const {expect} = require('chai');
-const chalk = require('chalk');
 const errorDigest = require('../../../src/plugin/errorDigest');
 const {TestResults} = require('@applitools/visual-grid-client');
 const snap = require('@applitools/snaptdout');

--- a/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
@@ -12,6 +12,16 @@ describe('shouldSetGlobalHooks', () => {
     expect(shouldSetGlobalHooks({version: '6.2.0', experimentalRunEvents: true})).to.be.true;
   });
 
+  it('should return false if no experimentalRunEvents flag is set', () => {
+    expect(shouldSetGlobalHooks({version: '6.2.0'})).to.be.false;
+  });
+
+  it('should return false if version > 6.2.0 but in interactive mode', () => {
+    expect(
+      shouldSetGlobalHooks({version: '6.2.0', experimentalRunEvents: true, isInteractive: true}),
+    ).to.be.false;
+  });
+
   it('should return true if version > 6.7.0', () => {
     expect(shouldSetGlobalHooks({version: '6.7.0'})).to.be.true;
   });

--- a/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
@@ -1,0 +1,22 @@
+'use strict';
+const {describe, it} = require('mocha');
+const {expect} = require('chai');
+const shouldSetGlobalHooks = require('../../../src/plugin/shouldSetGlobalHooks');
+
+describe('shouldSetGlobalHooks', () => {
+  it('should return false if eyesLegacyHooks flag is set', () => {
+    expect(shouldSetGlobalHooks({eyesLegacyHooks: true})).to.be.false;
+  });
+
+  it('should return true if version > 6.2.0 and experimentalRunEvents flag is set', () => {
+    expect(shouldSetGlobalHooks({version: '6.2.0', experimentalRunEvents: true})).to.be.true;
+  });
+
+  it('should return true if version > 6.7.0', () => {
+    expect(shouldSetGlobalHooks({version: '6.7.0'})).to.be.true;
+  });
+
+  it('should return false even if version > 6.7.0 but using eyesLegacyHooks', () => {
+    expect(shouldSetGlobalHooks({version: '6.7.0', eyesLegacyHooks: true})).to.be.false;
+  });
+});

--- a/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/shouldSetGlobalHooks.test.js
@@ -8,7 +8,7 @@ describe('shouldSetGlobalHooks', () => {
     expect(shouldSetGlobalHooks({eyesLegacyHooks: true})).to.be.false;
   });
 
-  it('should return true if version > 6.2.0 and experimentalRunEvents flag is set', () => {
+  it('should return true if version >= 6.2.0 and experimentalRunEvents flag is set', () => {
     expect(shouldSetGlobalHooks({version: '6.2.0', experimentalRunEvents: true})).to.be.true;
   });
 
@@ -16,17 +16,17 @@ describe('shouldSetGlobalHooks', () => {
     expect(shouldSetGlobalHooks({version: '6.2.0'})).to.be.false;
   });
 
-  it('should return false if version > 6.2.0 but in interactive mode', () => {
+  it('should return false if version >= 6.2.0 but in interactive mode', () => {
     expect(
       shouldSetGlobalHooks({version: '6.2.0', experimentalRunEvents: true, isInteractive: true}),
     ).to.be.false;
   });
 
-  it('should return true if version > 6.7.0', () => {
+  it('should return true if version >= 6.7.0', () => {
     expect(shouldSetGlobalHooks({version: '6.7.0'})).to.be.true;
   });
 
-  it('should return false even if version > 6.7.0 but using eyesLegacyHooks', () => {
-    expect(shouldSetGlobalHooks({version: '6.7.0', eyesLegacyHooks: true})).to.be.false;
+  it('should return false even if version >= 6.7.0 but in interactive mode', () => {
+    expect(shouldSetGlobalHooks({version: '6.7.0', isInteractive: true})).to.be.false;
   });
 });


### PR DESCRIPTION
[trello](https://trello.com/c/2tluhwWN)

in #384 we provided a way to use cypress' global hooks which was introduced in version `6.2.0` using a flag - `experimentalRunEvents`.

this PR addresses the fact that this flag is no longer needed in cypress >= `6.7.0`

### conditions table
| version        | mode/flag           | hooks  |
| ------------- |:-------------:| -----:|
| `>=6.2.0`      | `experimentalRunEvents` flag | global |
| `>=6.7.0`      | run mode      |   global |
| any                | interactive mode   | non-global
