### PR TITLE
chore(java/*): add support for log event command

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -29,6 +29,12 @@ eyes.selenium.java/src/main/resources/processResource.js
 venv
 */null
 
+# reports
+*/reports
+
+# universal core binaries
+eyes.universal.core/*/src/main/resources
+
 # sdk-coverage-tests
 **/test/java/coverage/generic/
 coverage-tests/configuration/local.js

--- a/java/eyes.appium.java/pom.xml
+++ b/java/eyes.appium.java/pom.xml
@@ -131,6 +131,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <distributionManagement>

--- a/java/eyes.appium.java/src/main/resources/sdk.version
+++ b/java/eyes.appium.java/src/main/resources/sdk.version
@@ -1,0 +1,1 @@
+applitools_sdk_version=${pom.version}

--- a/java/eyes.images.java/pom.xml
+++ b/java/eyes.images.java/pom.xml
@@ -89,6 +89,17 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <excludes>
+                    <exclude>
+                        *.jpeg
+                    </exclude>
+                </excludes>
+            </resource>
+        </resources>
     </build>
 
     <distributionManagement>

--- a/java/eyes.images.java/src/main/resources/sdk.version
+++ b/java/eyes.images.java/src/main/resources/sdk.version
@@ -1,0 +1,1 @@
+applitools_sdk_version=${pom.version}

--- a/java/eyes.playwright.java/pom.xml
+++ b/java/eyes.playwright.java/pom.xml
@@ -109,6 +109,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <distributionManagement>

--- a/java/eyes.playwright.java/src/main/java/com/applitools/eyes/playwright/universal/PSDKListener.java
+++ b/java/eyes.playwright.java/src/main/java/com/applitools/eyes/playwright/universal/PSDKListener.java
@@ -371,6 +371,7 @@ public class PSDKListener extends AbstractSDKListener {
                 case "Eyes.getResults":
                 case "EyesManager.getResults":
                 case "Debug.getHistory":
+                case "Core.logEvent":
                     handleResponse(payload, typeReferences.get(response.getName()));
                     break;
                 case "Logger.log":
@@ -387,7 +388,6 @@ public class PSDKListener extends AbstractSDKListener {
                         e.printStackTrace();
                     }
                     break;
-
                 default:
                     throw new EyesException("Unknown server command " + response.getName());
             }

--- a/java/eyes.playwright.java/src/main/resources/sdk.version
+++ b/java/eyes.playwright.java/src/main/resources/sdk.version
@@ -1,0 +1,1 @@
+applitools_sdk_version=${version}

--- a/java/eyes.playwright.java/src/main/resources/sdk.version
+++ b/java/eyes.playwright.java/src/main/resources/sdk.version
@@ -1,1 +1,1 @@
-applitools_sdk_version=${version}
+applitools_sdk_version=${pom.version}

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/settings/LogEventSettings.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/settings/LogEventSettings.java
@@ -1,5 +1,6 @@
 package com.applitools.eyes.settings;
 
+import com.applitools.eyes.universal.dto.LogEvent;
 import com.applitools.eyes.universal.dto.ProxyDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -10,8 +11,7 @@ public class LogEventSettings {
     private ProxyDto proxy;
     private String agentId;
     private String level;
-    private String type;
-    private final String javaVersion = System.getProperty("java.version");
+    private LogEvent event;
 
     public String getServerUrl() {
         return serverUrl;
@@ -53,16 +53,11 @@ public class LogEventSettings {
         this.level = level;
     }
 
-    public String getType() {
-        return type;
+    public LogEvent getEvent() {
+        return event;
     }
 
-    public void setType(String type) {
-        this.type = type;
+    public void setEvent(LogEvent event) {
+        this.event = event;
     }
-
-    public String getJavaVersion() {
-        return javaVersion;
-    }
-
 }

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/settings/LogEventSettings.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/settings/LogEventSettings.java
@@ -1,0 +1,68 @@
+package com.applitools.eyes.settings;
+
+import com.applitools.eyes.universal.dto.ProxyDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LogEventSettings {
+    private String serverUrl;
+    private String apiKey;
+    private ProxyDto proxy;
+    private String agentId;
+    private String level;
+    private String type;
+    private final String javaVersion = System.getProperty("java.version");
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
+    public void setServerUrl(String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public ProxyDto getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(ProxyDto proxy) {
+        this.proxy = proxy;
+    }
+
+    public String getAgentId() {
+        return agentId;
+    }
+
+    public void setAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+}

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/AbstractSDKListener.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/AbstractSDKListener.java
@@ -39,6 +39,7 @@ public abstract class AbstractSDKListener implements WebSocketListener {
         put("Eyes.getResults", new TypeReference<ResponseDto<List<CommandEyesGetResultsResponseDto>>>() {});
         put("EyesManager.getResults", new TypeReference<ResponseDto<TestResultsSummaryDto>>() {});
         put("Debug.getHistory", new TypeReference<ResponseDto<DebugHistoryDto>>() {});
+        put("Core.logEvent", new TypeReference<ResponseDto>() {});
     }};
 
     public AbstractSDKListener() {

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/CommandExecutor.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/CommandExecutor.java
@@ -55,10 +55,10 @@ public class CommandExecutor implements AutoCloseable {
   }
 
   private void logEvent(LogEventSettings settings) {
-    RequestDto<LogEvent> request = new RequestDto<>();
+    RequestDto<CommandLogEvent> request = new RequestDto<>();
     request.setName("Core.logEvent");
     request.setKey(UUID.randomUUID().toString());
-    request.setPayload(new LogEvent(settings));
+    request.setPayload(new CommandLogEvent(settings));
 
     SyncTaskListener syncTaskListener = checkedCommand(request);
     syncTaskListener.get();
@@ -373,7 +373,7 @@ public class CommandExecutor implements AutoCloseable {
 
   private void logJavaVersion(String agentId, OpenSettingsDto settingsDto) {
     LogEventSettings logEventSettings = new LogEventSettings();
-    logEventSettings.setType("JAVA_VERSION");
+    logEventSettings.setEvent(new LogEvent.LogJavaVersion());
     logEventSettings.setLevel("Notice");
     logEventSettings.setAgentId(agentId);
     logEventSettings.setProxy(settingsDto.getProxy());

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/USDKListener.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/USDKListener.java
@@ -70,6 +70,7 @@ public class USDKListener extends AbstractSDKListener implements WebSocketListen
                 case "Eyes.getResults":
                 case "EyesManager.getResults":
                 case "Debug.getHistory":
+                case "Core.logEvent":
                     handleResponse(payload, typeReferences.get(response.getName()));
                     break;
                 case "Logger.log":
@@ -86,7 +87,6 @@ public class USDKListener extends AbstractSDKListener implements WebSocketListen
                         e.printStackTrace();
                     }
                     break;
-
                 default:
                     throw new EyesException("Unknown server command " + response.getName());
             }

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/LogEvent.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/LogEvent.java
@@ -1,27 +1,35 @@
 package com.applitools.eyes.universal.dto;
 
-import com.applitools.eyes.settings.LogEventSettings;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class LogEvent {
 
-    private LogEventSettings settings;
+    protected String type;
 
-    public LogEvent(LogEventSettings settings) {
-        this.settings = settings;
+    public LogEvent() {
+        this.type = "JAVA_EVENT";
     }
 
-    public LogEventSettings getSettings() {
-        return settings;
+    public void setType(String type) {
+        this.type = type;
     }
 
-    public void setSettings(LogEventSettings settings) {
-        this.settings = settings;
+    public String getType() {
+        return type;
     }
 
-    @Override
-    public String toString() {
-        return "LogEvent{" +
-                "settings=" + settings +
-                '}';
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class LogJavaVersion extends LogEvent {
+
+        private final String javaVersion = System.getProperty("java.version");
+
+        public LogJavaVersion() {
+            super.setType("JAVA_VERSION");
+        }
+
+        public String getJavaVersion() {
+            return javaVersion;
+        }
     }
 }

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/LogEvent.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/LogEvent.java
@@ -1,0 +1,27 @@
+package com.applitools.eyes.universal.dto;
+
+import com.applitools.eyes.settings.LogEventSettings;
+
+public class LogEvent {
+
+    private LogEventSettings settings;
+
+    public LogEvent(LogEventSettings settings) {
+        this.settings = settings;
+    }
+
+    public LogEventSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(LogEventSettings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public String toString() {
+        return "LogEvent{" +
+                "settings=" + settings +
+                '}';
+    }
+}

--- a/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/request/CommandLogEvent.java
+++ b/java/eyes.sdk.core/src/main/java/com/applitools/eyes/universal/dto/request/CommandLogEvent.java
@@ -1,0 +1,27 @@
+package com.applitools.eyes.universal.dto.request;
+
+import com.applitools.eyes.settings.LogEventSettings;
+
+public class CommandLogEvent {
+
+    private LogEventSettings settings;
+
+    public CommandLogEvent(LogEventSettings settings) {
+        this.settings = settings;
+    }
+
+    public LogEventSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(LogEventSettings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public String toString() {
+        return "LogEvent{" +
+                "settings=" + settings +
+                '}';
+    }
+}

--- a/java/eyes.sdk.core/src/main/resources/sdk.version
+++ b/java/eyes.sdk.core/src/main/resources/sdk.version
@@ -1,1 +1,0 @@
-applitools_sdk_version=${parent.version}

--- a/java/eyes.selenium.common/pom.xml
+++ b/java/eyes.selenium.common/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.10.0</version>
+            <version>4.11.0</version>
         </dependency>
     </dependencies>
 

--- a/java/eyes.selenium.java/pom.xml
+++ b/java/eyes.selenium.java/pom.xml
@@ -134,6 +134,12 @@
                 </configuration>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
     <distributionManagement>

--- a/java/eyes.selenium.java/src/main/resources/sdk.version
+++ b/java/eyes.selenium.java/src/main/resources/sdk.version
@@ -1,0 +1,1 @@
+applitools_sdk_version=${pom.version}


### PR DESCRIPTION
* Added support for `Core.logEvent` command
* Fixed an issue with incorrect version in agentId

The SDK will send `Core.logEvent` right before `eyes.open` with the following settings in order to log the runtime Java version:

```
"settings": {
        "serverUrl": "https://eyesapi.applitools.com",
        "apiKey": "*****************",
        "level": "Notice",
        "type": "JAVA_VERSION",
        "javaVersion": "11.0.12"
    }
```