### PR TITLE
Fix ServerConnector logs

### DIFF
--- a/packages/eyes-sdk-core/lib/sdk/EyesBase.js
+++ b/packages/eyes-sdk-core/lib/sdk/EyesBase.js
@@ -127,6 +127,7 @@ class EyesBase {
 
   set logger(logger) {
     this._logger = logger
+    this._serverConnector._logger = logger
   }
 
   /**


### PR DESCRIPTION
We have a bug today that important logs from ServerConnector are not written when setting a console logger programmatically. Those logs **do** work when setting the env var `APPLITOOLS_SHOW_LOGS=true`.

So for example `manager.openEyes({driver, config: {logs: {type: 'console'}}})` doesn't log axios interceptors. And neither does:
```
eyes.setLogHandler(new ConsoleLogHandler(true))
```

The fix is one line, and is applied from the call in https://github.com/applitools/eyes.sdk.javascript1/blob/de3cef079ffa58bbcc8922ebba4a55c5994c539f/packages/eyes-sdk-core/lib/new/open-eyes.js#L18