### PR TITLE
fix: docs for eyes setup and concurrency message output

### DIFF
--- a/js/packages/eyes-cypress/src/plugin/concurrencyMsg.ts
+++ b/js/packages/eyes-cypress/src/plugin/concurrencyMsg.ts
@@ -3,6 +3,6 @@ const chalk = require('chalk')
 const MSG = `
 Important notice: Your Applitools visual tests are currently running with a testConcurrency value of 5.
 This means that only up to 5 visual tests can run in parallel, and therefore the execution might be slower.
-If your Applitools license supports a higher concurrency level, learn how to configure it here: https://www.npmjs.com/package/@applitools/eyes-cypress#concurrency.
+If your Applitools license supports a higher concurrency level, set the "testConcurrency" parameter as explained here: https://applitools.com/docs/api-ref/sdk-api/cypress/advanced.
 Need a higher concurrency in your account? Email us @ sdr@applitools.com with your required concurrency level.`
 export default {concurrencyMsg: chalk.yellow(MSG), msgText: MSG}

--- a/js/packages/eyes-cypress/src/setup/handlePlugin.js
+++ b/js/packages/eyes-cypress/src/setup/handlePlugin.js
@@ -21,7 +21,7 @@ We detected that you are using TS or ESM syntax. Please configure the plugin as 
 
 ${chalk.green.bold('import eyesPlugin from "@applitools/eyes-cypress"')}
 
-export default ${chalk.green.bold('eyesPlugin(')}definedConfig({
+export default ${chalk.green.bold('eyesPlugin(')}defineConfig({
   //...
 })${chalk.green.bold(')')}
 

--- a/js/packages/eyes-storybook/src/concurrencyMsg.js
+++ b/js/packages/eyes-storybook/src/concurrencyMsg.js
@@ -4,6 +4,6 @@ const chalk = require('chalk');
 module.exports = chalk.yellow(`
 Important notice: Your Applitools visual tests are currently running with a concurrency value of 5.
 This means that only up to 5 visual tests can run in parallel, and therefore the execution might be slower.
-If your Applitools license supports a higher concurrency level, learn how to configure it here: https://www.npmjs.com/package/@applitools/eyes-storybook#concurrency.
+If your Applitools license supports a higher concurrency level, set the "testConcurrency" parameter as explained here: https://applitools.com/docs/api-ref/sdk-api/storybook/config.
 Need a higher concurrency in your account? Email us @ sdr@applitools.com with your required concurrency level.
 `);


### PR DESCRIPTION
Same fix as #1949 plus additional fix to point to our official docs instead of the readme on npmjs.com