### PR TITLE
Fix typo in the Cypress defineConfig instructions

### DIFF
--- a/js/packages/eyes-cypress/src/setup/handlePlugin.js
+++ b/js/packages/eyes-cypress/src/setup/handlePlugin.js
@@ -21,7 +21,7 @@ We detected that you are using TS or ESM syntax. Please configure the plugin as 
 
 ${chalk.green.bold('import eyesPlugin from "@applitools/eyes-cypress"')}
 
-export default ${chalk.green.bold('eyesPlugin(')}definedConfig({
+export default ${chalk.green.bold('eyesPlugin(')}defineConfig({
   //...
 })${chalk.green.bold(')')}
 


### PR DESCRIPTION
When running `npx eyes-setup` the instructions say `export default eyesPlugin(definedConfig({` where it should be `defineConfig` per the official docs https://docs.cypress.io/guides/tooling/plugins-guide#Real-World-Example