### PR TITLE
docs(eyes-storybook): documenting runBefore and runAfter limitations

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- document runBefore and runAfter functions caveats
 
 ## 3.22.3 - 2021/6/1
 

--- a/packages/eyes-storybook/README.md
+++ b/packages/eyes-storybook/README.md
@@ -671,7 +671,7 @@ storiesOf('Components with ignoreDisplacements', module)
 
 The `runBefore` and `runAfter` functions serve as ways to interact with the page prior to taking the story screenshot.
 > ⚠️ Warning ⚠️   
-> the `rootEl` argument being passed to this function might be the same for several stories - this means that if your function creates side effects - it may affect other, non-related stories.
+> the `rootEl` argument being passed to these function might be the same for several stories - this means that if your function creates side effects - it may affect other, non-related stories.
 
 #### `runBefore`
 

--- a/packages/eyes-storybook/README.md
+++ b/packages/eyes-storybook/README.md
@@ -669,9 +669,10 @@ storiesOf('Components with ignoreDisplacements', module)
 
 ### `runBefore` and `runAfter` functions
 
-The `runBefore` and `runAfter` functions serve as ways to interact with the page prior to taking the story screenshot.
-> ⚠️ Warning ⚠️   
-> the `rootEl` argument being passed to these function might be the same for several stories - this means that if your function creates side effects - it may affect other, non-related stories.
+The `runBefore` function can be used to perform any action prior to taking the story snapshot. The `runAfter` method should be used to cleanup any side-effect that `runBefore` creates, if there are any.   
+For example, if `runBefore` adds a class to the `body` element, this class should be removed in `runAfter`. This is because the browser tab's window is not reloaded between stories.
+
+ _Note: `rootEl` also needs to be cleaned up, so any modification that was done on this element in `runBefore` should be reverted in `runAfter`._
 
 #### `runBefore`
 

--- a/packages/eyes-storybook/README.md
+++ b/packages/eyes-storybook/README.md
@@ -32,7 +32,7 @@ Applitools Eyes SDK for [Storybook](http://storybook.js.org).
   * [`strictRegions`](#strictregions)
   * [`accessibilityRegions`](#accessibilityregions)
   * [`accessibilityValidation`](#accessibilityvalidation)
-  * [Parameters that cannot be set as an Advanced configuration](#parameters-that-cannot-be-set-as-an--advanced-configuration---advanced-configuration)
+  * [Parameters that cannot be set as an Advanced configuration](#parameters-that-cannot-be-set-as-an-advanced-configuration)
   * [`runBefore`](#runbefore)
   * [`runAfter`](#runafter)
   * [`scriptHooks`](#scripthooks)
@@ -665,9 +665,15 @@ storiesOf('Components with ignoreDisplacements', module)
 });
 ```
 
-## Parameters that cannot be set as an [Advanced configuration](#advanced-configuration)
+## Parameters that cannot be set as an [advanced configuration](#advanced-configuration)
 
-### `runBefore`
+### `runBefore` and `runAfter` functions
+
+The `runBefore` and `runAfter` functions serve as ways to interact with the page prior to taking the story screenshot.
+> ⚠️ Warning ⚠️   
+> the `rootEl` argument being passed to this function might be the same for several stories - this means that if your function creates side effects - it may affect other, non-related stories.
+
+#### `runBefore`
 
 An asynchronous function that will be evaluated before the story's screenshot is taken. This is the place to perform any interaction with the story using DOM API's.
 
@@ -693,7 +699,7 @@ storiesOf('UI components', module)
   })
 ```
 
-### `runAfter`
+#### `runAfter`
 
 An asynchronous function that is evaluated after the story's screenshot is taken. This is the place to perform any clean ups that could change the way the next story renders.
 


### PR DESCRIPTION
[trello](https://trello.com/c/A160yfTX)

this PR adds a warning about `runBefore` and `runAfter` functions - emphasizing side-effects. 