### PR TITLE
[driver] change `helper` element click to "tap on coordinate"

### DIFF
--- a/js/packages/driver/src/element.ts
+++ b/js/packages/driver/src/element.ts
@@ -500,7 +500,7 @@ export class Element<TDriver, TContext, TElement, TSelector> {
 
         // vertical scrolling
         const yPadding = Math.max(Math.floor(effectiveRegion.height * 0.05), touchPadding + 3)
-        const xTrack = Math.floor(effectiveRegion.x + 5) // a little bit off left border
+        const xTrack = Math.floor(effectiveRegion.x + 6) // a little bit off left border
         const yBottom = effectiveRegion.y + effectiveRegion.height - yPadding
         const yDirection = remainingOffset.y > 0 ? 'down' : 'up'
         const yGap = yDirection === 'down' ? -touchPadding : touchPadding

--- a/js/packages/driver/src/helper-ios.ts
+++ b/js/packages/driver/src/helper-ios.ts
@@ -36,7 +36,12 @@ export class HelperIOS<TDriver, TContext, TElement, TSelector> {
   }
 
   async getContentRegion(element: Element<TDriver, TContext, TElement, TSelector>): Promise<Region> {
-    await this._element.click()
+    const {x, y} = await this._spec.getElementRegion(this._driver.target, this._element.target)
+    await this._spec.performAction(this._driver.target, [
+      {action: 'press', x, y},
+      {action: 'wait', ms: 300},
+      {action: 'release'},
+    ])
 
     const region = await this._spec.getElementRegion(this._driver.target, element.target)
 

--- a/js/packages/screenshoter/test/e2e/e2e.js
+++ b/js/packages/screenshoter/test/e2e/e2e.js
@@ -100,7 +100,7 @@ exports.makeDriver = async function makeDriver({
   const apps = {
     android: 'https://applitools.jfrog.io/artifactory/Examples/android/1.3/app-debug.apk',
     androidx: 'https://applitools.jfrog.io/artifactory/Examples/androidx/helper_lib/1.8.6/app-androidx-debug.apk',
-    ios: 'https://applitools.jfrog.io/artifactory/Examples/IOSTestApp/1.9/app/IOSTestApp.zip',
+    ios: 'https://applitools.jfrog.io/artifactory/Examples/IOSTestApp/1.11/app/IOSTestApp.zip',
   }
 
   const envs = {
@@ -189,6 +189,13 @@ exports.makeDriver = async function makeDriver({
         'appium:platformVersion': platformVersion || '16.0',
         'appium:automationName': 'XCUITest',
         'appium:orientation': orientation ? orientation.toUpperCase() : 'PORTRAIT',
+        'appium:processArguments': {
+          args: [],
+          env: {
+            DYLD_INSERT_LIBRARIES:
+              '@executable_path/Frameworks/UFG_lib.xcframework/ios-arm64_x86_64-simulator/UFG_lib.framework/UFG_lib',
+          },
+        },
         ...rest,
       },
     },
@@ -205,6 +212,13 @@ exports.makeDriver = async function makeDriver({
         platformName: 'iOS',
         platformVersion: platformVersion || '14.5',
         deviceOrientation: orientation ? orientation.toUpperCase() : 'PORTRAIT',
+        processArguments: {
+          args: [],
+          env: {
+            DYLD_INSERT_LIBRARIES:
+              '@executable_path/Frameworks/UFG_lib.xcframework/ios-arm64_x86_64-simulator/UFG_lib.framework/UFG_lib',
+          },
+        },
       },
     },
     'ios-bs': {
@@ -223,6 +237,13 @@ exports.makeDriver = async function makeDriver({
         'appium:app': apps[app || type] || (app !== 'safari' ? app : undefined),
         'appium:deviceName': deviceName || 'iPhone 12',
         'appium:platformVersion': platformVersion || '14.1',
+        'appium:processArguments': {
+          args: [],
+          env: {
+            DYLD_INSERT_LIBRARIES:
+              '@executable_path/Frameworks/UFG_lib.xcframework/ios-arm64_x86_64-simulator/UFG_lib.framework/UFG_lib',
+          },
+        },
         // 'appium:autoAcceptAlerts': true,
       },
     },


### PR DESCRIPTION
[trello](https://trello.com/c/xPatADrO/1453-fast-retailings-wdio-ios-membership-screen-missing-bottom-content)

The `element.click` isn't click when the button is to small (1X1). but using `_spec.performAction` to press on the element trigger the click event

Testing it using the "Collection view" (app-fully-collection.spec.js).
