### PR TITLE
Cypress - support variant group id

### DIFF
--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
- - add the option to sent , variationGroupId to checkSettings
+ - add the option to send , variationGroupId to checkwidnow
 
 
 ## 3.21.1 - 2021/5/12

--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ - add the option to sent , variationGroupId to checkSettings
+
 
 ## 3.21.1 - 2021/5/12
 

--- a/packages/eyes-cypress/README.md
+++ b/packages/eyes-cypress/README.md
@@ -190,6 +190,7 @@ Applitools will take screenshots and perform the visual comparisons in the backg
     - [scriptHooks](#scriptHooks)
     - [layoutBreakpoints](#layoutBreakpoints)
     - [sendDom](#sendDom)
+    - [variationGroupId](#variationGroupId)
   - [Close](#Close)
 - [Concurrency](#Concurrency)
 - [Advanced configuration](#Advanced-configuration)
@@ -420,6 +421,15 @@ cy.eyesCheckWindow({
 ```js
 cy.eyesCheckWindow({sendDom: false})
 ```
+
+##### `variationGroupId`
+
+```js
+cy.eyesCheckWindow({variationGroupId: 'Login Screen'})
+```
+
+For more information, visit our documentation page: https://applitools.com/docs/features/baseline-variations-groups.html
+
 
 ##### `useDom`
 

--- a/packages/eyes-cypress/README.md
+++ b/packages/eyes-cypress/README.md
@@ -425,7 +425,7 @@ cy.eyesCheckWindow({sendDom: false})
 ##### `variationGroupId`
 
 ```js
-cy.eyesCheckWindow({variationGroupId: 'Login Screen'})
+cy.eyesCheckWindow({variationGroupId: 'Login screen variation #1'})
 ```
 
 For more information, visit our documentation page: https://applitools.com/docs/features/baseline-variations-groups.html

--- a/packages/eyes-cypress/src/plugin/handlers.js
+++ b/packages/eyes-cypress/src/plugin/handlers.js
@@ -94,6 +94,7 @@ function makeHandlers({
       accessibility,
       matchLevel,
       visualGridOptions,
+      variationGroupId,
     }) => {
       logger.log(`[handlers] checkWindow: checkWindow=${typeof checkWindow}`);
       if (!checkWindow) {
@@ -133,6 +134,7 @@ function makeHandlers({
         accessibility,
         matchLevel,
         visualGridOptions,
+        variationGroupId,
       });
     },
 

--- a/packages/eyes-cypress/test/it/browser/eyesCheckWindow.it.test.js
+++ b/packages/eyes-cypress/test/it/browser/eyesCheckWindow.it.test.js
@@ -120,6 +120,7 @@ describe('eyesCheckWindow', () => {
     const accessibility = 'accessibility';
     const matchLevel = 'matchLevel';
     const visualGridOptions = 'visualGridOptions';
+    const variationGroupId = 'variationGroupId';
 
     await eyesCheckWindow('bla doc', {
       tag,
@@ -141,8 +142,8 @@ describe('eyesCheckWindow', () => {
       accessibility,
       matchLevel,
       visualGridOptions,
+      variationGroupId,
     });
-
     expect(sendRequestInput).to.eql({
       command: 'checkWindow',
       data: {
@@ -176,6 +177,7 @@ describe('eyesCheckWindow', () => {
         accessibility,
         matchLevel,
         visualGridOptions,
+        variationGroupId,
       },
     });
     expect(resourcesPutted).to.eql([

--- a/packages/eyes-cypress/test/it/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/it/plugin/handlers.test.js
@@ -24,7 +24,12 @@ describe('handlers', () => {
       });
 
       await handlers.open({});
-      await handlers.checkWindow({useDom: true, enablePatterns: true, ignoreDisplacements: true, variationGroupId: 'variationGroupId'});
+      await handlers.checkWindow({
+        useDom: true,
+        enablePatterns: true,
+        ignoreDisplacements: true,
+        variationGroupId: 'variationGroupId',
+      });
       expect(_args.useDom).to.be.true;
       expect(_args.enablePatterns).to.be.true;
       expect(_args.ignoreDisplacements).to.be.true;

--- a/packages/eyes-cypress/test/it/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/it/plugin/handlers.test.js
@@ -24,10 +24,11 @@ describe('handlers', () => {
       });
 
       await handlers.open({});
-      await handlers.checkWindow({useDom: true, enablePatterns: true, ignoreDisplacements: true});
+      await handlers.checkWindow({useDom: true, enablePatterns: true, ignoreDisplacements: true, variationGroupId: 'variationGroupId'});
       expect(_args.useDom).to.be.true;
       expect(_args.enablePatterns).to.be.true;
       expect(_args.ignoreDisplacements).to.be.true;
+      expect(_args.variationGroupId).be.equal('variationGroupId');
     });
   });
 

--- a/packages/eyes-cypress/test/unit/plugin/handlers.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/handlers.test.js
@@ -140,6 +140,7 @@ describe('handlers', () => {
     const accessibility = 'accessibility';
     const matchLevel = 'matchLevel';
     const visualGridOptions = 'visualGridOptions';
+    const variationGroupId = 'variationGroupId';
     const resourceContents = {};
 
     const result = await handlers.checkWindow({
@@ -165,6 +166,7 @@ describe('handlers', () => {
       accessibility,
       matchLevel,
       visualGridOptions,
+      variationGroupId,
     });
 
     expect(result).to.eql({
@@ -193,6 +195,7 @@ describe('handlers', () => {
       accessibility,
       matchLevel,
       visualGridOptions,
+      variationGroupId,
       __openArgs: {
         __test: 123,
         accessibilitySettings: undefined,
@@ -346,6 +349,7 @@ describe('handlers', () => {
       accessibility: undefined,
       matchLevel: undefined,
       visualGridOptions: undefined,
+      variationGroupId: undefined,
     });
   });
 


### PR DESCRIPTION
Add the ability to pass variant group id to checkwindow.
[Trello card](https://trello.com/c/kvzABpoR/843-support-variant-id-and-agentrunid)