### PR TITLE
add failOnDiff to let the user fail on errors and not diffs

### DIFF
--- a/js/packages/eyes-storybook/README.md
+++ b/js/packages/eyes-storybook/README.md
@@ -155,6 +155,7 @@ In addition to command-line arguments, it's possible to define the following con
 | `showStorybookOutput`     | undefined                   | Whether or not you want to see Storybook output (also available as command-line argument). |
 | `viewportSize`            | { width: 1024, height: 600} | The size of the puppeteer browser's window. This is the browser window which renders the stories originally (and opens at the size provided in the `viewportSize` parameter), and then a DOM snapshot is uploaded to the server, which renders this snapshot on all the browsers and sizes provided in the `browser` parameter.|
 | `exitcode`                | true                       | If tests failed or has visual differences close with non-zero exit code (also available as command-line argument).|
+| `failOnDiffs`             | true                       | if both `exitcode` and `failOnDiffs` are set to `true` close with non-zero exit code when visual differences are found
 | `browser`                 | { width: 1024, height: 768, name: 'chrome' } | The size and browser of the generated screenshots. For more info and possible values, see the [browser section below](#configuring-the-browser).|
 | `showLogs`                | false                       | Whether or not you want to see logs of the Eyes-Storybook plugin. |
 | `batch`                     | undefined                   | An object which describes different aspects of the batch. The following lines in this table depict the various ways to configure the batch. |

--- a/js/packages/eyes-storybook/src/cli.js
+++ b/js/packages/eyes-storybook/src/cli.js
@@ -58,7 +58,7 @@ const {performance, timeItAsync} = makeTiming();
       if (config.xmlFilePath) {
         handleXmlFile(config.xmlFilePath, summary, {totalTime});
       }
-      process.exit(config.exitcode ? exitCode : 0);
+      process.exit(config.exitcode && config.failOnDiffs ? exitCode : 0);
     }
   } catch (ex) {
     console.log(ex);

--- a/js/packages/eyes-storybook/src/defaultConfig.js
+++ b/js/packages/eyes-storybook/src/defaultConfig.js
@@ -18,4 +18,5 @@ module.exports = {
   reloadPagePerStory: false,
   include: undefined,
   startStorybookServerTimeout: 300,
+  failOnDiffs: true,
 };

--- a/js/packages/eyes-storybook/src/renderStories.js
+++ b/js/packages/eyes-storybook/src/renderStories.js
@@ -47,9 +47,7 @@ function makeRenderStories({
         prepareNewPage();
         return processStoryLoop();
       }
-      logger.log(`[page ${pageId}] waiting for queued renders`);
-      // await waitForQueuedRenders(storyDataGap);
-      logger.log(`[page ${pageId}] done waiting for queued renders`);
+
       const storyPromise = processStory();
       allStoriesPromise = allStoriesPromise.then(() => storyPromise);
       return processStoryLoop();

--- a/js/packages/eyes-storybook/test/unit/generateConfig.test.js
+++ b/js/packages/eyes-storybook/test/unit/generateConfig.test.js
@@ -110,4 +110,8 @@ describe('generateConfig', function() {
     const config = generateConfig({argv: {}});
     expect(config.renderers).to.eql([{name: 'chrome', width: 1024, height: 768}]);
   });
+  it('should set true as default value for failOnDiffs', () => {
+    const config = generateConfig({defaultConfig: {failOnDiffs: true}, argv: {}});
+    expect(config.failOnDiffs).to.eql(true);
+  });
 });

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -68,7 +68,8 @@ Apollo SDK:
     - 
 "@applitools/eyes-storybook":
   feature:
-    - Add the optiosn to not fail on visual differences when exit code is set to true
+    - |
+      Add the option to not fail on visual differences when `exitcode` is set to true
   bug-fix:
     - 
 "@applitools/eyes-browser-extension":

--- a/pending-changes.yaml
+++ b/pending-changes.yaml
@@ -68,7 +68,7 @@ Apollo SDK:
     - 
 "@applitools/eyes-storybook":
   feature:
-    - 
+    - Add the optiosn to not fail on visual differences when exit code is set to true
   bug-fix:
     - 
 "@applitools/eyes-browser-extension":


### PR DESCRIPTION
[Trello card](https://trello.com/c/3sq0h3lW/1872-canvaexitcode-configuration-in-storybook)
As for Canva request that we let the user exit with non-zero code if the test crashes but exit with zero exit code if there are diffs.
It was not clear to me if we need to exit with non zero code in case there was an error during one of the stories and at time of writing this I didn't not get an answer yet from Ranjith.

TODO:
- [ ] write an e2e test
- [ ] update pending changes