### PR TITLE
fix layout-breakpoint tests in Cypresss

### DIFF
--- a/packages/eyes-cypress/.gitignore
+++ b/packages/eyes-cypress/.gitignore
@@ -6,8 +6,6 @@ test/cypress/videos
 .applitools
 .private
 .History.md.swp
-test/fixtures/testAppCopies/*
-!test/fixtures/testAppCopies/noempty
 *.tap
 cdt.json
 .vscode

--- a/packages/eyes-cypress/CHANGELOG.md
+++ b/packages/eyes-cypress/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+ - fix layout-breakpoints should not hit cypress timeout
 
 ## 3.22.4 - 2021/9/7
 

--- a/packages/eyes-cypress/test/fixtures/breakpoints.html
+++ b/packages/eyes-cypress/test/fixtures/breakpoints.html
@@ -68,9 +68,10 @@
       <script>
         setTimeout(() => {
           var img = document.createElement('img')
+          img.id = 'smurfs-img'
           img.src = './smurfs.jpg'
           document.body.appendChild(img)
-        }, 3000) 
+        }, 1000);
       </script>
     </body>
     </html>

--- a/packages/eyes-cypress/test/fixtures/testApp/applitools.config.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/applitools.config.js
@@ -3,6 +3,7 @@ module.exports = {
   isDisabled: false,
   serverUrl2: 'eyes.applitools.com',
   serverUrl2: 'https://eyesfabric3eyes.applitools.com',
+  saveNewTests: false,
   // dontCloseBatches: true,
   // showLogs: true,
   // eyesTimeout: 1234,

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/layout-breakpoints.js
@@ -4,7 +4,7 @@ describe('JS layout', () => {
     cy.visit('https://applitools.github.io/demo/TestPages/JsLayout/');
     cy.eyesOpen({
       appName: 'JS layout',
-      testName: 'testing js layout support in cypress',
+      testName: 'should support js layouts in open',
       browser: [
         {width: 1000, height: 800},
         {iosDeviceInfo: {deviceName: 'iPad (7th generation)'}},
@@ -20,7 +20,7 @@ describe('JS layout', () => {
     cy.visit('https://applitools.github.io/demo/TestPages/JsLayout/');
     cy.eyesOpen({
       appName: 'JS layout',
-      testName: 'testing js layout support in cypress',
+      testName: 'should support js layouts in check',
       browser: [
         {name: 'chrome', width: 1000, height: 800},
         {iosDeviceInfo: {deviceName: 'iPad (7th generation)'}},
@@ -38,7 +38,7 @@ describe('JS layout', () => {
     cy.visit('https://applitools.github.io/demo/TestPages/JsLayout/');
     cy.eyesOpen({
       appName: 'JS layout',
-      testName: 'testing js layout support in cypress',
+      testName: 'should support js layouts = true',
       browser: [
         {name: 'chrome', width: 1000, height: 800},
         {iosDeviceInfo: {deviceName: 'iPad (7th generation)'}},
@@ -52,9 +52,10 @@ describe('JS layout', () => {
 
   it('should not hit the cypress default command timeout', () => {
     cy.visit('http://localhost:5555/breakpoints.html');
+    cy.get('#smurfs-img')
     cy.eyesOpen({
       appName: 'JS layout',
-      testName: 'testing js layout support in cypress',
+      testName: 'should not hit the cypress default command timeout',
       browser: [
         {name: 'chrome', width: 1000, height: 800},
         {iosDeviceInfo: {deviceName: 'iPad (7th generation)'}},

--- a/packages/eyes-cypress/test/fixtures/testAppCopies/.gitignore
+++ b/packages/eyes-cypress/test/fixtures/testAppCopies/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Fix `should not hit the cypress default command timeout` to include smurfs image to simulate slow dom snapshot and update tests names 