### PR TITLE
fix: adding ie11 as possible ie browser

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix ie browser name
 
 ## 3.22.1 - 2021/5/5
 

--- a/packages/eyes-storybook/src/shouldRenderIE.js
+++ b/packages/eyes-storybook/src/shouldRenderIE.js
@@ -33,7 +33,7 @@ function hasIE(config) {
 }
 
 function isIE(browser) {
-  return browser.name === BrowserType.IE_11;
+  return browser.name === BrowserType.IE_11 || browser.name === 'ie11';
 }
 
 function validateBrowsers(config) {
@@ -44,4 +44,4 @@ function validateBrowsers(config) {
   }
 }
 
-module.exports = {splitConfigsByBrowser, shouldRenderIE};
+module.exports = {splitConfigsByBrowser, shouldRenderIE, isIE};

--- a/packages/eyes-storybook/src/validateAndPopulateConfig.js
+++ b/packages/eyes-storybook/src/validateAndPopulateConfig.js
@@ -10,7 +10,7 @@ const {
   startStorybookFailMsg,
 } = require('./errMessages');
 const startStorybookServer = require('./startStorybookServer');
-const {BrowserType} = require('@applitools/eyes-sdk-core');
+const {isIE} = require('./shouldRenderIE');
 
 async function validateAndPopulateConfig({config, packagePath, logger}) {
   if (!config.apiKey) {
@@ -57,7 +57,7 @@ async function validateAndPopulateConfig({config, packagePath, logger}) {
     }
   }
 
-  if (config.fakeIE && !config.browser.find(({name}) => name === BrowserType.IE_11)) {
+  if (config.fakeIE && !config.browser.find(isIE)) {
     console.log(
       chalk.yellow(
         `\u26A0 fakeIE flag was set, but no IE browsers were found in the configuration`,

--- a/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
+++ b/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
@@ -309,7 +309,6 @@ describe('eyesStorybook', () => {
       )}/${encodeURIComponent(testResults.getId())}`;
 
       const session = await fetch(sessionUrl).then(r => r.json());
-      console.log(session.startInfo);
       expect(session.startInfo.parentBranchBaselineSavedBefore).to.match(
         /\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}:\d{2}\+\d{2}\:\d{2}/,
       );


### PR DESCRIPTION
in continuation of #421 - we used the enum from core - which has a key of `IE_11` with value of `ie`.

the visual grid knows to accept both `ie` and `ie11`.

with some customers using `ie11` - I have decided to add this support to not break existing tests.