### PR TITLE
Adjust eyes-storybook tests to align with storybook 6.4

### DIFF
--- a/packages/eyes-storybook/test/e2e/zero-stories-retry.e2e.test.js
+++ b/packages/eyes-storybook/test/e2e/zero-stories-retry.e2e.test.js
@@ -9,7 +9,8 @@ const envWithColor = {...process.env, FORCE_COLOR: true};
 const spawnOptions = {stdio: 'pipe', env: envWithColor};
 
 describe('zero stories retry', () => {
-  it('zero stories retry', async () => {
+  //skipped as storybook removed the option to load a story after storybook starts
+  it.skip('zero stories retry', async () => {
     const [err, result] = await presult(
       utils.process.sh(
         `node ${path.resolve(__dirname, '../../bin/eyes-storybook')} -f ${path.resolve(

--- a/packages/eyes-storybook/test/e2e/zero-stories-retry.e2e.test.js
+++ b/packages/eyes-storybook/test/e2e/zero-stories-retry.e2e.test.js
@@ -10,6 +10,7 @@ const spawnOptions = {stdio: 'pipe', env: envWithColor};
 
 describe('zero stories retry', () => {
   //skipped as storybook removed the option to load a story after storybook starts
+  // going forward we would like to re-add this test by running it with Storybook version 5
   it.skip('zero stories retry', async () => {
     const [err, result] = await presult(
       utils.process.sh(

--- a/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
+++ b/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
@@ -29,8 +29,11 @@ describe('eyesStorybook', () => {
   });
 
   let serverUrl, closeEyesServer;
-  beforeEach(async () => {
-    const {port, close} = await fakeEyesServer();
+  beforeEach(async function() {
+    let fakeEyesConfig = {}
+    if(this.test.title.includes('enforces legacy concurrency'))
+      fakeEyesConfig = {delay: 500}
+    const {port, close} = await fakeEyesServer(fakeEyesConfig);
     closeEyesServer = close;
     serverUrl = `http://localhost:${port}`;
   });

--- a/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
+++ b/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
@@ -30,18 +30,18 @@ describe('eyesStorybook', () => {
 
   let serverUrl, closeEyesServer;
   beforeEach(async function() {
-    let fakeEyesConfig = {}
-    if(this.test.title.includes('enforces legacy concurrency'))
-      fakeEyesConfig = {delay: 500}
-    const {port, close} = await fakeEyesServer(fakeEyesConfig);
-    closeEyesServer = close;
-    serverUrl = `http://localhost:${port}`;
+    // const {port, close} = await fakeEyesServer(fakeEyesConfig);
+    // closeEyesServer = close;
+    // serverUrl = `http://localhost:${port}`;
   });
   afterEach(async () => {
     await closeEyesServer();
   });
 
   it('renders test storybook with fake eyes and visual grid', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream, getEvents} = testStream();
     const configPath = path.resolve(__dirname, '../fixtures/applitools.config.js');
     const globalConfig = require(configPath);
@@ -199,6 +199,9 @@ describe('eyesStorybook', () => {
   });
 
   it('enforces default concurrency', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(__dirname, '../fixtures/applitools.config.js');
     const config = generateConfig({argv: {conf: configPath}, defaultConfig, externalConfigParams});
@@ -220,6 +223,9 @@ describe('eyesStorybook', () => {
   });
 
   it('enforces testConcurrency', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(__dirname, '../fixtures/applitools.config.js');
     const config = generateConfig({argv: {conf: configPath}, defaultConfig, externalConfigParams});
@@ -242,6 +248,9 @@ describe('eyesStorybook', () => {
   });
 
   it('enforces testConcurrency over legacy concurrency', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(__dirname, '../fixtures/applitools.config.js');
     const config = generateConfig({argv: {conf: configPath}, defaultConfig, externalConfigParams});
@@ -265,6 +274,9 @@ describe('eyesStorybook', () => {
   });
 
   it('enforces legacy concurrency', async () => {
+    const {port, close} = await fakeEyesServer({renderDelay: 1000});
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(
       __dirname,
@@ -290,6 +302,9 @@ describe('eyesStorybook', () => {
 
   // This test doesn't pass in CI, probably because git is not installed or doesn't work as expected. This needs to be investigated
   it.skip('sends parentBranchBaselineSavedBefore when branchName and parentBranchName are specified, and there is a merge-base time for them', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(
       __dirname,
@@ -327,6 +342,9 @@ describe('eyesStorybook', () => {
   });
 
   it('handles ignoreGitMergeBase', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const {stream} = testStream();
     const configPath = path.resolve(
       __dirname,
@@ -359,6 +377,9 @@ describe('eyesStorybook', () => {
   });
 
   it('fail immediately, wrong api key', async () => {
+    const {port, close} = await fakeEyesServer();
+    closeEyesServer = close;
+    serverUrl = `http://localhost:${port}`;
     const config = {apiKey: 'INVALIDAPIKEY'}; // this is a well-known apiKey that is meant to return 401 from fake eyes server
     let errorMessage;
 

--- a/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
+++ b/packages/eyes-storybook/test/it/eyesStorybook.it.test.js
@@ -30,9 +30,6 @@ describe('eyesStorybook', () => {
 
   let serverUrl, closeEyesServer;
   beforeEach(async function() {
-    // const {port, close} = await fakeEyesServer(fakeEyesConfig);
-    // closeEyesServer = close;
-    // serverUrl = `http://localhost:${port}`;
   });
   afterEach(async () => {
     await closeEyesServer();

--- a/packages/eyes-storybook/test/util/fakeEyesServer.js
+++ b/packages/eyes-storybook/test/util/fakeEyesServer.js
@@ -8,7 +8,7 @@ const path = require('path');
 const filenamify = require('filenamify');
 const {TestResultsStatus} = require('@applitools/eyes-sdk-core');
 
-function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp, delay=0} = {}) {
+function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp, renderDelay=0} = {}) {
   const runningSessions = {};
   let serverUrl;
   let renderCounter = 0;
@@ -46,7 +46,7 @@ function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp, 
           };
         }),
       )
-    }, delay)
+    }, renderDelay)
   });
 
   // render status

--- a/packages/eyes-storybook/test/util/fakeEyesServer.js
+++ b/packages/eyes-storybook/test/util/fakeEyesServer.js
@@ -8,7 +8,7 @@ const path = require('path');
 const filenamify = require('filenamify');
 const {TestResultsStatus} = require('@applitools/eyes-sdk-core');
 
-function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp} = {}) {
+function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp, delay=0} = {}) {
   const runningSessions = {};
   let serverUrl;
   let renderCounter = 0;
@@ -34,17 +34,19 @@ function fakeEyesServer({expectedFolder, updateFixtures, port, hangUp: _hangUp} 
 
   // render
   app.post('/render', (req, res) => {
-    res.send(
-      req.body.map(renderRequest => {
-        const renderId = renderRequest.renderId || `r${renderCounter++}`;
-        renderings[renderId] = renderRequest;
-        return {
-          renderId,
-          renderStatus: 'rendering',
-          needMoreDom: false,
-        };
-      }),
-    );
+    setTimeout(() => {
+      res.send(
+        req.body.map(renderRequest => {
+          const renderId = renderRequest.renderId || `r${renderCounter++}`;
+          renderings[renderId] = renderRequest;
+          return {
+            renderId,
+            renderStatus: 'rendering',
+            needMoreDom: false,
+          };
+        }),
+      )
+    }, delay)
   });
 
   // render status


### PR DESCRIPTION
1) Skip zero stories test for now, as the option to load a story after storybook started was removed from storybook API
2) Add a delay option for a render request in `fakeEyesServer`