### PR TITLE
fix: broken typescript es6 declaration

### DIFF
--- a/js/tsconfig.base.json
+++ b/js/tsconfig.base.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "moduleResolution": "node16",
     "target": "es2019",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string", "dom"],
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string", "dom", "ES6"],
     "strict": true,
     "esModuleInterop": true,
     "downlevelIteration": true,


### PR DESCRIPTION
when using `@applitools/eyes-selenium` with typescript, I got the following typescript exception:
![image](https://user-images.githubusercontent.com/11145132/235346336-de57f591-75d2-4835-8580-5773bf2bfd98.png)

seems like typescript needs to know (using `es6` in `lib` in the `tsconfig.json`) when an es6 feature is being used:
https://github.com/TypeStrong/atom-typescript/issues/1329

for additional reading:
https://www.typescriptlang.org/tsconfig#lib

I believe this change might fix the issue