### PR TITLE
Improve request error output

### DIFF
--- a/packages/eyes-sdk-core/lib/server/requestHelpers.js
+++ b/packages/eyes-sdk-core/lib/server/requestHelpers.js
@@ -181,7 +181,7 @@ async function handleRequestError({err, axios, logger}) {
     throw err
   }
   const {response, config} = err
-  const reason = `${err.message}${response ? `(${response.statusText})` : ''}`
+  const reason = constructReason(err)
 
   logger.log(
     `axios error interceptor - ${config.name} [${config.requestId}] - ${
@@ -232,6 +232,15 @@ async function handleRequestError({err, axios, logger}) {
     return axios.request(config)
   }
   throw new Error(reason)
+}
+
+function constructReason(err) {
+  const {response, config} = err
+  let reason = `Error in request ${config.name}: ${err.message}`
+  if (response) {
+    reason += ` (${response.statusText})\n${response.data}`
+  }
+  return reason
 }
 
 exports.configAxiosProxy = configAxiosProxy

--- a/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
+++ b/packages/eyes-sdk-core/test/unit/close/closeBatch.spec.js
@@ -14,7 +14,7 @@ describe('closeBatches', () => {
       .query({apiKey})
       .replyWithError({message, code: 500})
     const [err] = await presult(closeBatches({batchIds: ['678'], serverUrl, apiKey}))
-    expect(err.message).to.equal(message)
+    expect(err.message).to.equal(`Error in request deleteBatchSessions: ${message}`)
   })
 
   it('should handle a single batchId deletion failure', async () => {


### PR DESCRIPTION
This PR will make the SDK present the user with the actual error message that happened on the server.
I'm not sure if the string I construct is the best one (is it really important to present the user with the request name and status code? it's more for troubleshooting...).
But one insight is that both UFG and Eyes server return a message in the body of the response, which should not be ignored.
The tests I added are also a bit controversial, since they are prone to changes on the server (e.g. if we ask the UFG to fix the 500 response to be 400, then we would need to fix the test).
Happy to get feedback on this.