### PR TITLE
Add browser environment only once

### DIFF
--- a/packages/eyes-sdk-core/CHANGELOG.md
+++ b/packages/eyes-sdk-core/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## Unreleased
-
+ - make sure that we are not adding the same browser environment more than once when marging configs
 
 ## 12.21.3 - 2021/6/30
 

--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -1237,7 +1237,7 @@ class Configuration {
     ArgumentGuard.isArray(value, 'properties')
 
     for (const data of value) {
-      this._browsersInfo.push(data)
+      if (!this._browsersInfo.includes(data)) this._browsersInfo.push(data)
     }
     return this
   }

--- a/packages/eyes-sdk-core/lib/config/Configuration.js
+++ b/packages/eyes-sdk-core/lib/config/Configuration.js
@@ -1236,9 +1236,8 @@ class Configuration {
     }
     ArgumentGuard.isArray(value, 'properties')
 
-    for (const data of value) {
-      if (!this._browsersInfo.includes(data)) this._browsersInfo.push(data)
-    }
+    this._browsersInfo = value
+
     return this
   }
 

--- a/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
+++ b/packages/eyes-sdk-core/test/unit/config/Configuration.spec.js
@@ -15,6 +15,7 @@ const {
   SessionType,
   ProxySettings,
   PropertyData,
+  BrowserType,
 } = require('../../../index')
 
 const STRING_CONFIGS = [
@@ -249,6 +250,20 @@ describe('Configuration', () => {
 
     assert.strictEqual(configuration.getAppName(), configuration2.getAppName())
     assert.notStrictEqual(configuration.getApiKey(), configuration2.getApiKey())
+  })
+
+  it('mergeConfig, browser env added only once', () => {
+    const configuration = new Configuration()
+    configuration.setAppName('test')
+    configuration.setApiKey('apiKey')
+    configuration.addBrowser(800, 800, BrowserType.FIREFOX)
+
+    let configuration2 = configuration
+    configuration2.setBranchName('testBranch')
+
+    configuration.mergeConfig(configuration2.toJSON())
+
+    assert.strictEqual(configuration.getBrowsersInfo().length, 1)
   })
 
   it('cloneConfig', () => {


### PR DESCRIPTION
When calling `mergeConfig`, we add all the browser environments to the config regardless if the browser env is already there.  This caused unnecessary calls to `createRGridDOMAndGetResourceMapping`.
I added a check to add an environment to the configuration only if it's not already included in the `browserInfo` array.