### PR TITLE
user API addMobileDevice

### DIFF
--- a/packages/eyes-api/src/enums/AndroidDeviceName.ts
+++ b/packages/eyes-api/src/enums/AndroidDeviceName.ts
@@ -1,0 +1,22 @@
+export enum AndroidDeviceNameEnum {
+  Pixel_3_XL = 'Pixel 3 XL',
+  Pixel_4 = 'Pixel 4',
+  Pixel_4_XL = 'Pixel 4 XL',
+  Galaxy_Note_8 = 'Galaxy Note 8',
+  Galaxy_Note_9 = 'Galaxy Note 9',
+  Galaxy_S8 = 'Galaxy S8',
+  Galaxy_S8_Plus = 'Galaxy S8 Plus',
+  Galaxy_S9 = 'Galaxy S9',
+  Galaxy_S9_Plus = 'Galaxy S9 Plus',
+  Galaxy_S10 = 'Galaxy S10',
+  Galaxy_S10_Plus = 'Galaxy S10 Plus',
+  Galaxy_Note_10 = 'Galaxy Note 10',
+  Galaxy_Note_10_Plus = 'Galaxy Note 10 Plus',
+  Galaxy_S20 = 'Galaxy S20',
+  Galaxy_S20_PLUS = 'Galaxy S20 Plus',
+  Galaxy_S21 = 'Galaxy S21',
+  Galaxy_S21_PLUS = 'Galaxy S21 Plus',
+  Galaxy_S21_ULTRA = 'Galaxy S21 Ultra',
+}
+
+export type AndroidDeviceName = `${AndroidDeviceNameEnum}`

--- a/packages/eyes-api/src/enums/AndroidDeviceName.ts
+++ b/packages/eyes-api/src/enums/AndroidDeviceName.ts
@@ -13,10 +13,10 @@ export enum AndroidDeviceNameEnum {
   Galaxy_Note_10 = 'Galaxy Note 10',
   Galaxy_Note_10_Plus = 'Galaxy Note 10 Plus',
   Galaxy_S20 = 'Galaxy S20',
-  Galaxy_S20_PLUS = 'Galaxy S20 Plus',
+  Galaxy_S20_Plus = 'Galaxy S20 Plus',
   Galaxy_S21 = 'Galaxy S21',
-  Galaxy_S21_PLUS = 'Galaxy S21 Plus',
-  Galaxy_S21_ULTRA = 'Galaxy S21 Ultra',
+  Galaxy_S21_Plus = 'Galaxy S21 Plus',
+  Galaxy_S21_Ultra = 'Galaxy S21 Ultra',
 }
 
 export type AndroidDeviceName = `${AndroidDeviceNameEnum}`

--- a/packages/eyes-api/src/enums/AndroidVersion.ts
+++ b/packages/eyes-api/src/enums/AndroidVersion.ts
@@ -1,0 +1,7 @@
+export enum AndroidVersionEnum {
+  LATEST = 'latest',
+  ONE_VERSION_BACK = 'latest-1',
+  TWO_VERSION_BACK = 'latest-2',
+}
+
+export type AndroidVersion = `${AndroidVersionEnum}`

--- a/packages/eyes-api/src/index.ts
+++ b/packages/eyes-api/src/index.ts
@@ -24,6 +24,11 @@ export {DeviceName as DeviceNamePlain, DeviceNameEnum as DeviceName} from './enu
 export {FailureReport as FailureReportPlain, FailureReportEnum as FailureReport} from './enums/FailureReport'
 export {IosDeviceName as IosDeviceNamePlain, IosDeviceNameEnum as IosDeviceName} from './enums/IosDeviceName'
 export {IosVersion as IosVersionPlain, IosVersionEnum as IosVersion} from './enums/IosVersion'
+export {
+  AndroidDeviceName as AndroidDeviceNamePlain,
+  AndroidDeviceNameEnum as AndroidDeviceName,
+} from './enums/AndroidDeviceName'
+export {AndroidVersion as AndroidVersionPlain, AndroidVersionEnum as AndroidVersion} from './enums/AndroidVersion'
 export {MatchLevel as MatchLevelPlain, MatchLevelEnum as MatchLevel} from './enums/MatchLevel'
 export {
   ScreenOrientation as ScreenOrientationPlain,
@@ -89,7 +94,7 @@ export {PropertyData as PropertyDataPlain, PropertyDataData as PropertyData} fro
 export {ProxySettings as ProxySettingsPlain, ProxySettingsData as ProxySettings} from './input/ProxySettings'
 export {RectangleSize as RectangleSizePlain, RectangleSizeData as RectangleSize} from './input/RectangleSize'
 export {Region as RegionPlain, LegacyRegion as LegacyRegionPlain, RegionData as Region} from './input/Region'
-export {DesktopBrowserInfo, ChromeEmulationInfo, IOSDeviceInfo} from './input/RenderInfo'
+export {DesktopBrowserInfo, ChromeEmulationInfo, IOSDeviceInfo, AndroidDeviceInfo} from './input/RenderInfo'
 export {
   RunnerOptions as RunnerOptionsPlain,
   RunnerOptionsFluent,

--- a/packages/eyes-api/src/input/Configuration.ts
+++ b/packages/eyes-api/src/input/Configuration.ts
@@ -1051,7 +1051,7 @@ export class ConfigurationData<TElement = unknown, TSelector = unknown>
   addMobileDevice(
     deviceNameIosOrAndroid: IosDeviceName | AndroidDeviceName,
     screenOrientation: ScreenOrientation,
-    version?: any,
+    version?: AndroidVersion | IosVersion,
   ) {
     if (!this.browsersInfo) this.browsersInfo = []
 

--- a/packages/eyes-api/src/input/Configuration.ts
+++ b/packages/eyes-api/src/input/Configuration.ts
@@ -5,9 +5,19 @@ import {StitchMode, StitchModeEnum} from '../enums/StitchMode'
 import {MatchLevel, MatchLevelEnum} from '../enums/MatchLevel'
 import {BrowserType, BrowserTypeEnum} from '../enums/BrowserType'
 import {DeviceName} from '../enums/DeviceName'
+import {AndroidDeviceName, AndroidVersion, IosDeviceName, IosVersion} from '..'
+//import {AndroidVersion} from '../enums/AndroidVersion'
+// import {IosDeviceName} from '../enums/IosDeviceName'
+// import {IosVersion} from '../enums/IosVersion'
 import {ScreenOrientation, ScreenOrientationEnum} from '../enums/ScreenOrientation'
 import {AccessibilitySettings} from './AccessibilitySettings'
-import {DesktopBrowserInfo, ChromeEmulationInfo, IOSDeviceInfo, ChromeEmulationInfoLegacy} from './RenderInfo'
+import {
+  DesktopBrowserInfo,
+  ChromeEmulationInfo,
+  IOSDeviceInfo,
+  AndroidDeviceInfo,
+  ChromeEmulationInfoLegacy,
+} from './RenderInfo'
 import {CutProvider} from './CutProvider'
 import {LogHandler} from './LogHandler'
 import {DebugScreenshotProvider} from './DebugScreenshotProvider'
@@ -18,7 +28,12 @@ import {BatchInfo, BatchInfoData} from './BatchInfo'
 import {PropertyData, PropertyDataData} from './PropertyData'
 import {ImageMatchSettings, ImageMatchSettingsData} from './ImageMatchSettings'
 
-type RenderInfo = DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo | ChromeEmulationInfoLegacy
+type RenderInfo =
+  | DesktopBrowserInfo
+  | ChromeEmulationInfo
+  | IOSDeviceInfo
+  | AndroidDeviceInfo
+  | ChromeEmulationInfoLegacy
 
 type ConfigurationSpec<TElement = unknown, TSelector = unknown> = {
   isElement(element: any): element is TElement
@@ -95,7 +110,7 @@ export type ClassicConfiguration<TElement = unknown, TSelector = unknown> = {
 export type VGConfiguration = {
   /** @undocumented */
   concurrentSessions?: number
-  browsersInfo?: (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo)[]
+  browsersInfo?: (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo | AndroidDeviceInfo)[]
   visualGridOptions?: Record<string, any>
   layoutBreakpoints?: boolean | number[]
   disableBrowserFetching?: boolean
@@ -992,10 +1007,10 @@ export class ConfigurationData<TElement = unknown, TSelector = unknown>
     return this
   }
 
-  get browsersInfo(): (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo)[] {
+  get browsersInfo(): (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo | AndroidDeviceInfo)[] {
     return this._config.browsersInfo
   }
-  set browsersInfo(browsersInfo: (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo)[]) {
+  set browsersInfo(browsersInfo: (DesktopBrowserInfo | ChromeEmulationInfo | IOSDeviceInfo | AndroidDeviceInfo)[]) {
     utils.guard.isArray(browsersInfo, {name: 'browsersInfo'})
     this._config.browsersInfo = browsersInfo
   }
@@ -1029,6 +1044,24 @@ export class ConfigurationData<TElement = unknown, TSelector = unknown>
   addDeviceEmulation(deviceName: DeviceName, screenOrientation: ScreenOrientation = ScreenOrientationEnum.PORTRAIT) {
     if (!this.browsersInfo) this.browsersInfo = []
     this.browsersInfo.push({chromeEmulationInfo: {deviceName, screenOrientation}})
+    return this
+  }
+  addMobileDevice(deviceName: AndroidDeviceName, screenOrientation: ScreenOrientation, version?: AndroidVersion): this
+  addMobileDevice(deviceName: IosDeviceName, screenOrientation: ScreenOrientation, version?: IosVersion): this
+  addMobileDevice(
+    deviceNameIosOrAndroid: IosDeviceName | AndroidDeviceName,
+    screenOrientation: ScreenOrientation,
+    version?: any,
+  ) {
+    if (!this.browsersInfo) this.browsersInfo = []
+
+    if (utils.types.isEnumValue(deviceNameIosOrAndroid, IosDeviceName)) {
+      this.browsersInfo.push({
+        iosDeviceInfo: {deviceName: deviceNameIosOrAndroid, screenOrientation, iosVersion: version},
+      })
+    } else {
+      this.browsersInfo.push({androidDeviceInfo: {deviceName: deviceNameIosOrAndroid, screenOrientation, version}})
+    }
     return this
   }
 

--- a/packages/eyes-api/src/input/Configuration.ts
+++ b/packages/eyes-api/src/input/Configuration.ts
@@ -1050,7 +1050,7 @@ export class ConfigurationData<TElement = unknown, TSelector = unknown>
   addMobileDevice(deviceName: IosDeviceName, screenOrientation: ScreenOrientation, version?: IosVersion): this
   addMobileDevice(
     deviceNameIosOrAndroid: IosDeviceName | AndroidDeviceName,
-    screenOrientation: ScreenOrientation,
+    screenOrientation?: ScreenOrientation,
     version?: AndroidVersion | IosVersion,
   ) {
     if (!this.browsersInfo) this.browsersInfo = []

--- a/packages/eyes-api/src/input/Configuration.ts
+++ b/packages/eyes-api/src/input/Configuration.ts
@@ -5,10 +5,10 @@ import {StitchMode, StitchModeEnum} from '../enums/StitchMode'
 import {MatchLevel, MatchLevelEnum} from '../enums/MatchLevel'
 import {BrowserType, BrowserTypeEnum} from '../enums/BrowserType'
 import {DeviceName} from '../enums/DeviceName'
-import {AndroidDeviceName, AndroidVersion, IosDeviceName, IosVersion} from '..'
-//import {AndroidVersion} from '../enums/AndroidVersion'
-// import {IosDeviceName} from '../enums/IosDeviceName'
-// import {IosVersion} from '../enums/IosVersion'
+import {AndroidDeviceName} from '../enums/AndroidDeviceName'
+import {AndroidVersion} from '../enums/AndroidVersion'
+import {IosDeviceName, IosDeviceNameEnum} from '../enums/IosDeviceName'
+import {IosVersion} from '../enums/IosVersion'
 import {ScreenOrientation, ScreenOrientationEnum} from '../enums/ScreenOrientation'
 import {AccessibilitySettings} from './AccessibilitySettings'
 import {
@@ -1049,18 +1049,28 @@ export class ConfigurationData<TElement = unknown, TSelector = unknown>
   addMobileDevice(deviceName: AndroidDeviceName, screenOrientation: ScreenOrientation, version?: AndroidVersion): this
   addMobileDevice(deviceName: IosDeviceName, screenOrientation: ScreenOrientation, version?: IosVersion): this
   addMobileDevice(
-    deviceNameIosOrAndroid: IosDeviceName | AndroidDeviceName,
+    deviceName: IosDeviceName | AndroidDeviceName,
     screenOrientation?: ScreenOrientation,
     version?: AndroidVersion | IosVersion,
   ) {
     if (!this.browsersInfo) this.browsersInfo = []
 
-    if (utils.types.isEnumValue(deviceNameIosOrAndroid, IosDeviceName)) {
+    if (utils.types.isEnumValue(deviceName, IosDeviceNameEnum)) {
       this.browsersInfo.push({
-        iosDeviceInfo: {deviceName: deviceNameIosOrAndroid, screenOrientation, iosVersion: version},
+        iosDeviceInfo: {
+          deviceName: deviceName as IosDeviceName,
+          screenOrientation,
+          iosVersion: version as IosVersion,
+        },
       })
     } else {
-      this.browsersInfo.push({androidDeviceInfo: {deviceName: deviceNameIosOrAndroid, screenOrientation, version}})
+      this.browsersInfo.push({
+        androidDeviceInfo: {
+          deviceName: deviceName as AndroidDeviceName,
+          screenOrientation,
+          version: version as AndroidVersion,
+        },
+      })
     }
     return this
   }

--- a/packages/eyes-api/src/input/RenderInfo.ts
+++ b/packages/eyes-api/src/input/RenderInfo.ts
@@ -2,6 +2,8 @@ import {BrowserType} from '../enums/BrowserType'
 import {DeviceName} from '../enums/DeviceName'
 import {IosDeviceName} from '../enums/IosDeviceName'
 import {IosVersion} from '../enums/IosVersion'
+import {AndroidDeviceName} from '../enums/AndroidDeviceName'
+import {AndroidVersion} from '../enums/AndroidVersion'
 import {ScreenOrientation} from '../enums/ScreenOrientation'
 
 export type DesktopBrowserInfo = {
@@ -27,6 +29,14 @@ export type IOSDeviceInfo = {
   iosDeviceInfo: {
     deviceName: IosDeviceName
     iosVersion?: IosVersion
+    screenOrientation?: ScreenOrientation
+  }
+}
+
+export type AndroidDeviceInfo = {
+  androidDeviceInfo: {
+    deviceName: AndroidDeviceName
+    version?: AndroidVersion
     screenOrientation?: ScreenOrientation
   }
 }

--- a/packages/eyes-api/test/unit/enums.spec.ts
+++ b/packages/eyes-api/test/unit/enums.spec.ts
@@ -1,6 +1,6 @@
 import {strict as assert} from 'assert'
 import fetch from 'node-fetch'
-import {DeviceName, IosDeviceName} from '../../src'
+import {DeviceName, IosDeviceName, AndroidDeviceName} from '../../src'
 
 describe('enums', () => {
   describe('DeviceName', () => {
@@ -27,6 +27,19 @@ describe('enums', () => {
 
     it('should consists of allowed values', async () => {
       assert.deepEqual(Object.values(IosDeviceName).sort(), expectedDeviceNames.sort())
+    })
+  })
+
+  describe('AndroidDeviceName', () => {
+    const url = 'https://render-wus.applitools.com/public/android-devices'
+    let expectedDeviceNames: string[]
+    before(async () => {
+      const devices = await fetch(url).then(response => response.json())
+      expectedDeviceNames = Object.keys(devices)
+    })
+
+    it('should consists of allowed values', async () => {
+      assert.deepEqual(Object.values(AndroidDeviceName).sort(), expectedDeviceNames.sort())
     })
   })
 })

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -238,7 +238,11 @@ export type AndroidDeviceRenderer = {
     screenOrientation?: ScreenOrientation
   }
 }
-export type BrowserInfoRenderer = DesktopBrowserRenderer | ChromeEmulationDeviceRenderer | IOSDeviceRenderer
+export type BrowserInfoRenderer =
+  | DesktopBrowserRenderer
+  | ChromeEmulationDeviceRenderer
+  | IOSDeviceRenderer
+  | AndroidDeviceRenderer
 
 export type MatchResult = {
   readonly asExpected?: boolean

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -70,7 +70,6 @@ Apollo SDK:
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
-    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fixed broken links to enums implementation in the README.md
     - |

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -34,6 +34,7 @@ Apollo SDK:
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fixed broken links to enums implementation in the README.md
     - |
@@ -49,6 +50,7 @@ Apollo SDK:
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fixed the "Maximum Call Stack Size Exceeded" error when taking screenshots on iOS Safari
     - Fixed an issue with wrong cropped screenshots of elements out of viewport bounds on native devices
@@ -68,6 +70,7 @@ Apollo SDK:
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fixed broken links to enums implementation in the README.md
     - |
@@ -94,6 +97,7 @@ Apollo SDK:
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fixed the "Maximum Call Stack Size Exceeded" error when taking screenshots on iOS Safari
     - Fixed an issue with wrong cropped screenshots of elements out of viewport bounds on native devices
@@ -124,6 +128,7 @@ Apollo SDK:
     - Allowed `` values in custom properties
     - Add special attribute for pseudo elements
     - Add the ability for the SDK to lazy load the page prior to performing a check window
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - |
       `extractText` now supports regions that don't use hints while using `x`/`y` coordinates

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -17,13 +17,14 @@ Apollo SDK:
   feature:
     - Add the ability for the SDK to lazy load the page prior to performing a check window
     - Support padding for regions in the following region types - ignoreRegions, layoutRegions, strictRegions, contentRegions
+    - Support `addMobileDevice` in user API for NMG
   bug-fix:
     - Fix issue that prevented self-signed certificates from working when connecting through a proxy server
     - Fixed native screenshots of the elements under large collapsing areas
     - Fixed scrolling on some android devices
 "@applitools/eyes-webdriverio":
   feature:
-    - 
+    - Support `addMobileDevice` in user API for NMG 
   bug-fix:
     - 
 "@applitools/eyes-playwright":


### PR DESCRIPTION
support addMobileDevice in user API
1. I was not sure whether 'visual-grid-client` should be updated as well, for example:
`visual-grid-client/src/sdk/getDeviceInfoFromBrowserConfig.js` (there are more cases in VGC)
2. in `Configuration.ts` line 1054, once replacing the 'any' with proper types: `AndroidVersion | IosVersion` it results an error in line 1060 regarding to `iosVersion` vs. `version` - is there another way to solve this besides what was done? 
3. idea regarding the place the test for this should be added?
I found this `/eyes-api/test/unit/enums.spec.ts` it tests the emulated devices and ios devices sizes, I might add one test here (need to add a new service/api as well) but it will not test 'addMobileDevice' 