### PR TITLE
converting argTypes to visual tests

### DIFF
--- a/packages/eyes-storybook/src/addControlsStories.js
+++ b/packages/eyes-storybook/src/addControlsStories.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function addControlsStories(stories) {
+    const storiesIncludingControls = stories.reduce((stories, story) => {
+        const argTypes = story.parameters?.argTypes
+
+        const controlsKeys = Object.keys(argTypes).filter((k) => argTypes[k].visualTest);
+        
+        if (controlsKeys) {
+            let controlsStories = [];
+
+            controlsKeys.forEach((key) => {
+                argTypes[key].options.forEach((option) => {
+                    let controlStory = JSON.parse(JSON.stringify(story));
+
+                    // add validation
+                    controlStory.parameters.eyes.controls = {
+                        name: key,
+                        value: option,
+                    }
+
+                    controlsStories.push(controlStory);
+                })
+            })
+
+            return [...stories, ...controlsStories]
+
+        } else {
+            return [...stories, story];
+        }
+    }, [])
+
+    return storiesIncludingControls;
+}
+
+
+module.exports = addControlsStories;

--- a/packages/eyes-storybook/src/eyesStorybook.js
+++ b/packages/eyes-storybook/src/eyesStorybook.js
@@ -11,6 +11,7 @@ const makeGetStoryData = require('./getStoryData');
 const ora = require('ora');
 const filterStories = require('./filterStories');
 const addVariationStories = require('./addVariationStories');
+const addControlsStories = require('./addControlsStories');
 const browserLog = require('./browserLog');
 const memoryLog = require('./memoryLog');
 const getIframeUrl = require('./getIframeUrl');
@@ -121,7 +122,9 @@ async function eyesStorybook({
       config,
     });
 
-    logger.log(`starting to run ${storiesIncludingVariations.length} stories`);
+    const storiesIncludingControls = addControlsStories(storiesIncludingVariations)
+
+    logger.log(`starting to run ${storiesIncludingControls.length} stories`);
 
     const getStoryData = makeGetStoryData({
       logger,
@@ -158,7 +161,7 @@ async function eyesStorybook({
         setRenderIE,
         setTransitioningIntoIE,
         configs,
-        stories: storiesIncludingVariations,
+        stories: storiesIncludingControls,
         pagePool,
         logger,
         timeItAsync,

--- a/packages/eyes-storybook/src/getStoryTitle.js
+++ b/packages/eyes-storybook/src/getStoryTitle.js
@@ -3,8 +3,9 @@
 function getStoryTitle({name, kind, parameters}) {
   const queryParams = (parameters && parameters.eyes && parameters.eyes.queryParams) || {};
   const eyesVariation = queryParams['eyes-variation'];
+  const controls = parameters?.eyes?.controls;
 
-  return `${kind}: ${name}${eyesVariation ? ` [${eyesVariation}]` : ''}`;
+  return `${kind}: ${name}${eyesVariation ? ` [${eyesVariation}]` : ''}${controls ? `[${controls.name}:${controls.value}]` : ''}`;
 }
 
 module.exports = getStoryTitle;

--- a/packages/eyes-storybook/src/getStoryUrl.js
+++ b/packages/eyes-storybook/src/getStoryUrl.js
@@ -14,6 +14,11 @@ function getStoryUrl({name, kind, parameters}, baseUrl) {
     }
   }
 
+  const controls = parameters?.eyes.controls;
+  if (controls) {
+    storyUrl += `&args=${controls.name}:${controls.value}`
+  }
+
   return storyUrl;
 }
 


### PR DESCRIPTION
In order to see this in action:
1. Create argType with options (e.g. radio buttons)
2. To the story's argType add `visualTest: true`
3. To your story add: `
    parameters: {
        eyes: {
            variations: [
                { queryParams: {} },
            ]
        }
    }
    `
(this won't be necessary in the very near future)