### PR TITLE
Set eyes exceptions to TestResultsSummary

### DIFF
--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -24,6 +24,7 @@ Apollo SDK:
     - Fixed handling of navigation bar size on various devices
     - Fixed bug in native apps when screenshot of the element was taken only for the small visible part of the element
     - Fixed bug when navigation bar was presented in screenshot on Android 12
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-webdriverio":
   feature:
     - 
@@ -37,6 +38,7 @@ Apollo SDK:
       Support Galaxy S22 `DeviceName.Galaxy_S22` emulation device
   bug-fix:
     - Allow running with self-signed certificates
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-protractor":
   feature:
     - Support UFG for native mobile
@@ -60,6 +62,7 @@ Apollo SDK:
     - Allow running with self-signed certificates
     - Fixed bug in native apps when screenshot of the element was taken only for the small visible part of the element
     - Fixed bug when navigation bar was presented in screenshot on Android 12
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-puppeteer":
   feature:
     - Support UFG for native mobile
@@ -80,11 +83,12 @@ Apollo SDK:
     - Fixed check region fully in classic execution when using CSS stitching
     - Support data urls in iframes
     - Allow running with self-signed certificates
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-testcafe":
   feature:
     - 
   bug-fix:
-    - 
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-nightwatch":
   feature:
     - Support UFG for native mobile
@@ -107,11 +111,12 @@ Apollo SDK:
     - Allow running with self-signed certificates
     - Fixed bug in native apps when screenshot of the element was taken only for the small visible part of the element
     - Fixed bug when navigation bar was presented in screenshot on Android 12
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-cypress":
   feature:
     - 
   bug-fix:
-    - 
+    - Set EyesExceptions (such as new test, diffs exception and failed test exception) to exception property in TestResultsSummary
 "@applitools/eyes-storybook":
   feature:
     - 


### PR DESCRIPTION
I fixed the issue that was reported [here](https://trello.com/c/wvosVkhj/1141-gannett-media-corp-js-selenium-4-after-upgrading-eyes-selenium-exceptions-are-no-longer-accessible-through-testresultcontainer), in a [PR that I already merged](https://github.com/applitools/eyes.sdk.javascript1/pull/878), but forgot to update the `pending-changes` for more SDKs that would be affected by this change.
