### PR TITLE
fix(logger): ensure directory existence using recursion

### DIFF
--- a/js/packages/logger/src/handler-file.ts
+++ b/js/packages/logger/src/handler-file.ts
@@ -29,8 +29,5 @@ export function makeFileHandler({
 
 function ensureDirectoryExistence(filename: string) {
   const dirname = path.dirname(filename)
-  if (!fs.existsSync(dirname)) {
-    ensureDirectoryExistence(dirname)
-    fs.mkdirSync(dirname)
-  }
+  fs.mkdirSync(dirname, { recursive: true });
 }


### PR DESCRIPTION
Creating the logs directory may cause an exception, due to a race condition. The recursive flag makes `mkdirSync` skip folders that already exist

![image](https://github.com/applitools/eyes.sdk.javascript1/assets/11145132/2582de6a-c0eb-4976-92c1-4b2884552546)
