### PR TITLE
fix(eyes-storybook): fix config split when no flag provided

### DIFF
--- a/packages/eyes-storybook/CHANGELOG.md
+++ b/packages/eyes-storybook/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix IE execution in parallel
 
 ## 3.22.6 - 2021/7/7
 

--- a/packages/eyes-storybook/src/eyesStorybook.js
+++ b/packages/eyes-storybook/src/eyesStorybook.js
@@ -143,9 +143,7 @@ async function eyesStorybook({
       pagePool,
     });
 
-    logger.log('finished creating functions');
-
-    const configs = splitConfigsByBrowser(config);
+    const configs = config.fakeIE ? splitConfigsByBrowser(config) : [config];
     const [error, results] = await presult(
       executeRenders({
         renderStories,

--- a/packages/eyes-storybook/src/eyesStorybook.js
+++ b/packages/eyes-storybook/src/eyesStorybook.js
@@ -143,6 +143,8 @@ async function eyesStorybook({
       pagePool,
     });
 
+    logger.log('finished creating functions');
+
     const configs = config.fakeIE ? splitConfigsByBrowser(config) : [config];
     const [error, results] = await presult(
       executeRenders({


### PR DESCRIPTION
while introducing the `fake IE` feature - we gave the option to opt in by using the flag `fakeIE` in the config.

unfortunately, we still split the config by browser - even if the flag wasn't provided - which creates a situation where the IE execution is separated from the rest of the browsers causing a major performance hit.