### PR TITLE
chore(visual-grid-client): support multiple bcs hooks

### DIFF
--- a/packages/visual-grid-client/CHANGELOG.md
+++ b/packages/visual-grid-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+- adding multiple before capture screenshot hooks support
 ## 15.8.2 - 2021/4/26
 
 - rename `variantId` to `variationGroupId`

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -169,7 +169,7 @@ function makeCheckWindow({
       }
 
       const hooks = scriptHooksToArray(scriptHooks.beforeCaptureScreenshot)
-      console.log('hooks', hooks)
+
       const renderRequest = createRenderRequest({
         url,
         browser: browsers[index],
@@ -178,7 +178,7 @@ function makeCheckWindow({
         selector,
         selectorsToFindRegionsFor,
         region,
-        scriptHooks: hooks[index],
+        scriptHooks: {beforeCaptureScreenshot: hooks[index]},
         sendDom,
         visualGridOptions,
       })

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -168,6 +168,8 @@ function makeCheckWindow({
         return
       }
 
+      const hooks = scriptHooksToArray(scriptHooks.beforeCaptureScreenshot)
+      console.log('hooks', hooks)
       const renderRequest = createRenderRequest({
         url,
         browser: browsers[index],
@@ -176,7 +178,7 @@ function makeCheckWindow({
         selector,
         selectorsToFindRegionsFor,
         region,
-        scriptHooks,
+        scriptHooks: hooks[index],
         sendDom,
         visualGridOptions,
       })
@@ -325,6 +327,22 @@ function makeCheckWindow({
       })
 
       return renderRequestTask.promise
+    }
+
+    function scriptHooksToArray(hooks) {
+      if (Array.isArray(hooks)) {
+        return hooks
+      }
+
+      if (!hooks || typeof hooks === 'string') {
+        return Array(browsers.length).fill(hooks)
+      }
+
+      return Object.keys(hooks).reduce((acc, key, index) => {
+        const {name} = browsers[index]
+        acc.push(name ? hooks[name] : hooks[key])
+        return acc
+      }, [])
     }
   }
 }

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -338,9 +338,10 @@ function makeCheckWindow({
         return Array(browsers.length).fill(hooks)
       }
 
-      return Object.keys(hooks).reduce((acc, key, index) => {
-        const {name} = browsers[index]
-        acc.push(hooks[name] || hooks[key])
+      return Object.keys(hooks).reduce((acc, _key, index) => {
+        const {name, deviceName} = browsers[index]
+        const browserName = name || deviceName
+        acc.push(hooks[browserName] || hooks['default'])
         return acc
       }, [])
     }

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -6,6 +6,7 @@ const createCheckSettings = require('./createCheckSettings')
 const isInvalidAccessibility = require('./isInvalidAccessibility')
 const calculateSelectorsToFindRegionsFor = require('./calculateSelectorsToFindRegionsFor')
 const makeWaitForTestEnd = require('./makeWaitForTestEnd')
+const chalk = require('chalk')
 
 function makeCheckWindow({
   globalState,
@@ -338,10 +339,19 @@ function makeCheckWindow({
         return Array(browsers.length).fill(hooks)
       }
 
-      return Object.keys(hooks).reduce((acc, _key, index) => {
-        const {name, deviceName} = browsers[index]
-        const browserName = name || deviceName
-        acc.push(hooks[browserName] || hooks['default'])
+      return Object.keys(hooks).reduce((acc, key, index) => {
+        const browser = browsers[index]
+        if (browser) {
+          const {name, deviceName} = browser
+          const browserName = name || deviceName
+          acc.push(hooks[browserName] || hooks['default'])
+        } else {
+          console.log(
+            chalk.yellow(
+              `${key} was provided a bcs hook but was not found in the browser configuration`,
+            ),
+          )
+        }
         return acc
       }, [])
     }

--- a/packages/visual-grid-client/src/sdk/checkWindow.js
+++ b/packages/visual-grid-client/src/sdk/checkWindow.js
@@ -340,7 +340,7 @@ function makeCheckWindow({
 
       return Object.keys(hooks).reduce((acc, key, index) => {
         const {name} = browsers[index]
-        acc.push(name ? hooks[name] : hooks[key])
+        acc.push(hooks[name] || hooks[key])
         return acc
       }, [])
     }


### PR DESCRIPTION
[trello](https://trello.com/c/JYn99gKJ)
[trello](https://trello.com/c/GMWV2GAw)

this PR introduces the ability to run a before capture screenshot hook per browser.

previously, you could only specify a single bcs hook for all browsers in the customer's configuration.

### API
before:
```javascript
{
  scriptHooks: {
    beforeCaptureScreenshot: 'script that will run before each browser render'
  }
}
```
after:
```javascript
{
  scriptHooks: {
    beforeCaptureScreenshot: { 
      chrome: 'script that will run before rendering on chrome',
      firefox: 'script that will run before rendering on firefox',
      default: 'script that will run before rendering all other browsers'
    } 
  }
}
```

