### PR TITLE
fix(eyes-cypress): use `Cypress.currentTest` as a fallback to get `testName` (#710)

### DIFF
--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -53,7 +53,7 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
   Cypress.config('eyesOpenArgs', args);
   Cypress.log({name: 'Eyes: open'});
   const userAgent = navigator.userAgent;
-  const {title: testName} = this.currentTest || this.test;
+  const {title: testName} = Cypress.currentTest;
   const {browser: eyesOpenBrowser, isDisabled} = args;
   const globalBrowser = getGlobalConfigProperty('eyesBrowser');
   const defaultBrowser = {

--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -53,7 +53,7 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
   Cypress.config('eyesOpenArgs', args);
   Cypress.log({name: 'Eyes: open'});
   const userAgent = navigator.userAgent;
-  const {title: testName} = Cypress.currentTest;
+  const {title: testName} = this.currentTest || this.test || Cypress.currentTest;
   const {browser: eyesOpenBrowser, isDisabled} = args;
   const globalBrowser = getGlobalConfigProperty('eyesBrowser');
   const defaultBrowser = {


### PR DESCRIPTION
Replaces reference to `this.test` with `Cypress.currentTest` and fixes #710.