### PR TITLE
proposal: add requireIdleState parameter

### DIFF
--- a/js/packages/eyes-storybook/src/getStoryData.js
+++ b/js/packages/eyes-storybook/src/getStoryData.js
@@ -58,6 +58,13 @@ function makeGetStoryData({logger, takeDomSnapshots, waitBeforeCapture, reloadPa
       });
     }
 
+    if (eyesParameters && eyesParameters.requireIdleState) {
+        await page.waitForNetworkIdle({
+          idleTime: eyesParameters.requireIdleState
+        })
+      }
+    }
+
     logger.log(`running takeDomSnapshot(s) for story ${title}`);
 
     const domSnapshotsPromise = takeDomSnapshots({


### PR DESCRIPTION
In order to make VR results stable Applitools provides two options:
- `waitBeforeCapture` - to wait for a known selector, time or function
-  `runBefore` - to implement any other custom logic. In my case I've implemented wait for element to disappear

And in the majority of cases that is more than enough. Frankly speaking some other solutions (Chromatic) are not providing any "wait-for" capabilities and still working great.

However, to matter which API is exposed to the client there are some things known only to the browser and better handled by the browser. `waitForNetworkIdle` would be a perfect example
- one can implement loading tracking as a part of their application to properly delay taking snapshots until the story is ready. That could be multiple services and hundreds of lines of code to track all possible interactions leading to delay, especially network ones.
- one it can be one call to `waitForNetworkIdle` to wait until network activity will be absent for a given period of time. One line to rule them all.

-----

Please consider this PR as a proposal as I am using this channel due to the absence of issues functionality.