### PR TITLE
Fix bug in image cropping

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+fixed image cropping algorithm to not copy data into a heap
 
 ## 12.17.2 - 2021/4/6
 

--- a/packages/screenshoter/CHANGELOG.md
+++ b/packages/screenshoter/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+fixed image cropping algorithm to not copy data into a heap
+optimized image rotation and image copping algorithms
 
  ## 3.0.5 - 2021/2/18
 

--- a/packages/screenshoter/test/it/image.spec.js
+++ b/packages/screenshoter/test/it/image.spec.js
@@ -28,6 +28,14 @@ describe('image', () => {
     assert.ok(pixelmatch(actual.data, expected.data, null, expected.width, expected.height) === 0)
   })
 
+  it('should crop a big image without heap overflow', async () => {
+    const actual = await makeImage({width: 1000, height: 50000})
+      .crop({x: 0, y: 0, width: 1000, height: 49500})
+      .then(image => image.toObject())
+    assert.strictEqual(actual.width, 1000)
+    assert.strictEqual(actual.height, 49500)
+  })
+
   it('should scale', async () => {
     const actual = await makeImage('./test/fixtures/image/house.png')
       .scale(0.5)
@@ -44,6 +52,14 @@ describe('image', () => {
     assert.ok(pixelmatch(actual.data, expected.data, null, expected.width, expected.height) === 0)
   })
 
+  it('should rotate a big image without heap overflow', async () => {
+    const actual = await makeImage({width: 1000, height: 50000})
+      .rotate(270)
+      .then(image => image.toObject())
+    assert.strictEqual(actual.width, 50000)
+    assert.strictEqual(actual.height, 1000)
+  })
+
   it('should copy one image to another', async () => {
     const image = await makeImage('./test/fixtures/image/house.png').toObject()
     const composition = makeImage({width: image.width, height: image.height * 2})
@@ -52,5 +68,14 @@ describe('image', () => {
     const actual = await composition.toObject()
     const expected = await makeImage('./test/fixtures/image/house.stitched.png').toObject()
     assert.ok(pixelmatch(actual.data, expected.data, null, expected.width, expected.height) === 0)
+  })
+
+  it('should copy a big image without heap overflow', async () => {
+    const source = await makeImage({width: 1000, height: 50000}).toObject()
+    const actual = await makeImage({width: 1000, height: 50000})
+      .copy(source, {x: 100, y: 500})
+      .then(image => image.toObject())
+    assert.strictEqual(actual.width, 1000)
+    assert.strictEqual(actual.height, 50000)
   })
 })


### PR DESCRIPTION
Fix bug when a cropped part of an image was constructed in the application memory and only then converted to a buffer.  [Trello](https://trello.com/c/1tpLxTYh)

I have to fix it also in screenshoter, since implementation was inherited. In screenshoter I also find out that we have suboptimal algorithms for copy and rotate operations, so I have fixed them as well. I placed a test for this fix in screenshoter, since it just was more pleasant and screenshoter is something we want to use in the future.