### PR TITLE
Support Storybook 6.4

### DIFF
--- a/packages/eyes-storybook/src/storybookConnector.js
+++ b/packages/eyes-storybook/src/storybookConnector.js
@@ -72,7 +72,7 @@ class StorybookConnector extends EventEmitter {
 
       const successMessageListener = str => {
         const isReady = stripAnsi(str).match(
-          /Storybook \d{1,2}\.\d{1,2}\.\d{1,2}(-.+)? started|Storybook started on =>/,
+          /Storybook \d{1,2}\.\d{1,2}\.\d{1,2}(-.+)? started|for React started|Storybook started on =>/,
         );
 
         if (isReady) {


### PR DESCRIPTION
`Storybook` changed the client API we are using. `setSelection` was removed from storybook version 6.4.0 onwards.
Also, when `Storybook` starts, it outputs a different message, so we need to update our `Regex`
[Trello card](https://trello.com/c/mMmMfPMY/1170-storybook-slack-eyes-storybook-timing-out-after-upgrading-storybook-dependency-to-640)