### PR TITLE
make sure to check batchId property in global hooks when closing batch

### DIFF
--- a/packages/eyes-cypress/src/browser/commands.js
+++ b/packages/eyes-cypress/src/browser/commands.js
@@ -97,6 +97,7 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
   Cypress.log({name: 'Eyes: open'});
   Cypress.config('eyesOpenArgs', args);
   const {title: testName} = this.currentTest || this.test || Cypress.currentTest;
+  const batchIdEyesOpen = args.batchId || (args.batch && args.batch.id);
 
   if (Cypress.config('eyesIsDisabled') && args.isDisabled === false) {
     throw new Error(
@@ -130,6 +131,12 @@ Cypress.Commands.add('eyesOpen', function(args = {}) {
             {legacy: false, type: 'vg'},
           ),
         ));
+    }
+
+    if (batchIdEyesOpen && !shouldUseBrowserHooks) {
+      await socket.request('Test.saveBatchId', {batchIdEyesOpen}).catch(err => {
+        console.log('Error in cy.eyesOpen, saveBatchId', err);
+      });
     }
 
     const appliConfFile = Cypress.config('appliConfFile');

--- a/packages/eyes-cypress/src/plugin/hooks.js
+++ b/packages/eyes-cypress/src/plugin/hooks.js
@@ -26,7 +26,7 @@ function makeGlobalRunHooks({closeManager, closeBatches, closeUniversalServer}) 
         }
         if (!config.appliConfFile.dontCloseBatches) {
           await closeBatches({
-            batchIds: [config.appliConfFile.batch.id],
+            batchIds: [config.appliConfFile.batchId || config.appliConfFile.batch.id],
             serverUrl: config.appliConfFile.serverUrl,
             proxy: config.appliConfFile.proxy,
             apiKey: config.appliConfFile.apiKey,

--- a/packages/eyes-cypress/src/plugin/hooks.js
+++ b/packages/eyes-cypress/src/plugin/hooks.js
@@ -2,7 +2,7 @@
 const {TestResults} = require('@applitools/visual-grid-client');
 const handleTestResults = require('./handleTestResults');
 
-function makeGlobalRunHooks({closeManager, closeBatches, closeUniversalServer}) {
+function makeGlobalRunHooks({closeManager, closeBatches, closeUniversalServer, getAllBatchIds}) {
   return {
     'before:run': ({config}) => {
       if (!config.isTextTerminal) return;
@@ -25,8 +25,11 @@ function makeGlobalRunHooks({closeManager, closeBatches, closeUniversalServer}) 
           }
         }
         if (!config.appliConfFile.dontCloseBatches) {
+          const batchIdsFromEyesOpen = getAllBatchIds();
           await closeBatches({
-            batchIds: [config.appliConfFile.batchId || config.appliConfFile.batch.id],
+            batchIds: [config.appliConfFile.batchId || config.appliConfFile.batch.id].concat(
+              batchIdsFromEyesOpen,
+            ),
             serverUrl: config.appliConfFile.serverUrl,
             proxy: config.appliConfFile.proxy,
             apiKey: config.appliConfFile.apiKey,

--- a/packages/eyes-cypress/src/plugin/pluginExport.js
+++ b/packages/eyes-cypress/src/plugin/pluginExport.js
@@ -8,10 +8,22 @@ function makePluginExport({startServer, eyesConfig}) {
     let eyesServer;
     const pluginModuleExports = pluginModule.exports;
     pluginModule.exports = async function(...args) {
-      const {server, port, closeManager, closeBatches, closeUniversalServer} = await startServer();
+      const {
+        server,
+        port,
+        closeManager,
+        closeBatches,
+        closeUniversalServer,
+        getAllBatchIds,
+      } = await startServer();
       eyesServer = server;
 
-      const globalHooks = makeGlobalRunHooks({closeManager, closeBatches, closeUniversalServer});
+      const globalHooks = makeGlobalRunHooks({
+        closeManager,
+        closeBatches,
+        closeUniversalServer,
+        getAllBatchIds,
+      });
 
       const [origOn, config] = args;
       const isGlobalHookCalledFromUserHandlerMap = new Map();

--- a/packages/eyes-cypress/src/plugin/server.js
+++ b/packages/eyes-cypress/src/plugin/server.js
@@ -12,6 +12,7 @@ function makeStartServer({logger}) {
     const {port: universalPort, close: closeUniversalServer} = await makeServerProcess();
 
     const managers = [];
+    let batchIds = [];
     let socketWithUniversal;
 
     server.on('connection', socketWithClient => {
@@ -62,6 +63,17 @@ function makeStartServer({logger}) {
               }),
             );
           }
+        } else if (msg.name == 'Test.saveBatchId') {
+          if (!batchIds.includes(msg.payload.batchIdEyesOpen)) {
+            batchIds.push(msg.payload.batchIdEyesOpen);
+          }
+          socketWithClient.send(
+            JSON.stringify({
+              name: 'Test.saveBatchId',
+              key: msg.key,
+              payload: {result: 'success'},
+            }),
+          );
         } else {
           socketWithUniversal.send(message);
         }
@@ -74,8 +86,14 @@ function makeStartServer({logger}) {
       closeManager,
       closeBatches,
       closeUniversalServer,
+      getAllBatchIds,
     };
 
+    function getAllBatchIds() {
+      const tmp = batchIds;
+      batchIds = [];
+      return tmp;
+    }
     function closeManager() {
       return Promise.all(
         managers.map(({manager, socketWithUniversal}) =>
@@ -87,10 +105,16 @@ function makeStartServer({logger}) {
       );
     }
     function closeBatches(settings) {
-      if (socketWithUniversal)
+      logger.log('==> ', `{name: 'Core.closeBatches', "payload":${JSON.stringify(settings)}}`);
+      if (socketWithUniversal) {
         return socketWithUniversal.request('Core.closeBatches', {settings}).catch(err => {
-          logger.log('@@@', err);
+          // if the user defined a batchId in eyesOpen, then we also send the random Id we created that does not have any use,
+          //this will throw Batch not found error that we don't want to propagate to the user
+          if (!err.message.includes('Batch not found')) {
+            logger.log(`@@@ in closeBatches, batchIds: ${settings.batchId}`, err);
+          }
         });
+      }
     }
   };
 }

--- a/packages/eyes-cypress/test/e2e/cypress-run-batchId-eyesOpen.test.js
+++ b/packages/eyes-cypress/test/e2e/cypress-run-batchId-eyesOpen.test.js
@@ -1,0 +1,63 @@
+'use strict';
+const {describe, it, before, after} = require('mocha');
+const {expect} = require('chai');
+const {exec} = require('child_process');
+const {promisify: p} = require('util');
+const path = require('path');
+const pexec = p(exec);
+const fs = require('fs');
+const {presult} = require('@applitools/functional-commons');
+const applitoolsConfig = require('../fixtures/testApp/applitools.config.js');
+
+const sourceTestAppPath = path.resolve(__dirname, '../fixtures/testApp');
+const targetTestAppPath = path.resolve(
+  __dirname,
+  '../fixtures/testAppCopies/testApp-batchId-eyesOpen',
+);
+
+async function runCypress(pluginsFile, testFile = 'batchIdEyesOpen.js') {
+  return (
+    await pexec(
+      `./node_modules/.bin/cypress run --headless --config testFiles=${testFile},integrationFolder=cypress/integration-run,pluginsFile=cypress/plugins/${pluginsFile},supportFile=cypress/support/index-run.js`,
+      {
+        maxBuffer: 10000000,
+      },
+    )
+  ).stdout;
+}
+
+describe('handle batchId from eyesOpen', () => {
+  before(async () => {
+    if (fs.existsSync(targetTestAppPath)) {
+      fs.rmdirSync(targetTestAppPath, {recursive: true});
+    }
+    try {
+      await pexec(`cp -r ${sourceTestAppPath}/. ${targetTestAppPath}`);
+      process.chdir(targetTestAppPath);
+      await pexec(`npm install`, {
+        maxBuffer: 1000000,
+      });
+    } catch (ex) {
+      console.log(ex);
+      throw ex;
+    }
+  });
+
+  after(async () => {
+    fs.rmdirSync(targetTestAppPath, {recursive: true});
+  });
+
+  it('works for batchIds from eyesOpen', async () => {
+    await pexec(`npm install cypress@latest`);
+    const config = {...applitoolsConfig, showLogs: true, failCypressOnDiff: false};
+    fs.writeFileSync(
+      `${targetTestAppPath}/applitools.config.js`,
+      'module.exports =' + JSON.stringify(config, 2, null),
+    );
+    const [err, v] = await presult(runCypress('index-run.js', 'batchIdEyesOpen.js'));
+    expect(err).to.be.undefined;
+    expect(v).to.contain('Core.closeBatches');
+    expect(v).to.contain('BatchId-EyesOpen1');
+    expect(v).to.contain('BatchId-EyesOpen2');
+  });
+});

--- a/packages/eyes-cypress/test/e2e/cypress-run-batchId-property.js
+++ b/packages/eyes-cypress/test/e2e/cypress-run-batchId-property.js
@@ -1,0 +1,79 @@
+'use strict';
+const {describe, it, before, after} = require('mocha');
+const {exec} = require('child_process');
+const {promisify: p} = require('util');
+const path = require('path');
+const pexec = p(exec);
+const {testServerInProcess} = require('@applitools/test-server');
+const fs = require('fs');
+const applitoolsConfig = require('../fixtures/testApp/applitools.config.js');
+
+const sourceTestAppPath = path.resolve(__dirname, '../fixtures/testApp');
+const targetTestAppPath = path.resolve(
+  __dirname,
+  '../fixtures/testAppCopies/testApp-batchId-property',
+);
+
+describe('handle batchId property', () => {
+  let closeServer;
+  before(async () => {
+    const staticPath = path.resolve(__dirname, '../fixtures');
+    const server = await testServerInProcess({
+      port: 5555,
+      staticPath,
+    });
+    closeServer = server.close;
+    if (fs.existsSync(targetTestAppPath)) {
+      fs.rmdirSync(targetTestAppPath, {recursive: true});
+    }
+    await pexec(`cp -r ${sourceTestAppPath}/. ${targetTestAppPath}`);
+    process.chdir(targetTestAppPath);
+    await pexec(`npm install`, {
+      maxBuffer: 1000000,
+    });
+  });
+
+  after(async () => {
+    fs.rmdirSync(targetTestAppPath, {recursive: true});
+    await closeServer();
+  });
+
+  it('works with batchId from env var with global hooks', async () => {
+    await pexec(`npm install cypress@latest`);
+    process.env.APPLITOOLS_BATCH_ID = 'batchId1234';
+    try {
+      await pexec(
+        './node_modules/.bin/cypress run --headless --config testFiles=batchIdProperty.js,integrationFolder=cypress/integration-run,pluginsFile=cypress/plugins/index-run.js,supportFile=cypress/support/index-run.js',
+        {
+          maxBuffer: 10000000,
+        },
+      );
+    } catch (ex) {
+      console.error('Error during test!', ex.stdout);
+      throw ex;
+    } finally {
+      delete process.env.APPLITOOLS_BATCH_ID;
+    }
+  });
+  it('works with batchId from config file with global hooks', async () => {
+    await pexec(`npm install cypress@latest`);
+    const config = {...applitoolsConfig, batchId: 'batchId123456'};
+    fs.writeFileSync(
+      `${targetTestAppPath}/applitools.config.js`,
+      'module.exports =' + JSON.stringify(config, 2, null),
+    );
+    try {
+      await pexec(
+        './node_modules/.bin/cypress run --headless --config testFiles=batchIdProperty.js,integrationFolder=cypress/integration-run,pluginsFile=cypress/plugins/index-run.js,supportFile=cypress/support/index-run.js',
+        {
+          maxBuffer: 10000000,
+        },
+      );
+    } catch (ex) {
+      console.error('Error during test!', ex.stdout);
+      throw ex;
+    } finally {
+      delete process.env.APPLITOOLS_BATCH_ID;
+    }
+  });
+});

--- a/packages/eyes-cypress/test/e2e/cypress-run-batchId-property.test.js
+++ b/packages/eyes-cypress/test/e2e/cypress-run-batchId-property.test.js
@@ -72,8 +72,6 @@ describe('handle batchId property', () => {
     } catch (ex) {
       console.error('Error during test!', ex.stdout);
       throw ex;
-    } finally {
-      delete process.env.APPLITOOLS_BATCH_ID;
     }
   });
 });

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/batchIdEyesOpen.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/batchIdEyesOpen.js
@@ -1,0 +1,28 @@
+/* global cy */
+describe('Use batchId from env var', () => {
+  // This also tests the override of `testName`
+
+  it('shows how to use Applitools Eyes with Cypress', () => {
+    cy.visit('https://applitools.com/helloworld');
+    cy.eyesOpen({
+      appName: 'Hello World!',
+      testName: 'work with batchId eyesOpen',
+      browser: {width: 800, height: 600},
+      batchId: 'BatchId-EyesOpen1',
+    });
+    cy.eyesCheckWindow('Main Page');
+    cy.eyesClose();
+  });
+
+  it('shows how to use Applitools Eyes with Cypress', () => {
+    cy.visit('https://applitools.com/helloworld');
+    cy.eyesOpen({
+      appName: 'Hello World!',
+      testName: 'work with batchId eyesOpen',
+      browser: {width: 800, height: 600},
+      batch: {id: 'BatchId-EyesOpen2'},
+    });
+    cy.eyesCheckWindow('Main Page');
+    cy.eyesClose();
+  });
+});

--- a/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/batchIdProperty.js
+++ b/packages/eyes-cypress/test/fixtures/testApp/cypress/integration-run/batchIdProperty.js
@@ -1,0 +1,15 @@
+/* global cy */
+describe('Use batchId from env var', () => {
+  // This also tests the override of `testName`
+
+  it('shows how to use Applitools Eyes with Cypress', () => {
+    cy.visit('https://applitools.com/helloworld');
+    cy.eyesOpen({
+      appName: 'Hello World!',
+      testName: 'work with batchId property',
+      browser: {width: 800, height: 600},
+    });
+    cy.eyesCheckWindow('Main Page');
+    cy.eyesClose();
+  });
+});

--- a/packages/eyes-cypress/test/unit/plugin/config.test.js
+++ b/packages/eyes-cypress/test/unit/plugin/config.test.js
@@ -23,7 +23,9 @@ describe('config', () => {
 
   it('should work with env variables', () => {
     process.env.APPLITOOLS_IS_DISABLED = true;
+    process.env.APPLITOOLS_BATCH_ID = 'batchId123';
     const {config, eyesConfig} = makeConfig();
+    expect(config.batchId).to.equal('batchId123');
     expect(config.isDisabled).to.be.true;
     expect(eyesConfig).to.deep.equal({
       eyesIsDisabled: true,

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -95,7 +95,8 @@ Apollo SDK:
   feature:
     - 
   bug-fix:
-    - 
+    - consider batchId from config file and environments variable when closing batch
+    - consider batchId from eyesOpen when closing batch
 "@applitools/eyes-storybook":
   feature:
     - 


### PR DESCRIPTION
Consider `batchId` property (and not just `batch.id`) when closing the batch in global hooks.
This issue was raised [here](https://trello.com/c/H5xJSTsD/1271-cypress-batchid-configuration-not-being-honored-in-new-cypress-version)

While working on this issue I found that we don't support closing the batch form global hooks when the user sends the `batchId` from `eyesOpen`, so this should be addressed as well.