### PR TITLE
chore: add requestId to error logs

### DIFF
--- a/js/packages/core-base/src/server/req-eyes.ts
+++ b/js/packages/core-base/src/server/req-eyes.ts
@@ -106,8 +106,9 @@ function handleUnexpectedResponse(): Hooks<ReqEyesOptions> {
           ? !options.expected.includes(response.status)
           : options.expected !== response.status)
       ) {
+        const requestId = request.headers.get('x-applitools-eyes-client-request-id')
         throw new Error(
-          `Request "${options?.name}" that was sent to the address "[${request.method}]${request.url}" failed due to unexpected status ${response.statusText}(${response.status})`,
+          `Request "${options?.name}" [${requestId}] that was sent to the address "[${request.method}]${request.url}" failed due to unexpected status ${response.statusText}(${response.status})`,
         )
       }
     },


### PR DESCRIPTION

![image](https://github.com/applitools/eyes.sdk.javascript1/assets/11145132/393955e2-f631-4c61-a228-1e0df13f2d4c)


we have an error:
https://github.com/applitools/frontend/actions/runs/6323027602/job/17292289418?pr=1232 and the log says that:
```
    Error: Request "check" that was sent to the address "[POST]https://eyesapi.applitools.com/api/sessions/running/wVtxNzYkXEySAuC3R42RKQ__%241p%2400638317631789317203?apiKey=***" failed due to unexpected status Bad Request(400)

        at Object.afterResponse (/home/runner/work/frontend/frontend/node_modules/@applitools/eyes-playwright/node_modules/@applitools/core-base/dist/server/req-eyes.js:103:23)
        at /home/runner/work/frontend/frontend/node_modules/@applitools/eyes-playwright/node_modules/@applitools/req/dist/req.js:101:103
        at req (/home/runner/work/frontend/frontend/node_modules/@applitools/eyes-playwright/node_modules/@applitools/req/dist/req.js:179:20)
        at Object.check (/home/runner/work/frontend/frontend/node_modules/@applitools/eyes-playwright/node_modules/@applitools/core-base/dist/server/requests.js:329:26)
        at /home/runner/work/frontend/frontend/node_modules/@applitools/eyes-playwright/node_modules/@applitools/core/dist/ufg/check.js:235:381
```

it's not very helpful.
having the request ID will let us investigate the issue.