### PR TITLE
fix(eyes-storybook): handle `.html` files in storybook url

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix storybook url `html` extensions
 
 ## 3.22.3 - 2021/6/1
 

--- a/packages/eyes-storybook/src/getIframeUrl.js
+++ b/packages/eyes-storybook/src/getIframeUrl.js
@@ -3,11 +3,15 @@ const {URL} = require('url');
 
 function getIframeUrl(baseUrl) {
   const {origin, pathname} = new URL(baseUrl);
-  let baseUrlFixed = `${origin}${pathname}`;
+
+  let baseUrlFixed = `${origin}${pathname.replace(/[^\/]+\.html/, '')}`;
+
   if (!/\/$/.test(baseUrlFixed)) {
     baseUrlFixed += '/';
   }
-  return new URL(`iframe.html?eyes-storybook=true`, baseUrlFixed).href;
+
+  const url = new URL(`iframe.html?eyes-storybook=true`, baseUrlFixed);
+  return url.href;
 }
 
 module.exports = getIframeUrl;

--- a/packages/eyes-storybook/src/getIframeUrl.js
+++ b/packages/eyes-storybook/src/getIframeUrl.js
@@ -4,7 +4,7 @@ const {URL} = require('url');
 function getIframeUrl(baseUrl) {
   const {origin, pathname} = new URL(baseUrl);
 
-  let baseUrlFixed = `${origin}${pathname.replace(/[^\/]+\.html/, '')}`;
+  let baseUrlFixed = `${origin}${pathname.replace(/\/[^\/]+\.html/, '')}`;
 
   if (!/\/$/.test(baseUrlFixed)) {
     baseUrlFixed += '/';

--- a/packages/eyes-storybook/test/unit/getIframeUrl.test.js
+++ b/packages/eyes-storybook/test/unit/getIframeUrl.test.js
@@ -34,6 +34,18 @@ describe('getIframeUrl', () => {
     expect(getIframeUrl(baseUrl)).to.equal(expected);
   });
 
+  it('removes .html files from pathname', () => {
+    const baseUrl = 'http://some/url/index.html';
+    const expected = 'http://some/url/iframe.html?eyes-storybook=true';
+    expect(getIframeUrl(baseUrl)).to.equal(expected);
+  });
+
+  it('removes .html files from pathname with query params', () => {
+    const baseUrl = 'http://some/url/index.html/?hello=world';
+    const expected = 'http://some/url/iframe.html?eyes-storybook=true';
+    expect(getIframeUrl(baseUrl)).to.equal(expected);
+  });
+
   it('throws on invalid base URL', () => {
     const baseUrl = 'bla';
     try {


### PR DESCRIPTION
[trello](https://trello.com/c/VG2St3AJ)

storybook urls may end in a `.html` file - which resulted in the `getIframeUrl` function appending `iframe.html` to the url.

so the end result would look like: `https://some-storybook.com/index.html/iframe.html?eyes-storybook=true`
