### PR TITLE
fix(eyes-sdk-core): browser info

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix browser configuration for emulated device with `name` property
 
 ## 12.20.0 - 2021/5/24
 

--- a/packages/eyes-sdk-core/lib/utils/getBrowserInfo.js
+++ b/packages/eyes-sdk-core/lib/utils/getBrowserInfo.js
@@ -3,7 +3,8 @@
 const TypeUtils = require('./TypeUtils')
 
 async function getBrowserInfo({browser, getEmulatedDevicesSizes, getIosDevicesSizes}) {
-  const isMobile = browser.deviceName || browser.mobile
+  const isMobile =
+    browser.deviceName || browser.mobile || browser.iosDeviceInfo || browser.chromeEmulationInfo
   if (!isMobile) {
     const {name, width, height} = browser
     return {name, width, height}

--- a/packages/eyes-sdk-core/lib/utils/getBrowserInfo.js
+++ b/packages/eyes-sdk-core/lib/utils/getBrowserInfo.js
@@ -3,7 +3,8 @@
 const TypeUtils = require('./TypeUtils')
 
 async function getBrowserInfo({browser, getEmulatedDevicesSizes, getIosDevicesSizes}) {
-  if (TypeUtils.has(browser, 'name')) {
+  const isMobile = browser.deviceName || browser.mobile
+  if (!isMobile) {
     const {name, width, height} = browser
     return {name, width, height}
   } else {

--- a/packages/eyes-sdk-core/test/unit/utils/getBrowserInfo.spec.js
+++ b/packages/eyes-sdk-core/test/unit/utils/getBrowserInfo.spec.js
@@ -29,6 +29,17 @@ describe('getBrowserInfo(browser)', () => {
   })
 
   it('works with emulated device syntax', async () => {
+    const browser = {deviceName: 'emulated1', name: 'chrome', screenOrientation: 'landscape'}
+    assert.deepStrictEqual(
+      await getBrowserInfo({browser, getEmulatedDevicesSizes, getIosDevicesSizes}),
+      {
+        name: 'emulated1',
+        screenOrientation: 'landscape',
+        width: 11,
+        height: 1,
+      },
+    )
+
     const device1 = {deviceName: 'emulated1'}
     assert.deepStrictEqual(
       await getBrowserInfo({browser: device1, getEmulatedDevicesSizes, getIosDevicesSizes}),


### PR DESCRIPTION
[trello](https://trello.com/c/EX9VYn1s)

fixing a situation where customers provide the following browser configuration object:
```javascript
 {
      deviceName: 'iPhone X',
      screenOrientation: 'landscape',
      name: 'chrome' 
  }
```

we give this example in our documentation (cypress, testcafe, storybook) to illustrate that this is a chrome emulation and not an ios simulation.